### PR TITLE
feat(localization): Phase 3 magic strings + user-visible text (tasks …

### DIFF
--- a/docs/migration-plan/phase-03-localization.md
+++ b/docs/migration-plan/phase-03-localization.md
@@ -161,9 +161,9 @@ Phase 3 Completion decomposed into three parallel tracks:
 
 | Task | Routing | Blocking | Details |
 |------|---------|----------|---------|
-| **2.1: Audit codebase for magic strings** | Jr dev or flexible | 2.2 | Grep for hardcoded patterns that appear 2+ times or represent an enum/type. Document 10+ magic strings grouped by category. Success: Comprehensive list of candidates with locations. |
-| **2.2: Extract magic strings to constants** | Jr dev | 2.3 | Create constants files as needed (`src/constants/colors.mts`, `src/constants/viewModes.mts`, `src/constants/states.mts`). Move strings into named constants. Update exports in `src/constants/index.mts`. Success: All magic strings have a home, no duplication. |
-| **2.3: Update code to import & use constants** | Jr dev or flexible | None | Replace hardcoded strings with imported constants across codebase. Verify no regressions in build/tests. Success: All magic strings replaced exhaustively. |
+| **2.1: Audit codebase for magic strings** | Jr dev or flexible | 2.2 | ✅ Complete. Groups A–D documented. |
+| **2.2: Extract magic strings to constants** | Jr dev | 2.3 | ✅ Complete. Created `src/constants/cssClasses.mts` (VUE_APP_CLASS, ITEM_SHEET_CLASS, SETTINGS_CONFIG_CLASS). Exported from `src/constants/index.mts`. |
+| **2.3: Update code to import & use constants** | Jr dev or flexible | None | ✅ Complete. All 4 groups replaced: SYSTEM_ID (14 locations), CSS classes (9 files), secretEffectType (3 locations), DEFAULT_COLOR (ColorFormGroup.vue). |
 
 ---
 
@@ -176,10 +176,10 @@ Phase 3 Completion decomposed into three parallel tracks:
 | Task | Routing | Blocking | Details |
 |------|---------|----------|---------|
 | **3.1: Formula Familiar dropdown — prop names → localized labels** | Lead dev | 3.4 | Locate formula familiar dropdown component displaying property names. Add mapping from prop names to localization keys. Update lang files with `dnd35e.FORMULA_FAMILIAR.PROPERTIES.*` entries. Update component to use `game.i18n.localize(key)` for display. Success: Dropdown shows human-readable localized labels, not raw prop names. |
-| **3.2: Sheet UI text audit — section headers, tabs, group labels** | Jr dev (lead review) | 3.4 | Search all `src/vue/**/*.vue` components for hardcoded text in section headings (`<h3>`, `<h4>`, `<legend>`), tab labels, group labels, form section titles. Document each location (file + line) and current text. Identify which should use auto-derived labels vs. new keys. Success: Comprehensive list of 20+ hardcoded UI strings. |
-| **3.3: Button labels & action messages audit** | Jr dev | 3.4 | Search for hardcoded text in: `<button>` labels/titles, `.textContent`/`.innerText` in templates, notification messages (toasts, dialogs), chat messages. Document locations and current text. Success: List of button/message strings (10+). |
-| **3.4: Add localization keys to lang files** | Jr dev or flexible | 3.5 | Create/update lang file sections for all strings identified in 3.2 + 3.3. Organize by domain: `dnd35e.UI.*`, `dnd35e.MESSAGES.*`, `dnd35e.BUTTONS.*`, `dnd35e.FORMULA_FAMILIAR.*`. Ensure keys are descriptive and reusable. Success: All keys from 3.2 + 3.3 have entries. |
-| **3.5: Wire localization into components** | Jr dev (lead reviews) | 3.6 | Update all components with hardcoded text to use `game.i18n.localize()`. Replace direct text with computed/rendered localized values. Handle dynamic text (interpolation) if needed. Success: No hardcoded English strings visible to user, all replaced with localization calls. |
+| **3.2: Sheet UI text audit — section headers, tabs, group labels** | Jr dev (lead review) | 3.4 | ✅ Complete. 8 raw label props + 3 inline strings identified and documented. |
+| **3.3: Button labels & action messages audit** | Jr dev | 3.4 | ✅ Complete. 2 raw button/aria strings found; deprecated LandingPad deferred. |
+| **3.4: Add localization keys to lang files** | Jr dev or flexible | 3.5 | ✅ Complete. Added `equippedSlotIds` to EQUIPPABLE.FIELDS, `IsInfinite` to quantity, `dnd35e.UI.EditField` and `dnd35e.UI.Content` to common.json. |
+| **3.5: Wire localization into components** | Jr dev (lead reviews) | 3.6 | ✅ Complete. Removed 8 raw label props (auto-derive from schema), fixed 3 inline strings, fixed 2 button/aria strings. Build clean. |
 | **3.6: Verify user-visible localization exhaustively** | Lead dev | None | Run dev build. Manually test all sheets (items, weapons, effects, materials). Check: section headers, tabs, buttons, dropdowns, tooltips all show localized text. Switch language in settings (test with another language if available). Success: Zero hardcoded English text visible in UI. |
 
 ---

--- a/memories/session/phase-03-buttons-messages-audit.md
+++ b/memories/session/phase-03-buttons-messages-audit.md
@@ -1,0 +1,67 @@
+# Phase 3 — Button & Message Text Audit (Task 3.3)
+
+**Status**: Audit complete. Implementation (Tasks 3.4, 3.5) not started.
+
+---
+
+## FINDINGS
+
+### Hardcoded English in button/control attributes
+
+| File | Line | Issue | Action |
+|------|------|-------|--------|
+| `src/entities/items/components/Physical/sheet/components/ItemQuantity.vue` | 16 | `:title="'Is Infinite'"` — raw string, not i18n key | Replace with `game.i18n.localize('dnd35e.PHYSICAL_ITEM.FIELDS.quantity.IsInfinite')` (new key) |
+| `src/vue/components/Fields/FormGroups/RichTextEditorFormGroup.vue` | 18 | `` :aria-label="`Edit ${label \|\| 'content'}`" `` — interpolated raw English | Replace with localized template e.g. `game.i18n.format('dnd35e.UI.EditField', { field: label \|\| game.i18n.localize('dnd35e.UI.Content') })` |
+
+### Deprecated components — skip
+| File | Issue | Decision |
+|------|-------|---------|
+| `src/vue/components/LandingPad.vue` | `"Drop materials here"` (line 13), `✕` button text (line 30) | Component is `@deprecated` and unused — defer/ignore |
+| `src/entities/activeEffects/material/sheet/MaterialsLandingPad.vue` | Consumes deprecated LandingPad | Also `@deprecated` — skip |
+
+### Already clean — no action needed
+- All `ui.notifications.*` calls: ✓ all use `game.i18n.localize()` with proper keys
+- All `DialogV2.confirm()` calls: ✓ all use `game.i18n.localize()` with proper keys
+- Math operator symbols (`+`, `×`, `=`, `↑`, `↓`) in `HasActiveEffectsNotification.vue`: ✓ these are universal symbols, not localizable text
+- All settings buttons (Save/Reset/Add/Delete): ✓ all use `localize()` with `dnd35e.SETTINGS.*` or `dnd35e.COMMON.*` keys
+- All effects list buttons (Create, Edit, Delete, Toggle): ✓ all use `createLocalizedComputed()` or `game.i18n.localize()`
+
+---
+
+## New lang keys required
+
+| Key | Text | File needed in |
+|-----|------|----------------|
+| `dnd35e.PHYSICAL_ITEM.FIELDS.quantity.IsInfinite` | "Is Infinite" | `src/lang/en/items.json` |
+| `dnd35e.UI.EditField` | "Edit {field}" (format string) | `src/lang/en/common.json` |
+| `dnd35e.UI.Content` | "content" (fallback for RichText aria-label) | `src/lang/en/common.json` |
+
+---
+
+## Summary — all three audits complete
+
+### Total items requiring implementation across all audits:
+
+**Magic Strings (2.2/2.3)**:
+- Group A: 14 files with raw `'dnd35e'` → `SYSTEM_ID`
+- Group B: new `cssClasses.mts` constants (3 constants, 9 files)
+- Group C: 3 occurrences in `IdentifiableItem.mts` → `secretEffectType`
+- Group D: 2 occurrences in `ColorFormGroup.vue` → local `DEFAULT_COLOR`
+
+**Sheet UI Text (3.4/3.5)**:
+- Category 1: 8 raw English `label` props → remove (auto-derive from schema)
+- Category 2: 3 hardcoded computed/inline strings → `game.i18n.localize()`
+- 1 non-standard key format in `DesignedForSize.vue` to investigate
+
+**Button/Message Text (3.4/3.5 continued)**:
+- 1 raw `:title` in `ItemQuantity.vue`
+- 1 raw `aria-label` in `RichTextEditorFormGroup.vue`
+
+**New lang keys needed** (check what already exists before adding):
+- `dnd35e.EQUIPPABLE.FIELDS.isCarried.label`
+- `dnd35e.EQUIPPABLE.FIELDS.isEquipped.label`
+- `dnd35e.EQUIPPABLE.FIELDS.isWeightlessWhenEquipped.label`
+- `dnd35e.PHYSICAL_ITEM.FIELDS.hp.label`
+- `dnd35e.PHYSICAL_ITEM.FIELDS.quantity.IsInfinite`
+- `dnd35e.UI.EditField`
+- `dnd35e.UI.Content`

--- a/memories/session/phase-03-magic-strings-audit.md
+++ b/memories/session/phase-03-magic-strings-audit.md
@@ -1,0 +1,92 @@
+# Phase 3 — Magic Strings Audit (Task 2.1)
+
+**Status**: Audit complete. Implementation (Tasks 2.2, 2.3) not started.
+
+---
+
+## GROUP A: 'dnd35e' literal → use `SYSTEM_ID`
+
+`SYSTEM_ID` already exists: `src/settings/shared.mts` line 8.
+
+Files that use raw `'dnd35e'` where `SYSTEM_ID` should be used:
+
+| File | Line(s) | Usage |
+|------|---------|-------|
+| `src/entities/items/registration.mts` | 17 | `registerSheet('dnd35e', ...)` |
+| `src/entities/activeEffects/registration.mts` | 53 | `registerSheet(..., 'dnd35e', ...)` |
+| `src/entities/components/CoreMixin/sheet/DocumentSheetStore.mts` | 159, 245 | `setFlag/getFlag('dnd35e', ...)` |
+| `src/entities/components/CoreMixin/sheet/stores/FieldOverridesStore.mts` | 146 | `getFlag('dnd35e', ...)` |
+| `src/vue/apps/VueItemSheet.mts` | 12 | `classes: ['dnd35e', 'vueApp']` |
+| `src/vue/apps/VueActiveEffectConfig.mts` | 12 | `classes: ['dnd35e', 'vueApp']` |
+| `src/entities/items/baseItem/sheet/BaseItemSheet.mts` | 20 | `classes: ['dnd35e', 'item-sheet']` |
+| `src/settings/skills/sheet/SkillSettingsConfig.mts` | 30 | `classes: ['dnd35e', 'vueApp', 'settings-config']` |
+| `src/settings/roll/sheet/RollSettingsConfig.mts` | 30 | `classes: ['dnd35e', 'vueApp', 'settings-config']` |
+| `src/settings/health/sheet/HealthSettingsConfig.mts` | 31 | `classes: ['dnd35e', 'vueApp', 'settings-config']` |
+| `src/settings/gameRules/sheet/GameRulesSettingsConfig.mts` | 31 | `classes: ['dnd35e', 'vueApp', 'settings-config']` |
+| `src/settings/display/sheet/DisplaySettingsConfig.mts` | 31 | `classes: ['dnd35e', 'vueApp', 'settings-config']` |
+| `src/settings/currency/sheet/CurrencySettingsConfig.mts` | 27 | `classes: ['dnd35e', 'vueApp', 'settings-config']` |
+| `src/settings/combat/sheet/CombatSettingsConfig.mts` | 30 | `classes: ['dnd35e', 'vueApp', 'settings-config']` |
+
+Import path for all: `import { SYSTEM_ID } from '@settings/shared.mjs'` (or relative `../../shared.mjs` for settings files that already use relative imports).
+
+---
+
+## GROUP B: CSS class literals → new constants
+
+Create `src/constants/cssClasses.mts`:
+```ts
+export const VUE_APP_CLASS = 'vueApp';
+export const ITEM_SHEET_CLASS = 'item-sheet';
+export const SETTINGS_CONFIG_CLASS = 'settings-config';
+```
+
+Export all three from `src/constants/index.mts`.
+
+Usage locations:
+| Constant | Files that need it |
+|---|---|
+| `VUE_APP_CLASS` | VueItemSheet.mts, VueActiveEffectConfig.mts, all 6 settings configs |
+| `ITEM_SHEET_CLASS` | BaseItemSheet.mts |
+| `SETTINGS_CONFIG_CLASS` | all 6 settings configs |
+
+---
+
+## GROUP C: `'secret'` literal → `secretEffectType`
+
+`secretEffectType` constant exists: `src/entities/activeEffects/secret/secretEffectType.mts` (value: `'secret'`)
+
+File that uses raw `'secret'` literal instead of the constant:
+| File | Lines | Note |
+|------|-------|------|
+| `src/entities/components/Identifiable/IdentifiableItem.mts` | 116, 135, 140 | Should import `secretEffectType` from `@effects/secret/secretEffectType.mjs` |
+
+---
+
+## GROUP D: Default color `'#ffffff'` → local constant
+
+File: `src/vue/components/Fields/FormGroups/ColorFormGroup.vue`
+Lines: 12, 19 (both in template: `?? '#ffffff'`)
+
+Fix: extract as local script constant `const DEFAULT_COLOR = '#ffffff'` — not worth a shared constants file (one component only).
+
+---
+
+## OUT OF SCOPE (already handled)
+
+- `EDIT`/`PLAY`/`TRUE` view mode constants — defined in `src/helpers/formulae/types.mts` ✓
+- `materialEffectType` / `secretEffectType` / `GENERAL_EFFECT_TYPE` — constants exist ✓
+- `LogLevel` — constants exist in `src/constants/logging.mts` ✓
+- Bonus type constants (`BONUS_TYPE_MATERIAL`, etc.) — constants exist ✓
+- All hex colors in CSS/SCSS blocks — these are styling values in `<style>` blocks, not application logic; excluded from scope
+
+---
+
+## Implementation Plan (Tasks 2.2 + 2.3)
+
+### Step 1: Create `src/constants/cssClasses.mts`
+### Step 2: Export from `src/constants/index.mts`
+### Step 3: Replace all Group A instances with `SYSTEM_ID`
+### Step 4: Replace all Group B instances with CSS class constants
+### Step 5: Fix Group C (`IdentifiableItem.mts`)
+### Step 6: Fix Group D (`ColorFormGroup.vue` local constant)
+### Step 7: `npm run build` — must be clean

--- a/memories/session/phase-03-ui-text-audit.md
+++ b/memories/session/phase-03-ui-text-audit.md
@@ -1,0 +1,77 @@
+# Phase 3 — Sheet UI Text Audit (Task 3.2)
+
+**Status**: Audit complete. Implementation (Tasks 3.4, 3.5) not started.
+
+---
+
+## CATEGORY 1: Raw English text in `label` props (not i18n keys)
+
+These are passed to FormGroup/FormGroupSection via `label=` prop, which calls `game.i18n.localize()` on them — but since they're raw English, not keys, they just pass through unchanged.
+
+The fix for most is to **remove the label prop** so schema auto-derivation kicks in (the field-path already exists, so FIELDS.*.label will be used). For schema fields without a FIELDS entry yet, the lang file needs a key first.
+
+| File | Line | Raw label | Schema auto-derive? | Action |
+|------|------|-----------|---------------------|--------|
+| `src/entities/items/components/Physical/sheet/components/ItemHP.vue` | 3 | `label="HP"` (FormGroupSection) | ⚠️ `system.hp` is a compound — may not auto-derive | Add key `dnd35e.PHYSICAL_ITEM.FIELDS.hp.label` + remove prop |
+| `src/entities/items/components/Physical/sheet/components/ItemHP.vue` | 10 | `label="Current"` | ✅ `system.hp.current` exists in schema | Remove prop (auto-derives) |
+| `src/entities/items/components/Physical/sheet/components/ItemHP.vue` | 19 | `label="Max"` | ✅ `system.hp.max` exists in schema | Remove prop (auto-derives) |
+| `src/entities/items/components/Equippable/sheet/components/ItemIsMelded.vue` | 3 | `label="Is Melded"` | ✅ `system.isMelded` exists | Remove prop (auto-derives) |
+| `src/entities/items/components/Equippable/sheet/components/ItemIsWeightlessWhenEquipped.vue` | 3 | `label="Is Weightless When Equipped"` | ✅ `system.isWeightlessWhenEquipped` exists | Remove prop (auto-derives) |
+| `src/entities/items/components/Equippable/sheet/components/ItemSlot.vue` | 3 | `label="Equipped Slots"` | ✅ `system.equippedSlotIds` exists | Remove prop (auto-derives) |
+| `src/entities/items/components/Physical/sheet/components/ItemSheetIsCarriedCheckbox.vue` | 3 | `label="Is Carried"` | ✅ `system.isCarried` exists | Remove prop (auto-derives) |
+| `src/entities/items/components/Physical/sheet/components/ItemSheetIsMeldedCheckbox.vue` | 3 | `label="Is Carried"` ⚠️ WRONG LABEL | ✅ `system.isCarried` exists | Remove prop — also note the label text appears wrong (probably should be field auto-derive anyway) |
+
+### Possibly-non-FIELDS label key (non-standard format):
+| File | Line | Current label prop | Issue | Action |
+|------|------|--------------------|--------------------|--------|
+| `src/entities/items/components/Equippable/sheet/components/DesignedForSize.vue` | 3 | `label="dnd35e.EQUIPPABLE.DesignedForSize"` | Uses non-FIELDS path (`dnd35e.EQUIPPABLE.DesignedForSize` not `.EQUIPPABLE.FIELDS.designedForSize.label`) | Remove prop if FIELDS path is in lang file; or migrate key to FIELDS pattern |
+
+---
+
+## CATEGORY 2: Hardcoded text in template HTML (not passing through localize)
+
+| File | Line | Raw text | Action |
+|------|------|----------|--------|
+| `src/entities/items/components/Physical/sheet/components/PhysicalItemHeaderStatus.vue` | 5 | `Carried` (inline text in template) | Replace with `game.i18n.localize('dnd35e.EQUIPPABLE.FIELDS.isCarried.label')` or dedicated key |
+| `src/entities/items/components/Equippable/sheet/components/EquippableHeaderStatus.vue` | 20 | `statusLabel` computed: `'Equipped'` / `'Carried'` (raw strings) | Replace computed return values with `game.i18n.localize(...)` calls |
+| `src/entities/items/components/Equippable/sheet/components/EquippableItemWeight.vue` | 10 | `:title="'Is Weightless When Equipped'"` | Replace with `game.i18n.localize('dnd35e.EQUIPPABLE.FIELDS.isWeightlessWhenEquipped.label')` |
+
+---
+
+## CATEGORY 3: Already localized — no action needed
+
+All of the following are confirmed clean:
+- `Effects.vue` — all strings via `localize()` with proper keys ✓
+- `EffectCategory.vue` — all strings via `createLocalizedComputed()` ✓
+- `SecretsList.vue` — all strings via `localize()` ✓
+- `MaterialsList.vue` — string via `localize()` ✓
+- `SecretMasks.vue` — all strings via `game.i18n.localize()` ✓
+- `EffectChangesList.vue` — all strings via `game.i18n.localize()` ✓
+- `SecretSheet.vue` — player edit label via `game.i18n.localize()` ✓
+- `SkillSettingsApp.vue` — all strings via `localize()` ✓
+- `GameRulesSettingsApp.vue` — all strings via `localize()` ✓
+- `CurrencySettingsApp.vue` — all strings via `localize()` ✓
+- `HealthSettingsApp.vue` — all strings via explicit label keys ✓
+- `IsIdentifiedToggle.vue` — all strings via `game.i18n.localize()` ✓
+- `TabDivider.vue` — tab labels come from TabStore with keys ✓
+- `DocumentHeader.vue` — type label from store getter ✓
+
+---
+
+## Required lang file additions
+
+For Category 2, these keys need to exist (check if already in lang files):
+- `dnd35e.EQUIPPABLE.FIELDS.isCarried.label` (for "Carried" / "Is Carried")
+- `dnd35e.EQUIPPABLE.FIELDS.isEquipped.label` (for "Equipped")
+- `dnd35e.EQUIPPABLE.FIELDS.isWeightlessWhenEquipped.label` (for title tooltip)
+- `dnd35e.PHYSICAL_ITEM.FIELDS.hp.label` (for HP section header, if not present)
+
+---
+
+## Implementation Plan (Tasks 3.4 + 3.5)
+
+### Step 1: Verify which lang keys already exist in `src/lang/en/items.json`
+### Step 2: Add any missing keys to lang files
+### Step 3: Remove raw English `label` props from Category 1 components (let schema auto-derive)
+### Step 4: Fix Category 2 computed/inline text to use `game.i18n.localize()`
+### Step 5: Verify `DesignedForSize.vue` key format — migrate to FIELDS pattern if needed

--- a/src/constants/cssClasses.mts
+++ b/src/constants/cssClasses.mts
@@ -1,0 +1,9 @@
+const VUE_APP_CLASS = 'vueApp';
+const ITEM_SHEET_CLASS = 'item-sheet';
+const SETTINGS_CONFIG_CLASS = 'settings-config';
+
+export {
+  ITEM_SHEET_CLASS,
+  SETTINGS_CONFIG_CLASS,
+  VUE_APP_CLASS,
+};

--- a/src/constants/index.mts
+++ b/src/constants/index.mts
@@ -7,6 +7,7 @@ import {
   type BonusType,
 } from './bonusTypes.mjs';
 import { EffectConfig, ItemConfig } from './config/index.mjs';
+import { ITEM_SHEET_CLASS, SETTINGS_CONFIG_CLASS, VUE_APP_CLASS } from './cssClasses.mjs';
 import { devConfig } from './devConfig.mjs';
 import { EQUIP_SLOT_SELECT_OPTIONS,EQUIP_SLOTS } from './equipmentSlots.mjs';
 import { defaultGameSettings } from './gameSettings/index.mjs';
@@ -29,11 +30,14 @@ export {
   EQUIP_SLOTS,
   hbsTemplatePath,
   isAttackAction,
+  ITEM_SHEET_CLASS,
   ItemConfig,
   LogLevel,
+  SETTINGS_CONFIG_CLASS,
   SIZE_SELECT_OPTIONS,
   SIZES,
   systemPath,
+  VUE_APP_CLASS,
 };
 
 export type { BonusType };

--- a/src/entities/activeEffects/registration.mts
+++ b/src/entities/activeEffects/registration.mts
@@ -13,6 +13,7 @@ import { secretEffectType } from '@effects/secret/secretEffectType.mjs';
 import { SecretSheet } from '@effects/secret/sheet/SecretSheet.mjs';
 import { gatherAspectsFromSchema, registerFamiliarSchema } from '@helpers/formulae/index.mjs';
 import type { ItemDnd35e, ItemSheetStore } from '@items/baseItem/index.mjs';
+import { SYSTEM_ID } from '@settings/shared.mjs';
 
 const syncOpenSheetTitle = (sheet: { rendered?: boolean; title?: string; window?: { title?: HTMLElement } } | null | undefined): void => {
   if (!sheet?.rendered) return;
@@ -50,7 +51,7 @@ const registerEffectSheets = () => {
   for (const [effectType, Sheet] of effectSheets) {
     foundry.applications.apps.DocumentSheetConfig.registerSheet(
       foundry.documents.ActiveEffect,
-      'dnd35e',
+      SYSTEM_ID,
       Sheet,
       {
         types: [effectType],

--- a/src/entities/components/CoreMixin/sheet/DocumentSheetStore.mts
+++ b/src/entities/components/CoreMixin/sheet/DocumentSheetStore.mts
@@ -6,6 +6,7 @@ import { buildDocumentFamiliar } from '@helpers/formulae/index.mjs';
 import type { FamiliarSchema } from '@helpers/formulae/types.mjs';
 import type { ItemDnd35e } from '@items/baseItem/index.mjs';
 import type { ItemType } from '@items/itemTypes.mjs';
+import { SYSTEM_ID } from '@settings/shared.mjs';
 import type {
   FieldEditability,
   FieldVisibility,
@@ -156,7 +157,7 @@ const useDocumentSheetStore = <TDocument extends SheetDocument>(
 
   const updateFlag = async (key: string, value: unknown): Promise<boolean> => {
     try {
-      await document.value.setFlag('dnd35e', key, value);
+      await document.value.setFlag(SYSTEM_ID, key, value);
       triggerRef(document);
       return true;
     } catch (err) {
@@ -221,17 +222,6 @@ const useDocumentSheetStore = <TDocument extends SheetDocument>(
 
   // --- Overridable implementations (replaced by extending stores via _storeUtils) ---
 
-  // type GetEffectiveFieldValueFn = <T>(fieldPath: string, realValue: T) => T;
-  // type GetViewAwareFieldUpdaterFn = (path: string) => (value: unknown) => Promise<boolean>;
-
-  // const _getEffectiveFieldValueImpl = ref<GetEffectiveFieldValueFn>(
-  //   <T,>(_fieldPath: string, realValue: T): T => realValue
-  // );
-  // const _getViewAwareFieldUpdaterImpl = ref<GetViewAwareFieldUpdaterFn>(
-  //   (path: string) => async (value: unknown) => {
-  //     return await updateDocument({ [path]: value } as Partial<TDocument>);
-  //   }
-  // );
   const _getFreshDocumentImpl = ref<(id: string) => Promise<TDocument | null>>(
     async (_id: string): Promise<TDocument | null> => {
       console.error('getFreshDocument is not implemented for this store');
@@ -242,7 +232,7 @@ const useDocumentSheetStore = <TDocument extends SheetDocument>(
   // --- Getters ---
 
   const getFlagValue = <T,>(flagPath: string): T => {
-    return document.value.getFlag('dnd35e', flagPath) as T;
+    return document.value.getFlag(SYSTEM_ID, flagPath) as T;
   };
 
   const getSchemaField = (fieldPath: string): foundry.data.fields.DataField | undefined => {

--- a/src/entities/components/CoreMixin/sheet/stores/FieldOverridesStore.mts
+++ b/src/entities/components/CoreMixin/sheet/stores/FieldOverridesStore.mts
@@ -11,6 +11,7 @@
  * @module
  */
 
+import { SYSTEM_ID } from '@settings/shared.mjs';
 import type {
   FieldEditability,
   FieldOverride,
@@ -143,7 +144,7 @@ const useFieldOverridesStore = (options: FieldOverridesStoreOptions): FieldOverr
   const { document, updateFlag } = options;
 
   const fieldOverrides = computed((): FieldOverrides => {
-    return (document.value.getFlag('dnd35e', FIELD_OVERRIDES_FLAG) as FieldOverrides | undefined) ?? {};
+    return (document.value.getFlag(SYSTEM_ID, FIELD_OVERRIDES_FLAG) as FieldOverrides | undefined) ?? {};
   });
 
   // ---------------------------------------------------------------------------

--- a/src/entities/components/Identifiable/IdentifiableItem.mts
+++ b/src/entities/components/Identifiable/IdentifiableItem.mts
@@ -1,5 +1,6 @@
 import type { Dnd35eDocumentProperties } from '@ec/CoreMixin/Dnd35eDocument.mjs';
 import type { EvaluationDocument, FormulaRegistration } from '@ec/CoreMixin/index.mjs';
+import { secretEffectType } from '@effects/secret/secretEffectType.mjs';
 import type { ItemSourceDnd35e } from '@items/baseItem/index.mjs';
 import { ItemDnd35e } from '@items/baseItem/index.mjs';
 import type { ItemType } from '@items/index.mjs';
@@ -113,7 +114,7 @@ const IdentifiableDocumentMixin = <TBase extends IdentifiableDocumentCtor> (Base
      */
     private _deriveIdentifiableState (): void {
       const secrets = [...this.effects].filter(
-        e => e.type === 'secret'
+        e => e.type === secretEffectType
       );
       this.isIdentifiable = secrets.length > 0;
       this.isIdentified = !secrets.some(e => e.active);
@@ -132,12 +133,12 @@ const IdentifiableDocumentMixin = <TBase extends IdentifiableDocumentCtor> (Base
         const effectId = effect.id;
         if (!effectId) continue;
 
-        if (effect.type === 'secret' && !effect.disabled) {
+        if (effect.type === secretEffectType && !effect.disabled) {
           updates.push({ _id: effectId, disabled: true });
           continue;
         }
 
-        if (effect.type !== 'secret' && 'system' in effect && (effect as { system?: { isHidden?: boolean } }).system?.isHidden) {
+        if (effect.type !== secretEffectType && 'system' in effect && (effect as { system?: { isHidden?: boolean } }).system?.isHidden) {
           updates.push({ _id: effectId, 'system.isHidden': false });
         }
       }

--- a/src/entities/items/baseItem/sheet/BaseItemSheet.mts
+++ b/src/entities/items/baseItem/sheet/BaseItemSheet.mts
@@ -1,6 +1,8 @@
 import type { DocumentSheetRenderContext } from '@client/applications/api/document-sheet.mjs';
+import { ITEM_SHEET_CLASS } from '@constants/cssClasses.mjs';
 import type { ItemDnd35e } from '@items/baseItem/index.mjs';
 import type { ItemType } from '@items/itemTypes.mjs';
+import { SYSTEM_ID } from '@settings/shared.mjs';
 import type { VueApplicationConfiguration, VueRenderOptions } from '@vueApps/index.mjs';
 import { VueItemSheet } from '@vueApps/index.mjs';
 
@@ -17,7 +19,7 @@ abstract class ItemSheetDnd35e<
   
   static override get DEFAULT_OPTIONS (): VueApplicationConfiguration<ItemDnd35e> {
     return {
-      classes: ['dnd35e', 'item-sheet'],
+      classes: [SYSTEM_ID, ITEM_SHEET_CLASS],
       position: {
         width: 560,
         height: 650,

--- a/src/entities/items/components/Equippable/sheet/components/DesignedForSize.vue
+++ b/src/entities/items/components/Equippable/sheet/components/DesignedForSize.vue
@@ -1,6 +1,5 @@
 <template>
   <SelectFormGroup
-    label="dnd35e.EQUIPPABLE.DesignedForSize"
     :value="designedForSize"
     :options="SIZE_SELECT_OPTIONS"
     field-path="system.designedForSize"

--- a/src/entities/items/components/Equippable/sheet/components/EquippableHeaderStatus.vue
+++ b/src/entities/items/components/Equippable/sheet/components/EquippableHeaderStatus.vue
@@ -19,7 +19,9 @@
   const { isEquipped, isCarried } = store.documentGetters;
   const isEquippedOrCarried = computed(() => isEquipped.value || isCarried.value);
   const equippedIcon = computed(() => isEquipped.value ? 'fas fa-shield-alt' : 'fas fa-bag-check');
-  const statusLabel = computed(() => isEquipped.value ? 'Equipped' : 'Carried');
+  const statusLabel = computed(() => isEquipped.value
+    ? game.i18n.localize('dnd35e.EQUIPPABLE.FIELDS.isEquipped.label')
+    : game.i18n.localize('dnd35e.PHYSICAL_ITEM.FIELDS.isCarried.label'));
 </script>
 
 <style scoped lang="scss">

--- a/src/entities/items/components/Equippable/sheet/components/EquippableItemWeight.vue
+++ b/src/entities/items/components/Equippable/sheet/components/EquippableItemWeight.vue
@@ -5,7 +5,7 @@
         class="field-control-btn weightless-toggle"
         type="button"
         @click="isWeightlessWhenEquippedUpdater(!isWeightlessWhenEquipped)"
-        :title="'Is Weightless When Equipped'"
+        :title="weightlessTitle"
       >
         <i class="fas fa-weight-hanging icon-off" v-if="!isWeightlessWhenEquipped"></i>
 
@@ -27,6 +27,7 @@
   import type { EquippableDocumentStore } from '../EquippableItemStore.mjs';
 
   const { isEditMode } = inject(RenderModeStoreSymbol) as RenderModeStore;
+  const weightlessTitle = game.i18n.localize('dnd35e.EQUIPPABLE.FIELDS.isWeightlessWhenEquipped.label');
   const {
     documentGetters: {
       isWeightlessWhenEquipped,

--- a/src/entities/items/components/Equippable/sheet/components/ItemIsMelded.vue
+++ b/src/entities/items/components/Equippable/sheet/components/ItemIsMelded.vue
@@ -1,6 +1,5 @@
 <template>
   <CheckBoxFormGroup
-    label="Is Melded"
     :value="isMelded"
     :on-update="updater"
     field-path="system.isMelded"

--- a/src/entities/items/components/Equippable/sheet/components/ItemIsWeightlessWhenEquipped.vue
+++ b/src/entities/items/components/Equippable/sheet/components/ItemIsWeightlessWhenEquipped.vue
@@ -1,6 +1,5 @@
 <template>
   <CheckBoxFormGroup
-    label="Is Weightless When Equipped"
     :value="isWeightlessWhenEquipped"
     :on-update="updater"
     field-path="system.isWeightlessWhenEquipped"

--- a/src/entities/items/components/Equippable/sheet/components/ItemSlot.vue
+++ b/src/entities/items/components/Equippable/sheet/components/ItemSlot.vue
@@ -1,6 +1,5 @@
 <template>
   <MultiSelectFormGroup
-    label="Equipped Slots"
     :value="equippedSlotIds"
     :on-update="updater"
     :options="EQUIP_SLOT_SELECT_OPTIONS"

--- a/src/entities/items/components/Physical/sheet/components/ItemHP.vue
+++ b/src/entities/items/components/Physical/sheet/components/ItemHP.vue
@@ -1,13 +1,12 @@
 <template>
   <FormGroupSection
-    label="HP"
+    label="dnd35e.PHYSICAL_ITEM.FIELDS.hp.label"
     field-path="system.hp"
     :default-visibility="ownerPlusVisibility"
     :default-editability="gmOnlyEditability"
     class="item-hp-section"
   >
     <NumberFormGroup
-      label="Current"
       :value="currentHp"
       :on-update="updateCurrentHp"
       field-path="system.hp.current"
@@ -16,7 +15,6 @@
       direct-update
     />
     <NumberFormGroup
-      label="Max"
       :value="maxHp"
       :on-update="maxHpUpdater"
       field-path="system.hp.max"

--- a/src/entities/items/components/Physical/sheet/components/ItemQuantity.vue
+++ b/src/entities/items/components/Physical/sheet/components/ItemQuantity.vue
@@ -13,7 +13,7 @@
         class="field-control-btn"
         type="button"
         :class="{ 'is-active': isInfinite }"
-        :title="'Is Infinite'"
+        :title="isInfiniteTitle"
         @click="toggleInfinite"
       >
         <i class="fas fa-infinity" />
@@ -46,4 +46,5 @@
   const isInfinite = computed(() => quantity.value === -1);
 
   const toggleInfinite = () => updater(isInfinite.value ? 0 : -1);
+  const isInfiniteTitle = game.i18n.localize('dnd35e.PHYSICAL_ITEM.FIELDS.quantity.IsInfinite');
 </script>

--- a/src/entities/items/components/Physical/sheet/components/ItemSheetIsCarriedCheckbox.vue
+++ b/src/entities/items/components/Physical/sheet/components/ItemSheetIsCarriedCheckbox.vue
@@ -1,7 +1,6 @@
 <template>
   <CheckBoxFormGroup
     v-if="hasOwner"
-    label="Is Carried"
     :value="isCarried"
     :on-update="updater"
     field-path="system.isCarried"

--- a/src/entities/items/components/Physical/sheet/components/ItemSheetIsMeldedCheckbox.vue
+++ b/src/entities/items/components/Physical/sheet/components/ItemSheetIsMeldedCheckbox.vue
@@ -1,6 +1,5 @@
 <template>
   <CheckBoxFormGroup
-    label="Is Carried"
     :value="isCarried"
     :on-update="updater"
     field-path="system.isCarried"

--- a/src/entities/items/components/Physical/sheet/components/PhysicalItemHeaderStatus.vue
+++ b/src/entities/items/components/Physical/sheet/components/PhysicalItemHeaderStatus.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="isCarried" class="header-status-badge">
     <i class="fas fa-bag-check" />
-    Carried
+    {{ carriedLabel }}
   </div>
 </template>
 
@@ -13,6 +13,7 @@
   const store = inject(DocumentSheetStoreSymbol) as PhysicalDocumentStore;
 
   const { isCarried } = store.documentGetters;
+  const carriedLabel = game.i18n.localize('dnd35e.PHYSICAL_ITEM.FIELDS.isCarried.label');
 </script>
 
 <style scoped lang="scss">

--- a/src/entities/items/registration.mts
+++ b/src/entities/items/registration.mts
@@ -6,6 +6,7 @@ import type { ItemSheetStore } from '@items/baseItem/index.mjs';
 import { ItemProxyDnd35e } from '@items/baseItem/index.mjs';
 import { weaponItemType } from '@items/itemTypes.mjs';
 import { WeaponSheet, WeaponSystemModel } from '@items/weapon/index.mjs';
+import { SYSTEM_ID } from '@settings/shared.mjs';
 
 const registerItemSheets = () => {
   foundry.documents.collections.Items.unregisterSheet('core', foundry.appv1.sheets.ItemSheet);
@@ -14,7 +15,7 @@ const registerItemSheets = () => {
   ] as const;
 
   for (const [type, Sheet] of itemSheets) {
-    foundry.documents.collections.Items.registerSheet('dnd35e', Sheet, {
+    foundry.documents.collections.Items.registerSheet(SYSTEM_ID, Sheet, {
       types: [type],
       makeDefault: true,
     });

--- a/src/lang/en/common.json
+++ b/src/lang/en/common.json
@@ -44,6 +44,10 @@
       "ActorTypeNPC": "NPC",
       "ActorTypeTrap": "Trap"
     },
+    "UI": {
+      "EditField": "Edit {field}",
+      "Content": "content"
+    },
     "DOCUMENT": {
       "FIELDS": {
         "version": {

--- a/src/lang/en/items.json
+++ b/src/lang/en/items.json
@@ -96,7 +96,8 @@
         },
         "quantity": {
           "label": "Quantity",
-          "hint": "The number of this item in the stack."
+          "hint": "The number of this item in the stack.",
+          "IsInfinite": "Is Infinite"
         },
         "weight": {
           "label": "Weight",
@@ -142,6 +143,10 @@
         "isWeightlessWhenEquipped": {
           "label": "Weightless When Equipped",
           "hint": "If checked, this item does not contribute weight when equipped."
+        },
+        "equippedSlotIds": {
+          "label": "Equipped Slots",
+          "hint": "The equipment slots this item occupies when equipped."
         }
       },
       "EquipSlot": {

--- a/src/settings/combat/sheet/CombatSettingsConfig.mts
+++ b/src/settings/combat/sheet/CombatSettingsConfig.mts
@@ -2,6 +2,7 @@
  * Vue-based Combat Settings Configuration Dialog
  */
 
+import { SETTINGS_CONFIG_CLASS, VUE_APP_CLASS } from '@constants/cssClasses.mjs';
 import { useVueSettingsMixin, type VueSettingsRenderOptions } from '@vueApps/index.mjs';
 import type { App, Component } from 'vue';
 import { createApp } from 'vue';
@@ -27,7 +28,7 @@ class CombatSettingsConfig extends VueSettingsBase {
     {
       id: 'dnd35e-combat-config',
       tag: 'div',
-      classes: ['dnd35e', 'vueApp', 'settings-config'],
+      classes: [SYSTEM_ID, VUE_APP_CLASS, SETTINGS_CONFIG_CLASS],
       position: {
         width: 540,
         height: 'auto',

--- a/src/settings/currency/sheet/CurrencySettingsConfig.mts
+++ b/src/settings/currency/sheet/CurrencySettingsConfig.mts
@@ -2,6 +2,7 @@
  * Vue-based Currency Settings Configuration Dialog
  */
 
+import { SETTINGS_CONFIG_CLASS, VUE_APP_CLASS } from '@constants/cssClasses.mjs';
 import type { VueSettingsRenderOptions } from '@vueApps/index.mjs';
 import { useVueSettingsMixin } from '@vueApps/index.mjs';
 import type { Component } from 'vue';
@@ -24,7 +25,7 @@ class CurrencySettingsConfig extends VueSettingsBase {
     {
       id: 'dnd35e-currency-config',
       tag: 'form',
-      classes: ['dnd35e', 'vueApp', 'settings-config'],
+      classes: [SYSTEM_ID, VUE_APP_CLASS, SETTINGS_CONFIG_CLASS],
       position: {
         width: 640,
         height: 'auto',

--- a/src/settings/display/sheet/DisplaySettingsConfig.mts
+++ b/src/settings/display/sheet/DisplaySettingsConfig.mts
@@ -2,6 +2,7 @@
  * Vue-based Display Settings Configuration Dialog
  */
 
+import { SETTINGS_CONFIG_CLASS, VUE_APP_CLASS } from '@constants/cssClasses.mjs';
 import type { VueSettingsRenderOptions } from '@vueApps/index.mjs';
 import { useVueSettingsMixin } from '@vueApps/index.mjs';
 import type { App, Component } from 'vue';
@@ -28,7 +29,7 @@ class DisplaySettingsConfig extends VueSettingsBase {
     {
       id: 'dnd35e-display-config',
       tag: 'div',
-      classes: ['dnd35e', 'vueApp', 'settings-config'],
+      classes: [SYSTEM_ID, VUE_APP_CLASS, SETTINGS_CONFIG_CLASS],
       position: {
         width: 540,
         height: 'auto',

--- a/src/settings/gameRules/sheet/GameRulesSettingsConfig.mts
+++ b/src/settings/gameRules/sheet/GameRulesSettingsConfig.mts
@@ -2,6 +2,7 @@
  * Vue-based Game Rules Settings Configuration Dialog
  */
 
+import { SETTINGS_CONFIG_CLASS, VUE_APP_CLASS } from '@constants/cssClasses.mjs';
 import { useVueSettingsMixin, type VueSettingsRenderOptions } from '@vueApps/index.mjs';
 import type { App, Component } from 'vue';
 import { createApp } from 'vue';
@@ -28,7 +29,7 @@ class GameRulesSettingsConfig extends VueSettingsBase {
     {
       id: 'dnd35e-game-rules-config',
       tag: 'div',
-      classes: ['dnd35e', 'vueApp', 'settings-config'],
+      classes: [SYSTEM_ID, VUE_APP_CLASS, SETTINGS_CONFIG_CLASS],
       position: {
         width: 540,
         height: 'auto',

--- a/src/settings/health/sheet/HealthSettingsConfig.mts
+++ b/src/settings/health/sheet/HealthSettingsConfig.mts
@@ -2,6 +2,7 @@
  * Vue-based Health Settings Configuration Dialog
  */
 
+import { SETTINGS_CONFIG_CLASS, VUE_APP_CLASS } from '@constants/cssClasses.mjs';
 import type { VueSettingsRenderOptions } from '@vueApps/index.mjs';
 import { useVueSettingsMixin } from '@vueApps/index.mjs';
 import type { Component } from 'vue';
@@ -28,7 +29,7 @@ class HealthSettingsConfig extends VueSettingsBase {
     {
       id: 'dnd35e-health-config',
       tag: 'div',
-      classes: ['dnd35e', 'vueApp', 'settings-config'],
+      classes: [SYSTEM_ID, VUE_APP_CLASS, SETTINGS_CONFIG_CLASS],
       position: {
         width: 560,
         height: 500,

--- a/src/settings/roll/sheet/RollSettingsConfig.mts
+++ b/src/settings/roll/sheet/RollSettingsConfig.mts
@@ -2,6 +2,7 @@
  * Vue-based Roll Settings Configuration Dialog
  */
 
+import { SETTINGS_CONFIG_CLASS, VUE_APP_CLASS } from '@constants/cssClasses.mjs';
 import type { VueSettingsRenderOptions } from '@vueApps/index.mjs';
 import { useVueSettingsMixin } from '@vueApps/index.mjs';
 import type { Component } from 'vue';
@@ -27,7 +28,7 @@ class RollSettingsConfig extends VueSettingsBase {
     {
       id: 'dnd35e-roll-config',
       tag: 'div',
-      classes: ['dnd35e', 'vueApp', 'settings-config'],
+      classes: [SYSTEM_ID, VUE_APP_CLASS, SETTINGS_CONFIG_CLASS],
       position: {
         width: 540,
         height: 'auto',

--- a/src/settings/skills/sheet/SkillSettingsConfig.mts
+++ b/src/settings/skills/sheet/SkillSettingsConfig.mts
@@ -2,6 +2,7 @@
  * Vue-based Skill Settings Configuration Dialog
  */
 
+import { SETTINGS_CONFIG_CLASS, VUE_APP_CLASS } from '@constants/cssClasses.mjs';
 import type { VueSettingsRenderOptions } from '@vueApps/index.mjs';
 import { useVueSettingsMixin } from '@vueApps/index.mjs';
 import type { Component } from 'vue';
@@ -27,7 +28,7 @@ class SkillSettingsConfig extends VueSettingsBase {
     {
       id: 'dnd35e-skill-config',
       tag: 'div',
-      classes: ['dnd35e', 'vueApp', 'settings-config'],
+      classes: [SYSTEM_ID, VUE_APP_CLASS, SETTINGS_CONFIG_CLASS],
       position: {
         width: 720,
         height: 500,

--- a/src/vue/apps/VueActiveEffectConfig.mts
+++ b/src/vue/apps/VueActiveEffectConfig.mts
@@ -1,5 +1,7 @@
 import type { DocumentSheetConfiguration } from '@client/applications/api/document-sheet.mjs';
+import { VUE_APP_CLASS } from '@constants/cssClasses.mjs';
 import type { DnD35eActiveEffect } from '@entities/activeEffects/index.mjs';
+import { SYSTEM_ID } from '@settings/shared.mjs';
 
 import type { VueApplicationConfiguration, VueRenderOptions } from './VueAppTypes.mjs';
 import { useVueDocumentSheetMixin } from './VueDocumentSheetMixin.mjs';
@@ -9,7 +11,7 @@ const EffectConfigBase = foundry.applications.sheets.ActiveEffectConfig<DnD35eAc
 abstract class VueActiveEffectConfig extends useVueDocumentSheetMixin(EffectConfigBase) {
   static override get DEFAULT_OPTIONS (): DeepPartial<DocumentSheetConfiguration<DnD35eActiveEffect>> {
     return {
-      classes: ['dnd35e', 'vueApp'],
+      classes: [SYSTEM_ID, VUE_APP_CLASS],
       actions: {},
       position: {
         width: 985,

--- a/src/vue/apps/VueItemSheet.mts
+++ b/src/vue/apps/VueItemSheet.mts
@@ -1,5 +1,7 @@
 import type { DocumentSheetConfiguration } from '@client/applications/api/document-sheet.mjs';
+import { VUE_APP_CLASS } from '@constants/cssClasses.mjs';
 import type { ItemDnd35e } from '@items/baseItem/ItemDnd35e.mjs';
+import { SYSTEM_ID } from '@settings/shared.mjs';
 
 import type { VueApplicationConfiguration, VueRenderOptions } from './VueAppTypes.mjs';
 import { useVueDocumentSheetMixin } from './VueDocumentSheetMixin.mjs';
@@ -9,7 +11,7 @@ const ItemSheetBase = foundry.applications.sheets.ItemSheetV2<ItemDnd35e, VueApp
 abstract class VueItemSheet extends useVueDocumentSheetMixin(ItemSheetBase) {
   static override get DEFAULT_OPTIONS (): DeepPartial<DocumentSheetConfiguration<ItemDnd35e>> {
     return {
-      classes: ['dnd35e', 'vueApp'],
+      classes: [SYSTEM_ID, VUE_APP_CLASS],
       actions: {},
       position: {
         width: 560,

--- a/src/vue/components/Fields/FormGroups/ColorFormGroup.vue
+++ b/src/vue/components/Fields/FormGroups/ColorFormGroup.vue
@@ -9,14 +9,14 @@
   >
     <input
       type="color"
-      :value="editValue ?? '#ffffff'"
+      :value="editValue ?? DEFAULT_COLOR"
       :disabled="isDisabled"
       @change="onChange(($event.target as HTMLInputElement).value)"
     />
     <template #readonly>
       <div
         class="color-display"
-        :style="{ backgroundColor: value ?? '#ffffff' }"
+        :style="{ backgroundColor: value ?? DEFAULT_COLOR }"
       ></div>
       {{ value ?? localize('dnd35e.COMMON.NoColor') }}
     </template>
@@ -81,6 +81,8 @@
     if (!isGM.value && isEditMode.value && hasMaskForField(props.fieldPath).value) return props.value;
     return sourceValue.value as string | null;
   });
+
+  const DEFAULT_COLOR = '#ffffff';
 
   function onChange(val: string) {
     fieldUpdater(val);

--- a/src/vue/components/Fields/FormGroups/RichTextEditorFormGroup.vue
+++ b/src/vue/components/Fields/FormGroups/RichTextEditorFormGroup.vue
@@ -85,6 +85,7 @@
     documentActions: { getViewAwareFieldUpdater, getDirectFieldUpdater },
     _storeUtils: {
       getSourceProperty,
+      getSchemaField,
       createLocalizedComputed: localize,
       enrichHTML,
     },
@@ -118,7 +119,13 @@
   }
 
   const isEditButtonVisible = computed(() => !isEditing.value && isEditMode.value);
-  const editAriaLabel = computed(() => game.i18n.format('dnd35e.UI.EditField', { field: props.label || game.i18n.localize('dnd35e.UI.Content') }));
+  const editAriaLabel = computed(() => {
+    const localizedLabel = props.label
+      ? game.i18n.localize(props.label)
+      : (getSchemaField(props.field)?.options?.label as string | undefined)
+        ?? game.i18n.localize('dnd35e.UI.Content');
+    return game.i18n.format('dnd35e.UI.EditField', { field: localizedLabel });
+  });
 
   async function onSave(event: Event) {
     const target = event.target as HTMLElement & { value?: string };

--- a/src/vue/components/Fields/FormGroups/RichTextEditorFormGroup.vue
+++ b/src/vue/components/Fields/FormGroups/RichTextEditorFormGroup.vue
@@ -15,7 +15,7 @@
         v-if="editable && isEditButtonVisible"
         type="button"
         class="field-control-btn edit-button"
-        :aria-label="`Edit ${label || 'content'}`"
+        :aria-label="editAriaLabel"
         @click="startEditing"
       >
         <i class="fas fa-feather" />
@@ -118,6 +118,7 @@
   }
 
   const isEditButtonVisible = computed(() => !isEditing.value && isEditMode.value);
+  const editAriaLabel = computed(() => game.i18n.format('dnd35e.UI.EditField', { field: props.label || game.i18n.localize('dnd35e.UI.Content') }));
 
   async function onSave(event: Event) {
     const target = event.target as HTMLElement & { value?: string };


### PR DESCRIPTION
# Phase 3 Deliverables 2 & 3: Magic Strings + User-Visible Text — Implementation PR

**Date**: April 23, 2026  
**Branch**: `feature/phase3`  
**Status**: ✅ Complete  
**Implementation cycles**: 1 cycle  
**Files modified**: 33 source files  
**Lines**: +251 / −53  
**Build status**: Passes `npm run build` cleanly (392 modules)

---

## What We Built

### Deliverable 2: Magic Strings → Constants (Tasks 2.1–2.3)

Replaced four categories of hardcoded string literals with named constants:

- **Group A — `SYSTEM_ID`**: 14 occurrences of raw `'dnd35e'` replaced across `registration.mts` files, sheet app classes arrays, `DocumentSheetStore`, `FieldOverridesStore`. All now import `SYSTEM_ID` from `@settings/shared.mjs`.
- **Group B — CSS class constants**: New `src/constants/cssClasses.mts` exports `VUE_APP_CLASS`, `ITEM_SHEET_CLASS`, `SETTINGS_CONFIG_CLASS`. The 9 files that used raw class arrays (`['dnd35e', 'vueApp']` etc.) now use these constants.
- **Group C — `secretEffectType`**: 3 raw `'secret'` literals in `IdentifiableItem.mts` replaced with the existing `secretEffectType` constant from `@effects/secret/secretEffectType.mjs`.
- **Group D — `DEFAULT_COLOR`**: `ColorFormGroup.vue` extracted `const DEFAULT_COLOR = '#ffffff'` and replaced two `?? '#ffffff'` template occurrences.

### Deliverable 3: User-Visible Text Localization (Tasks 3.2–3.5)

**New lang keys added:**
- `dnd35e.EQUIPPABLE.FIELDS.equippedSlotIds.label` — "Equipped Slots" (was missing from EQUIPPABLE.FIELDS)
- `dnd35e.PHYSICAL_ITEM.FIELDS.quantity.IsInfinite` — "Is Infinite" (button title)
- `dnd35e.UI.EditField` — "Edit {field}" (format string for RichText aria-label)
- `dnd35e.UI.Content` — "content" (fallback when no label provided to RichText)

**Raw label props removed (schema auto-derivation):**  
8 components had explicit `label="..."` props with raw English text. Removing them lets `FormGroup.vue` auto-derive the localized label from `schemaField.options.label` (pre-localized via `LOCALIZATION_PREFIXES`):
- `ItemHP.vue` — removed `label="HP"` from `FormGroupSection`, `label="Current"` and `label="Max"` from child `NumberFormGroup`s. `FormGroupSection` now passes the i18n key `'dnd35e.PHYSICAL_ITEM.FIELDS.hp.label'`.
- `ItemIsMelded.vue` — removed `label="Is Melded"`
- `ItemIsWeightlessWhenEquipped.vue` — removed `label="Is Weightless When Equipped"`
- `ItemSlot.vue` (Equippable) — removed `label="Equipped Slots"`
- `ItemSheetIsCarriedCheckbox.vue` — removed `label="Is Carried"`
- `ItemSheetIsMeldedCheckbox.vue` — removed `label="Is Carried"` (was also wrong text)
- `DesignedForSize.vue` — removed non-standard `label="dnd35e.EQUIPPABLE.DesignedForSize"` (now auto-derives from `system.designedForSize`)

**Inline/computed hardcoded strings fixed:**
- `PhysicalItemHeaderStatus.vue` — `"Carried"` inline template text → `game.i18n.localize('dnd35e.PHYSICAL_ITEM.FIELDS.isCarried.label')` (stored in script constant `carriedLabel`)
- `EquippableHeaderStatus.vue` — computed `statusLabel` returning `'Equipped'`/`'Carried'` → both branches call `game.i18n.localize()` with FIELDS keys
- `EquippableItemWeight.vue` — `:title="'Is Weightless When Equipped'"` → script constant `weightlessTitle` via `game.i18n.localize()`
- `ItemQuantity.vue` — `:title="'Is Infinite'"` → script constant `isInfiniteTitle` via `game.i18n.localize()`
- `RichTextEditorFormGroup.vue` — `:aria-label="\`Edit ${label || 'content'}\`"` → computed `editAriaLabel` using `game.i18n.format('dnd35e.UI.EditField', { field: ... })`

---

## Files Changed

### New Files
| File | Purpose |
|------|---------|
| `src/constants/cssClasses.mts` | `VUE_APP_CLASS`, `ITEM_SHEET_CLASS`, `SETTINGS_CONFIG_CLASS` constants |

### Modified — Constants & Registration
| File | Change |
|------|--------|
| `src/constants/index.mts` | Export cssClasses constants |
| `src/entities/items/registration.mts` | `'dnd35e'` → `SYSTEM_ID` |
| `src/entities/activeEffects/registration.mts` | `'dnd35e'` → `SYSTEM_ID` |
| `src/vue/apps/VueItemSheet.mts` | CSS classes → constants |
| `src/vue/apps/VueActiveEffectConfig.mts` | CSS classes → constants |
| `src/entities/items/baseItem/sheet/BaseItemSheet.mts` | CSS classes → constants |
| `src/settings/*/sheet/*SettingsConfig.mts` (×7) | CSS classes → constants |
| `src/entities/components/CoreMixin/sheet/DocumentSheetStore.mts` | `getFlag`/`setFlag` `'dnd35e'` → `SYSTEM_ID` |
| `src/entities/components/CoreMixin/sheet/stores/FieldOverridesStore.mts` | `getFlag` `'dnd35e'` → `SYSTEM_ID` |
| `src/entities/components/Identifiable/IdentifiableItem.mts` | `'secret'` → `secretEffectType` |
| `src/vue/components/Fields/FormGroups/ColorFormGroup.vue` | Extract `DEFAULT_COLOR` constant |

### Modified — Lang Files
| File | Change |
|------|--------|
| `src/lang/en/items.json` | Add `equippedSlotIds` FIELDS entry; add `quantity.IsInfinite` key |
| `src/lang/en/common.json` | Add `dnd35e.UI.EditField` and `dnd35e.UI.Content` |

### Modified — Vue Components (localization)
| File | Change |
|------|--------|
| `src/entities/items/components/Physical/sheet/components/ItemHP.vue` | Remove 3 raw label props; pass i18n key to FormGroupSection |
| `src/entities/items/components/Equippable/sheet/components/ItemIsMelded.vue` | Remove raw label prop |
| `src/entities/items/components/Equippable/sheet/components/ItemIsWeightlessWhenEquipped.vue` | Remove raw label prop |
| `src/entities/items/components/Equippable/sheet/components/ItemSlot.vue` | Remove raw label prop |
| `src/entities/items/components/Physical/sheet/components/ItemSheetIsCarriedCheckbox.vue` | Remove raw label prop |
| `src/entities/items/components/Physical/sheet/components/ItemSheetIsMeldedCheckbox.vue` | Remove raw label prop |
| `src/entities/items/components/Equippable/sheet/components/DesignedForSize.vue` | Remove non-standard label prop |
| `src/entities/items/components/Physical/sheet/components/PhysicalItemHeaderStatus.vue` | Inline `"Carried"` → `game.i18n.localize()` |
| `src/entities/items/components/Equippable/sheet/components/EquippableHeaderStatus.vue` | Computed `'Equipped'`/`'Carried'` → localized |
| `src/entities/items/components/Equippable/sheet/components/EquippableItemWeight.vue` | Button title → `game.i18n.localize()` |
| `src/entities/items/components/Physical/sheet/components/ItemQuantity.vue` | Button title → `game.i18n.localize()` |
| `src/vue/components/Fields/FormGroups/RichTextEditorFormGroup.vue` | aria-label → `game.i18n.format()` computed |

---

## Technical Decisions

### 1. `game.i18n` Called in `<script setup>`, Not in Template
**Decision**: All `game.i18n.localize()` / `game.i18n.format()` calls are made in `<script setup>` and stored as constants or `computed()` refs. Templates reference the variable, never call `game.i18n` directly.

**Rationale**: Vue's template compiler type-checks against the component's exposed bindings. `game` is a Foundry global — not in the component's reactive scope — so direct template calls cause TypeScript errors (`Property 'game' does not exist on type ...`). Script-level calls are fine because TypeScript's global augmentation (`global.mts`) makes `game` available at module scope.

**Impact**: All future components must follow this pattern. For static strings, use `const label = game.i18n.localize(key)` in setup. For strings that depend on reactive props, use `computed(() => game.i18n.localize(...))`.

### 2. `FormGroupSection` Requires `label` Prop — Pass i18n Key
**Decision**: `FormGroupSection` has `label: string` as a required prop. It internally calls `localize(props.label)`, so passing an i18n key (e.g. `'dnd35e.PHYSICAL_ITEM.FIELDS.hp.label'`) works correctly. `ItemHP.vue`'s `FormGroupSection` now uses the FIELDS key directly.

**Rationale**: Making `label` optional on `FormGroupSection` would require schema auto-derivation at the section level, which is more complex (sections don't always correspond to a single schema field). Passing the key is the correct pattern for compound-field sections and keeps the component API explicit.

### 3. Deferred: `LandingPad.vue` and `MaterialsLandingPad.vue`
Both components have hardcoded English strings (`"Drop materials here"`, button text). Both are marked `@deprecated` and unused in the active UI. These are intentionally skipped to avoid churn on dead code.
