### PR TITLE
Add bonus language feat to formula familiar

### DIFF
--- a/.github/agents/planning.agent.md
+++ b/.github/agents/planning.agent.md
@@ -451,3 +451,17 @@ When planning a feature or phase, answer:
 @planning Plan [feature/phase]
 → Produces task breakdown, dependency map, parallelization analysis, skill routing
 ```
+
+## Phase Status Transitions
+
+When a phase changes status, **both** of these locations must be updated:
+
+1. **Phase doc header** (`docs/migration-plan/phase-NN-*.md`): `**Status**: 🔶 In Progress`
+2. **Roadmap table** (`docs/migration-plan/README.md`): matching row in the phase table
+
+Status progression (from the README legend):
+```
+📄 Stub → 📖 Rough Sketch → 📋 Outlined → 📝 Planned → ✅ Approved → 🔶 In Progress → ✅ Complete → 🔒 Hardened
+```
+
+The planning agent does not implement, but when producing a plan that moves a phase from `✅ Approved` → `🔶 In Progress`, note this in your output and remind the user to update both locations (or do it directly if asked).

--- a/.github/agents/silversmith.agent.md
+++ b/.github/agents/silversmith.agent.md
@@ -109,14 +109,21 @@ Each checklist item from the phase spec is one execution cycle:
 
 **Critical rule**: After approval, ALWAYS update the phase doc checklist (`docs/migration-plan/phase-NN-*.md`) by changing `[ ]` to `[x]` on completed items BEFORE moving to the next section. The checklist is the single source of truth — if it's not checked off, it didn't happen. This includes sub-items. When multiple items were completed in a single cycle, check them ALL off.
 
+**Critical rule**: When a phase transitions to a new status (e.g., first item begins → `🔶 In Progress`; all items complete → `✅ Complete`), update the status in **both**:
+1. The phase doc header: `**Status**: 🔶 In Progress` (or the new status)
+2. The roadmap table: `docs/migration-plan/README.md` — the matching row in the phase table
+
+Use the Status Legend in `README.md` (Stub → Rough Sketch → Outlined → Planned → Approved → In Progress → Complete → Hardened) to pick the correct symbol.
+
 ### Phase 2: Section Completion (when user says "complete")
 
 When the user confirms a section is complete:
 
-1. **Update the phase doc** — check off the completed item
-2. **Update session memory** — record what was completed and any decisions made
-3. **Identify knowledge worth caching** — if Foundry API patterns, D35E migration patterns, or architectural decisions were discovered during this section, delegate to `@kb-curator` to capture them in compressed-for-AI format in the appropriate KB files
-4. **Present the next checklist item** — brief description of what's coming next, ask if ready to proceed
+1. **Update the phase doc** — check off the completed item, make any notes about changes to the phase or implementation, ensure phase doc is accurate to implmentation so far
+2. **Update phase status if changed** — if the phase status has changed (first item started → `🔶 In Progress`; all items complete → `✅ Complete`), update `**Status**:` in the phase doc header AND the matching row in `docs/migration-plan/README.md`
+3. **Update session memory** — record what was completed and any decisions made
+4. **Identify knowledge worth caching** — if Foundry API patterns, D35E migration patterns, or architectural decisions were discovered during this section, delegate to `@kb-curator` to capture them in compressed-for-AI format in the appropriate KB files
+5. **Present the next checklist item** —review where we are in the plan and present a brief description of what's coming next, ask if ready to proceed
 
 ## Reference Material Access
 

--- a/docs/migration-plan/README.md
+++ b/docs/migration-plan/README.md
@@ -167,9 +167,9 @@ The plan is organized into **layers**. Each layer builds on the one before it. W
 
 | # | Phase | Status | Dependencies | Notes |
 |---|-------|--------|--------------|-------|
-| 1 | [Item Foundation (Weapon PoC)](phase-01-item-foundation.md) | ✅ Approved | — | Weapon DataModel, mixin chain, Vue sheet, Identifiable |
-| 2 | [Active Effect on Item (Material)](phase-02-active-effect-on-item.md) | ✅ Approved | Phase 1 | Material AE, phase system, stacking engine, proxy dispatcher, GeneralSystemModel |
-| 3 | [Localization](phase-03-localization.md) | ✅ Approved | — | LOCALIZATION_PREFIXES, lang files, FormGroup auto-labels |
+| 1 | [Item Foundation (Weapon PoC)](phase-01-item-foundation.md) | ✅ Complete | — | Weapon DataModel, mixin chain, Vue sheet, Identifiable |
+| 2 | [Active Effect on Item (Material)](phase-02-active-effect-on-item.md) | 🔶 In Progress | Phase 1 | Material AE, phase system, stacking engine, proxy dispatcher, GeneralSystemModel |
+| 3 | [Localization](phase-03-localization.md) | ✅ Complete | — | LOCALIZATION_PREFIXES, lang files, FormGroup auto-labels |
 
 **What Layer 1 proves**: Items exist with schemas. AEs modify items. Stacking works. i18n works.
 

--- a/docs/migration-plan/phase-02-active-effect-on-item.md
+++ b/docs/migration-plan/phase-02-active-effect-on-item.md
@@ -1,6 +1,6 @@
 # Phase 2: Active Effect on Item (Material)
 
-**Status**: ✅ Approved
+**Status**: 🔶 In Progress
 
 > **Milestone**: POC  
 > **Dependencies**: Phase 1  

--- a/docs/migration-plan/phase-03-localization.md
+++ b/docs/migration-plan/phase-03-localization.md
@@ -1,6 +1,6 @@
 # Phase 3: Localization Pattern
 
-**Status**: ✅ Approved
+**Status**: ✅ Complete
 
 > **Milestone**: POC  
 > **Dependencies**: None  
@@ -145,9 +145,9 @@ Phase 3 Completion decomposed into three parallel tracks:
 
 | Task | Routing | Blocking | Details |
 |------|---------|----------|---------|
-| **1.1: Create pre-localization utility** | Lead dev | 1.2 | Create `src/helpers/localization/preLocalizeConfig.mts` following dnd5e pattern. Recursively pre-localizes nested CONFIG objects, handles arrays, sets `.label` property on enum entries. Success: Function exists with JSDoc, handles nested structures. |
-| **1.2: Register i18nInit hook + add CONFIG keys to lang files** | Lead dev | 1.3 | Add `Hooks.once('i18nInit', () => preLocalizeConfig(CONFIG.DND35E))` to `main.mts`. Add localization keys to `src/lang/en/common.json` for: `dnd35e.CONFIG.Abilities.*`, `dnd35e.CONFIG.Skills.*`, `dnd35e.CONFIG.Sizes.*`, `dnd35e.CONFIG.DamageTypes.*`, `dnd35e.CONFIG.WeaponTypes.*`, `dnd35e.CONFIG.ArmorTypes.*`, `dnd35e.CONFIG.MaterialTypes.*`, `dnd35e.CONFIG.DamageReductionTypes.*`. Success: Hook registered, keys added, build succeeds. |
-| **1.3: Verify pre-localization at runtime** | Lead dev | None | Test in dev mode that CONFIG.DND35E enums have `.label` properties after i18nInit. Can log `CONFIG.DND35E.abilities.str.label` and see localized text. Success: Pre-localized values visible and correct. |
+| **1.1: Create pre-localization utility** | Lead dev | 1.2 | ✅ Complete. `src/helpers/localization/preLocalizeConfig.mts` created with `registerConfigPreLocalization()` and `preLocalizeConfig()`. |
+| **1.2: Register i18nInit hook + add CONFIG keys to lang files** | Lead dev | 1.3 | ✅ Complete. `Hooks.once('i18nInit', ...)` in `main.mts`; `SIZES_CONFIG`, `WEAPON_TYPES_CONFIG`, `DAMAGE_REDUCTION_TYPES_CONFIG` added to CONFIG; lang keys added to `attacks.json`. |
+| **1.3: Verify pre-localization at runtime** | Lead dev | None | ✅ Complete. Live-merge pattern verified in MaterialStore, PhysicalItemStore, DamageReductionTable. |
 
 ---
 
@@ -175,7 +175,7 @@ Phase 3 Completion decomposed into three parallel tracks:
 
 | Task | Routing | Blocking | Details |
 |------|---------|----------|---------|
-| **3.1: Formula Familiar dropdown — prop names → localized labels** | Lead dev | 3.4 | Locate formula familiar dropdown component displaying property names. Add mapping from prop names to localization keys. Update lang files with `dnd35e.FORMULA_FAMILIAR.PROPERTIES.*` entries. Update component to use `game.i18n.localize(key)` for display. Success: Dropdown shows human-readable localized labels, not raw prop names. |
+| **3.1: Formula Familiar dropdown — prop names → localized labels** | Lead dev | 3.4 | ✅ Complete. Full locale-transparent formula system implemented: (1) `gatherAspectsFromSchema` uses `ModelClass.schema.fields` (cached, localized via `LOCALIZATION_PREFIXES`) — `field.label` carries pre-localized text. `AspectGroup` keys remain canonical schema field names; `FieldAspect.display` carries the localized label. (2) `normalizeLabel()` converts display labels to PascalCase identifiers for use in `localizeFormula`/`canonicalizeFormula` — never used for tree keys. (3) `VARIABLE_REGEX` updated to `[\p{L}\p{N}_]+` (Unicode-aware) so Polish/Czech/etc names are recognized in stored formulas. (4) `localizeFormula(stored, schema)` translates `#self.hardness` → `#Self.Hardness` (en) / `#Siebie.Twardość` (pl) for display. (5) `canonicalizeFormula(display, schema)` reverses this: `#Siebie.Twardość` → `#self.hardness` for storage. (6) `FormulaFormGroup` and `AspectPicker` wired: display uses `localizeFormula`, save uses `canonicalizeFormula`. Autocomplete matches and inserts localized names; `fullPath` is the localized insertion text. (7) `buildDocumentFamiliar` derives localized context display names (`dnd35e.Formula.Context.Self`) and stores them in `FamiliarContext.display`. Result: stored formula is always canonical (`#self.hardness`); user sees and types localized form (`#Self.Hardness` / `#Siebie.Twardość`). |
 | **3.2: Sheet UI text audit — section headers, tabs, group labels** | Jr dev (lead review) | 3.4 | ✅ Complete. 8 raw label props + 3 inline strings identified and documented. |
 | **3.3: Button labels & action messages audit** | Jr dev | 3.4 | ✅ Complete. 2 raw button/aria strings found; deprecated LandingPad deferred. |
 | **3.4: Add localization keys to lang files** | Jr dev or flexible | 3.5 | ✅ Complete. Added `equippedSlotIds` to EQUIPPABLE.FIELDS, `IsInfinite` to quantity, `dnd35e.UI.EditField` and `dnd35e.UI.Content` to common.json. |

--- a/docs/migration-plan/phase-31-community-hardening.md
+++ b/docs/migration-plan/phase-31-community-hardening.md
@@ -207,6 +207,13 @@ Example:
 - [ ] Create `docs/LOCALIZATION_ITEM_CONTENT_WORKFLOW.md` that defines how localization contributors localize item content post-release (inputs, file locations, review/merge handoff).
 - [ ] Keep this as a Phase 31 documentation workflow; no Phase 3 implementation changes.
 
+**Formula Familiar — Locale-Aware Identifier Normalization (Deferred from Phase 3):**
+- [ ] Implement `CONFIG.dnd35e.localization[locale].normalizeIdentifier(label: string): string` hook.
+  - System ships with a default EN implementation: strips spaces, PascalCases each word segment (current `normalizeLabel()` behavior).
+  - Mods or locale packs can override per locale — e.g. Japanese is a straight passthrough (no spaces, no casing concept); German may want to preserve noun capitalization rather than forcing all-caps word starts.
+  - `normalizeLabel()` in `schemaWalker.mts` and `utils.mts` delegates to this hook when available, falling back to the built-in EN logic.
+  - Must not break stored formulas — any change to identifier generation requires a storage migration for affected locales.
+
 **Feedback Collection Infrastructure:**
 - [ ] Create `docs/COMMUNITY_FEEDBACK_SURVEY.md`:
   - Section 1: Demographic data (campaign type, player count, campaign length)

--- a/src/helpers/formulae/FormulaFormGroup.vue
+++ b/src/helpers/formulae/FormulaFormGroup.vue
@@ -56,7 +56,9 @@
   import type { AutocompleteOption, FamiliarSchema, ValidationError } from './types.mts';
   import { useFamiliarOverlayInput } from './useFamiliarOverlayInput.mjs';
   import {
+    canonicalizeFormula,
     filterExcludedFields,
+    localizeFormula,
     parseFormula,
     renderFormulaDisplayHTML,
     renderFormulaHTML,
@@ -137,8 +139,9 @@
     updateAutocomplete,
   } = useFamiliarOverlayInput();
 
-  // Local state
-  const localValue = ref(effectiveFormula.value || '');
+  // Local state — stored as localized display form (e.g. #Self.Hardness)
+  // canonicalizeFormula is applied on commit; localizeFormula on every sync from external
+  const localValue = ref('');
   const formulaErrors = ref<ValidationError[]>([]);
 
   // Track whether the user is actively editing to avoid feedback loops
@@ -156,8 +159,8 @@
     if (props.hint) return props.hint;
     const keys = Object.keys(contexts.value);
     if (keys.length === 0) return '';
-    const capitalized = keys.map(k => k.charAt(0).toUpperCase() + k.slice(1));
-    return `Available Contexts: [${capitalized.join(', ')}]`;
+    const names = Object.entries(contexts.value).map(([k, ctx]) => ctx.display ?? (k.charAt(0).toUpperCase() + k.slice(1)));
+    return `Available Contexts: [${names.join(', ')}]`;
   });
 
   const displayHint = computed(() => isEditMode.value ? dynamicHint.value : (props.hint ?? ''));
@@ -219,7 +222,15 @@
   // Sync external value changes into local state (but not during active editing)
   watch(effectiveFormula, (newValue) => {
     if (!isUserEditing) {
-      localValue.value = newValue || '';
+      localValue.value = localizeFormula(newValue || '', contexts.value);
+      updateValidation();
+    }
+  });
+
+  // Re-localize when the schema loads or locale changes (e.g. initial load, context switch)
+  watch(contexts, () => {
+    if (!isUserEditing) {
+      localValue.value = localizeFormula(effectiveFormula.value || '', contexts.value);
       updateValidation();
     }
   });
@@ -268,10 +279,11 @@
 
   function commitValue() {
     if (typeof props.onUpdate === 'function') {
-      // Only persist if the value actually changed from the source
+      // Canonicalize before saving (e.g. #Self.Hardness → #self.hardness)
+      const canonical = canonicalizeFormula(localValue.value, contexts.value);
       const current = effectiveFormula.value || '';
-      if (localValue.value !== current) {
-        props.onUpdate(localValue.value);
+      if (canonical !== current) {
+        props.onUpdate(canonical);
       }
     }
   }
@@ -293,8 +305,8 @@
 
     // Escape = cancel editing (Familiar already handled its own Escape above)
     if (event.key === 'Escape') {
-      // Revert to prop value
-      localValue.value = props.value || '';
+      // Revert to localized form of stored value
+      localValue.value = localizeFormula(effectiveFormula.value || '', contexts.value);
       isUserEditing = false;
       getInputElement()?.blur();
       event.preventDefault();
@@ -379,7 +391,7 @@
 
   // Initialize
   onMounted(() => {
-    localValue.value = effectiveFormula.value || '';
+    localValue.value = localizeFormula(effectiveFormula.value || '', contexts.value);
     updateValidation();
     if (isEditable.value && getInputElement()) {
       nextTick(() => getInputElement()?.focus());

--- a/src/helpers/formulae/index.mts
+++ b/src/helpers/formulae/index.mts
@@ -33,7 +33,7 @@ import {
   getFamiliarBuilder,
   registerFamiliarSchema,
 } from './registry.mjs';
-import { DOCUMENT_LEVEL_ASPECTS, gatherAspectsFromSchema } from './schemaWalker.mjs';
+import { DOCUMENT_LEVEL_ASPECTS, gatherAspectsFromSchema, normalizeLabel } from './schemaWalker.mjs';
 import type {
   AspectGroup,
   AutocompleteOption,
@@ -59,6 +59,7 @@ import { useFamiliarOverlayInput } from './useFamiliarOverlayInput.mjs';
 import type { AspectLookupResult, GetAutocompleteOptionsConfig } from './utils.mjs';
 import {
   buildDocumentDataMap,
+  canonicalizeFormula,
   ensureNameFormula,
   extractVariableAtPosition,
   extractVariables,
@@ -73,6 +74,7 @@ import {
   getVariableTokenIndex,
   getVariableTokens,
   insertAtCursor,
+  localizeFormula,
   mergeAspectGroups,
   nameToFormulaData,
   parseFormula,
@@ -88,6 +90,7 @@ export {
   buildDocumentDataMap,
   buildDocumentFamiliar,
   buildMergedFamiliarContext,
+  canonicalizeFormula,
   DOCUMENT_LEVEL_ASPECTS,
   EDIT,
   ensureNameFormula,
@@ -112,9 +115,11 @@ export {
   getVariableTokens,
   insertAtCursor,
   isFieldAspect,
+  localizeFormula,
   measureTextOffset,
   mergeAspectGroups,
   nameToFormulaData,
+  normalizeLabel,
   parseFormula,
   PLAY,
   registerFamiliarSchema,

--- a/src/helpers/formulae/registry.mts
+++ b/src/helpers/formulae/registry.mts
@@ -15,6 +15,7 @@ import type { EffectType } from '@effects/effectTypes.mjs';
 import type { ItemDnd35e } from '@items/baseItem/ItemDnd35e.mjs';
 import type { ItemType } from '@items/itemTypes.mjs';
 
+import { normalizeLabel } from './schemaWalker.mjs';
 import type { AspectGroup, FamiliarContext, FamiliarSchema, FormulaFieldData } from './types.mjs';
 import { mergeAspectGroups } from './utils.mjs';
 
@@ -116,6 +117,27 @@ function buildContextFromFormula(
 }
 
 /**
+ * Generate localized aliases for a context by looking up the Foundry document-type
+ * translation (`TYPES.{docType}.{subtype}`).  Adds the normalized translation to the
+ * existing alias list when it differs from all current entries (case-insensitive).
+ *
+ * Called lazily at render time so `game.i18n` is always available.
+ */
+function buildContextAliases(
+  docType: string,
+  subtype: string,
+  existingAliases?: string[]
+): string[] | undefined {
+  const raw = (game as unknown as { i18n?: { localize?(k: string): string } }).i18n?.localize?.(`TYPES.${docType}.${subtype}`);
+  const localized = raw ? normalizeLabel(raw) : undefined;
+  const all = [...(existingAliases ?? [])];
+  if (localized && !all.some(a => a.toLowerCase() === localized.toLowerCase())) {
+    all.push(localized);
+  }
+  return all.length ? all : undefined;
+}
+
+/**
  * Recursively gather FormulaContextDeclarations from all FormulaField instances
  * in a schema's field tree.
  */
@@ -157,8 +179,17 @@ function buildDocumentFamiliar(document: DocumentContext): FamiliarSchema {
   const docType = document.documentName;
   const subtype = document.type as ContextDocumentType;
   if (hasFamiliarSchema(docType, subtype)) {
+    // Derive localized display label for the "Self" context from the i18n system.
+    // Lazy call — always runs after i18nInit since builders are lazy.
+    const selfLabel = (game as unknown as { i18n?: { localize?(k: string): string } }).i18n?.localize?.('dnd35e.Formula.Context.Self') ?? 'Self';
+    const normalizedSelf = normalizeLabel(selfLabel) ?? 'Self';
+    const selfTypeAliases = buildContextAliases(docType, subtype) ?? [];
+    // Collect all user-typeable aliases: localized Self + type-based aliases
+    const selfAliases = [normalizedSelf, ...selfTypeAliases.filter(a => a !== normalizedSelf)];
     schema.self = {
       properties: getFamiliarBuilder(docType, subtype)!(document),
+      display: selfLabel,
+      aliases: selfAliases,
     };
   }
 
@@ -192,7 +223,7 @@ function buildDocumentFamiliar(document: DocumentContext): FamiliarSchema {
         if (hasFamiliarSchema(ctxDocType, ctxSubtype)) {
           schema[decl.contextName] = {
             properties: getFamiliarBuilder(ctxDocType, ctxSubtype)!(contextDoc),
-            aliases: decl.aliases,
+            aliases: buildContextAliases(ctxDocType, ctxSubtype, decl.aliases),
           };
         }
       } else if (decl.fallbackSubtypes?.length) {
@@ -202,7 +233,7 @@ function buildDocumentFamiliar(document: DocumentContext): FamiliarSchema {
           if (hasFamiliarSchema(fallbackDocType, fallbackSubtype as ContextDocumentType)) {
             schema[decl.contextName] = {
               properties: getFamiliarBuilder(fallbackDocType, fallbackSubtype as ContextDocumentType)!(),
-              aliases: decl.aliases,
+              aliases: buildContextAliases(fallbackDocType, fallbackSubtype, decl.aliases),
             };
             break;
           }

--- a/src/helpers/formulae/schemaWalker.mts
+++ b/src/helpers/formulae/schemaWalker.mts
@@ -232,17 +232,19 @@ function gatherAspectsFromSchema(
   // Walk system-level fields (all schema fields live under document.system)
   walkFields(fields, context, 'system', result);
 
-  // Merge document-level fields (name, img, etc.) with localized keys
-  // Use game.i18n for the label so it works in all locales (lazy call — always after i18nInit)
+  // Merge document-level fields (name, img, etc.) with localized display labels.
+  // The tree key is ALWAYS the canonical 'name' — storage must be locale-independent.
+  // The localized PascalCase label (e.g. 'Name' in EN, 'Naam' in NL) is added as an alias
+  // so users can type either form; localizeFormula() will render the display form on output.
   const nameLabel = (game as { i18n?: { localize?(k: string): string } }).i18n?.localize?.('Name') ?? 'Name';
-  const nameKey = normalizeLabel(nameLabel) ?? 'name';
   const nameProp: FieldAspect = { display: nameLabel, type: 'string', accessPath: 'name' };
-  if (nameKey !== 'name') nameProp.aliases = ['name'];
+  const localizedNameKey = normalizeLabel(nameLabel);
+  if (localizedNameKey && localizedNameKey !== 'name') nameProp.aliases = [localizedNameKey];
   if (context) {
     const resolved = resolveValue(context, 'name', 'string');
     if (resolved !== undefined) nameProp.value = resolved;
   }
-  result[nameKey] = nameProp;
+  result['name'] = nameProp;
 
   return result;
 }

--- a/src/helpers/formulae/schemaWalker.mts
+++ b/src/helpers/formulae/schemaWalker.mts
@@ -15,7 +15,7 @@
  */
 
 import type { DocumentContext } from './registry.mjs';
-import type { AspectGroup, FieldAspect,FormulaFieldMeta } from './types.mjs';
+import type { AspectGroup, FieldAspect, FormulaFieldMeta } from './types.mjs';
 
 const {
   NumberField,
@@ -23,8 +23,41 @@ const {
 } = foundry.data.fields;
 
 /**
+ * Convert a display label into a valid formula-variable identifier segment.
+ * Strips non-letter/non-digit characters (Unicode-aware) and PascalCases the result.
+ * Used by `localizeFormula` / `canonicalizeFormula` to map between typed variable
+ * names and localized display labels — NOT used for AspectGroup keys (those are
+ * always the canonical schema field name).
+ *
+ * Examples (English): "Hit Points" → "HitPoints", "Hardness" → "Hardness"
+ * Examples (Polish):   "Twardość"  → "Twardość", "Punkty Wytrzymałości" → "PunktyWytrzymałości"
+ *
+ * Returns `undefined` when the label is empty or produces no word segments.
+ *
+ * @todo Community hardening: PascalCasing is inappropriate for some languages.
+ *   Japanese has no concept of letter casing (passthrough — no spaces to strip either).
+ *   German capitalizes only nouns. Arabic, Hebrew, Thai, and CJK scripts have no uppercase.
+ *   Planned fix: `CONFIG.dnd35e.localization[locale].normalizeIdentifier(label)` hook.
+ *   System ships with the EN implementation (current behavior). Mods / locale packs
+ *   can override per locale. Changing the function for a locale is a storage-breaking
+ *   migration for any formula that used localized identifiers in that locale.
+ *   Tracked: docs/migration-plan/phase-31-community-hardening.md
+ */
+export function normalizeLabel(label: string | undefined): string | undefined {
+  if (!label) return undefined;
+  // \p{L} = any Unicode letter, \p{N} = any Unicode digit
+  const words = label.split(/[^\p{L}\p{N}]+/u).filter(Boolean);
+  if (!words.length) return undefined;
+  // PascalCase: capitalize first letter of every word, preserve the rest
+  return words
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join('');
+}
+
+/**
  * Document-level fields that live outside `system` but should appear in familiar.
  * These are merged into the top level of every AspectGroup.
+ * The `display` is intentionally a plain key — localized at call time in gatherAspectsFromSchema.
  */
 const DOCUMENT_LEVEL_ASPECTS: Record<string, Omit<FieldAspect, 'value'>> = {
   name: { display: 'Name', type: 'string', accessPath: 'name' },
@@ -70,6 +103,13 @@ function resolveValue(
 
 /**
  * Add a leaf entry to an AspectGroup.
+ *
+ * Key: always the canonical schema field name (`key`), or `meta.aspectKey` when
+ * explicitly overridden. Localized display labels live in `FieldAspect.display`;
+ * they are never used as tree keys.
+ *
+ * `accessPath` is always the raw Foundry document path used internally at
+ * resolution time — users never see it.
  */
 function addLeafToGroup(
   field: foundry.data.fields.DataField,
@@ -80,16 +120,21 @@ function addLeafToGroup(
   output: AspectGroup
 ): void {
   const type = meta?.aspectType ?? inferFieldType(field);
+  // field.label is set by Foundry's localizeDataModel (via LOCALIZATION_PREFIXES) after i18nInit.
+  // field.options.label is only set when explicitly passed in the constructor.
+  const label = (field as unknown as { label?: string }).label
+    ?? (field.options as Record<string, unknown>).label as string | undefined;
   const aspectKey = meta?.aspectKey ?? key;
 
   const prop: FieldAspect = {
-    display: (field.options as Record<string, unknown>).label as string ?? key,
+    display: label ?? key,
     type,
     accessPath,
   };
 
-  if (meta?.aliases?.length) {
-    prop.aliases = meta.aliases;
+  const aliases: string[] = [...(meta?.aliases ?? [])];
+  if (aliases.length) {
+    prop.aliases = aliases;
   }
 
   if (context) {
@@ -137,8 +182,11 @@ function walkFields(
         Record<string, foundry.data.fields.DataField> | undefined;
       if (childFields) {
         const branch: AspectGroup = {};
+        const branchLabel = (field as unknown as { label?: string }).label
+          ?? (field.options as Record<string, unknown>).label as string | undefined;
+        if (branchLabel) branch._display = branchLabel;
         walkFields(childFields, context, currentPath, branch);
-        if (Object.keys(branch).length > 0) {
+        if (Object.keys(branch).filter(k => !k.startsWith('_')).length > 0) {
           output[key] = branch;
         }
       }
@@ -152,12 +200,13 @@ function walkFields(
 /**
  * Build an AspectGroup from a DataModel class's schema.
  *
- * Walks `ModelClass.defineSchema()` and collects all fields by default.
+ * Uses `ModelClass.schema.fields` (the cached, LOCALIZATION_PREFIXES-mutated schema)
+ * rather than `ModelClass.defineSchema()` (which creates fresh unlabeled instances).
  * Fields opt out with `familiar: { formulaVisible: false }`. Opaque leaves
  * (PriceField, FormulaField, `isFamiliarLeaf`) are recognized by a static
  * marker on their constructors.
  *
- * @param ModelClass  A DataModel class (or any object with a static `defineSchema()`)
+ * @param ModelClass  A TypeDataModel class whose `schema.fields` holds localized field metadata
  * @param context     Optional live Foundry document – when provided, property values are resolved inline
  * @returns           An AspectGroup ready for use in FormulaFormGroup
  *
@@ -171,24 +220,29 @@ function walkFields(
  * ```
  */
 function gatherAspectsFromSchema(
-  ModelClass: { defineSchema(): Record<string, foundry.data.fields.DataField> },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ModelClass: { schema?: { fields: Record<string, any> }; defineSchema(): Record<string, foundry.data.fields.DataField> },
   context?: DocumentContext
 ): AspectGroup {
-  const schema = ModelClass.defineSchema();
+  // Prefer the cached schema (fields have localized labels from LOCALIZATION_PREFIXES).
+  // Fall back to defineSchema() only if schema is not yet available (e.g. unit tests).
+  const fields = (ModelClass.schema?.fields) ?? ModelClass.defineSchema();
   const result: AspectGroup = {};
 
   // Walk system-level fields (all schema fields live under document.system)
-  walkFields(schema, context, 'system', result);
+  walkFields(fields, context, 'system', result);
 
-  // Merge document-level fields (name, img, etc.)
-  for (const [key, meta] of Object.entries(DOCUMENT_LEVEL_ASPECTS)) {
-    const prop: FieldAspect = { ...meta };
-    if (context) {
-      const resolved = resolveValue(context, meta.accessPath, meta.type);
-      if (resolved !== undefined) prop.value = resolved;
-    }
-    result[key] = prop;
+  // Merge document-level fields (name, img, etc.) with localized keys
+  // Use game.i18n for the label so it works in all locales (lazy call — always after i18nInit)
+  const nameLabel = (game as { i18n?: { localize?(k: string): string } }).i18n?.localize?.('Name') ?? 'Name';
+  const nameKey = normalizeLabel(nameLabel) ?? 'name';
+  const nameProp: FieldAspect = { display: nameLabel, type: 'string', accessPath: 'name' };
+  if (nameKey !== 'name') nameProp.aliases = ['name'];
+  if (context) {
+    const resolved = resolveValue(context, 'name', 'string');
+    if (resolved !== undefined) nameProp.value = resolved;
   }
+  result[nameKey] = nameProp;
 
   return result;
 }

--- a/src/helpers/formulae/types.mts
+++ b/src/helpers/formulae/types.mts
@@ -120,10 +120,24 @@ export function isFieldAspect(value: unknown): value is FieldAspect {
 }
 
 /**
- * Represents a nested structure of properties (can be leaf or branch)
+ * Represents a nested structure of properties (can be leaf or branch).
+ *
+ * Branch nodes (SchemaField groups) may carry metadata properties prefixed
+ * with `_` (skipped during autocomplete traversal):
+ *   - `_display`: pre-localized label for the group (e.g. "Hit Points")
+ *   - `_aliases`: schema key(s) that also resolve to this branch
+ *     (e.g. `['hp']` when the branch's primary key is the localized form)
  */
 export interface AspectGroup {
-  [propertyPath: string]: FieldAspect | AspectGroup;
+  /** Pre-localized display label for this group node. Set by the schema walker. */
+  _display?: string;
+  /**
+   * Alternative keys that resolve to this branch node.
+   * Populated when the primary key is a localized label and the schema field
+   * name differs (e.g. primary key `hitPoints`, alias `hp`).
+   */
+  _aliases?: string[];
+  [propertyPath: string]: FieldAspect | AspectGroup | string[] | string | undefined;
 }
 
 /**
@@ -133,6 +147,11 @@ export interface AspectGroup {
 export interface FamiliarContext {
   properties: AspectGroup;
   aliases?: string[];  // e.g., ["item", "weapon"] — alternative names that also resolve to this context
+  /**
+   * Localized display label shown in the autocomplete dropdown instead of the raw key.
+   * e.g. key='self', display='Self' (or 'Siebie' in Polish).
+   */
+  display?: string;
 }
 
 /**

--- a/src/helpers/formulae/utils.mts
+++ b/src/helpers/formulae/utils.mts
@@ -6,6 +6,7 @@ import type { FormulaDataSource } from './FormulaData.mjs';
 import { FormulaData } from './FormulaData.mjs';
 import type { DocumentContext } from './registry.mjs';
 import { buildContextFromFormula } from './registry.mjs';
+import { normalizeLabel } from './schemaWalker.mjs';
 import type {
   AspectGroup,
   AutocompleteOption,
@@ -41,6 +42,9 @@ export function filterExcludedFields(
     const props = { ...ctx.properties };
     for (const key of excludedFields) {
       delete props[key];
+      // Also delete the PascalCase-normalized form in case keys have been localized
+      const normalized = normalizeLabel(key);
+      if (normalized && normalized !== key) delete props[normalized];
     }
     filtered[ctxName] = { ...ctx, properties: props };
   }
@@ -58,7 +62,8 @@ export function filterExcludedFields(
  *
  * Uses a negative lookbehind so `\#` is treated as a literal `#`, not a variable.
  */
-const VARIABLE_REGEX = /(?<!\\)#\w+(?:\.(?:'[^']*'|'[^ ']*|\w+))*/g;
+// Unicode-aware: \p{L} = any letter, \p{N} = any digit — allows Polish/Czech/etc variable names
+const VARIABLE_REGEX = /(?<!\\)#[\p{L}\p{N}_]+(?:\.(?:'[^']*'|'[^ ']*|[\p{L}\p{N}_]+))*/gu;
 
 /**
  * Parse a formula into tokens (text and variables)
@@ -66,7 +71,7 @@ const VARIABLE_REGEX = /(?<!\\)#\w+(?:\.(?:'[^']*'|'[^ ']*|\w+))*/g;
  */
 export function parseFormula(formula: string): FormulaToken[] {
   const tokens: FormulaToken[] = [];
-  const regex = new RegExp(VARIABLE_REGEX.source, 'g');
+  const regex = new RegExp(VARIABLE_REGEX.source, 'gu');
   let lastIndex = 0;
   let match;
 
@@ -159,7 +164,7 @@ function parseVariableSegments(body: string): { context: string; path: string[];
  * @returns Array of found variables
  */
 export function extractVariables(formula: string): FormulaVariable[] {
-  const regex = new RegExp(VARIABLE_REGEX.source, 'g');
+  const regex = new RegExp(VARIABLE_REGEX.source, 'gu');
   const variables: FormulaVariable[] = [];
   let match;
 
@@ -204,7 +209,31 @@ export function resolveFormula(
   // Process in reverse order to maintain string indices
   for (let i = variables.length - 1; i >= 0; i--) {
     const variable = variables[i];
-    const docData = documentDataMap[variable.context];
+
+    // Resolve context data: direct lookup first, then via familiarSchema alias
+    let docData = documentDataMap[variable.context];
+    if (!docData) {
+      // variable.context may be a localized alias (e.g. 'Self') while documentDataMap
+      // uses the internal key ('self'). Use the familiarSchema to bridge them.
+      const ctxEntry = familiarSchema[variable.context]
+        ? { key: variable.context, ctx: familiarSchema[variable.context] }
+        : (() => {
+          const found = Object.entries(familiarSchema).find(([, ctx]) =>
+            ctx.aliases?.includes(variable.context)
+          );
+          return found ? { key: found[0], ctx: found[1] } : null;
+        })();
+      if (ctxEntry) {
+        // Try the primary FamiliarSchema key in documentDataMap
+        docData = documentDataMap[ctxEntry.key];
+        if (!docData) {
+          // Try each alias of that context in documentDataMap
+          for (const alias of (ctxEntry.ctx.aliases ?? [])) {
+            if (documentDataMap[alias]) { docData = documentDataMap[alias]; break; }
+          }
+        }
+      }
+    }
     if (!docData) continue;
 
     // Custom quoted path — use the raw path directly as the accessPath
@@ -296,12 +325,33 @@ function getFieldAspect(context: FamiliarSchema, contextName: string, path: stri
     if (key in obj) {
       current = obj[key];
     } else {
-      // Alias fallback
-      const aliasMatch = Object.entries(obj).find(([, v]) =>
+      // Leaf alias fallback (FieldAspect.aliases)
+      const leafAlias = Object.entries(obj).find(([, v]) =>
         isFieldAspect(v) && v.aliases?.includes(key)
       );
-      if (aliasMatch) {
-        current = aliasMatch[1];
+      if (leafAlias) {
+        current = leafAlias[1];
+        continue;
+      }
+      // Branch alias fallback (AspectGroup._aliases)
+      const branchAlias = Object.entries(obj).find(([, v]) =>
+        typeof v === 'object' && v !== null && !isFieldAspect(v)
+        && (v as { _aliases?: string[] })._aliases?.includes(key)
+      );
+      if (branchAlias) {
+        current = branchAlias[1];
+        continue;
+      }
+      // Localized display name fallback
+      const localDisplay = Object.entries(obj).find(([k, v]) => {
+        if (k.startsWith('_')) return false;
+        const localKey = isFieldAspect(v)
+          ? normalizeLabel((v as FieldAspect).display)
+          : normalizeLabel((v as AspectGroup)._display);
+        return localKey === key;
+      });
+      if (localDisplay) {
+        current = localDisplay[1];
       } else {
         return null;
       }
@@ -379,6 +429,125 @@ export function mergeAspectGroups(...groups: AspectGroup[]): AspectGroup {
 }
 
 /**
+ * Translate a formula from canonical storage form to the current locale's display form.
+ *
+ * - `#self.hardness`  →  `#Self.Hardness`   (English)
+ * - `#self.hardness`  →  `#Siebie.Twardość` (Polish)
+ *
+ * Context and property names are normalized with `normalizeLabel` (PascalCase,
+ * spaces removed) so multi-word labels like "Hit Points" become `HitPoints`.
+ * Custom quoted paths (`#self.'raw.path'`) are left unchanged.
+ * Segments that cannot be resolved are left as-is.
+ */
+export function localizeFormula(formula: string, schema: FamiliarSchema): string {
+  const variables = extractVariables(formula);
+  if (!variables.length) return formula;
+
+  let result = formula;
+  // Process in reverse order to preserve string indices
+  for (let i = variables.length - 1; i >= 0; i--) {
+    const v = variables[i];
+    if (v.customAccessPath !== undefined) continue;
+
+    // Find context entry: direct key or alias
+    const ctxEntry = Object.entries(schema).find(([k, ctx]) =>
+      k === v.context || ctx.aliases?.includes(v.context)
+    );
+    if (!ctxEntry) continue;
+    const [, ctx] = ctxEntry;
+    const localCtx = normalizeLabel(ctx.display) ?? v.context;
+
+    // Walk path, translating each canonical key to its localized display name
+    let current: unknown = ctx.properties;
+    const localPath: string[] = [];
+    for (const seg of v.path) {
+      if (typeof current !== 'object' || current === null) { localPath.push(seg); continue; }
+      const obj = current as Record<string, unknown>;
+      const entry = obj[seg];
+      if (entry === undefined) { localPath.push(seg); break; }
+      if (isFieldAspect(entry)) {
+        localPath.push(normalizeLabel(entry.display) ?? seg);
+        current = null;
+      } else {
+        const branch = entry as AspectGroup;
+        localPath.push(normalizeLabel(branch._display) ?? seg);
+        current = branch;
+      }
+    }
+
+    const localized = localPath.length ? `#${localCtx}.${localPath.join('.')}` : `#${localCtx}`;
+    result = result.substring(0, v.startIndex) + localized + result.substring(v.endIndex);
+  }
+  return result;
+}
+
+/**
+ * Translate a formula from localized display form back to canonical storage form.
+ *
+ * - `#Self.Hardness`   →  `#self.hardness`  (English)
+ * - `#Siebie.Twardość` →  `#self.hardness`  (Polish)
+ *
+ * Matches each segment against `normalizeLabel(entry.display)`. Falls through
+ * to the canonical key if no display match is found, so this is safe to call
+ * on formulas that are already canonical.
+ */
+export function canonicalizeFormula(formula: string, schema: FamiliarSchema): string {
+  const variables = extractVariables(formula);
+  if (!variables.length) return formula;
+
+  let result = formula;
+  for (let i = variables.length - 1; i >= 0; i--) {
+    const v = variables[i];
+    if (v.customAccessPath !== undefined) continue;
+
+    // Find canonical context key: direct match, localized display match, or alias
+    const ctxKV = Object.entries(schema).find(([k, ctx]) =>
+      k === v.context
+      || (normalizeLabel(ctx.display) ?? k) === v.context
+      || ctx.aliases?.includes(v.context)
+    );
+    if (!ctxKV) continue;
+    const [canonCtx, ctxSchema] = ctxKV;
+
+    // Walk path, mapping each localized segment back to its canonical key
+    let current: unknown = ctxSchema.properties;
+    const canonPath: string[] = [];
+    for (const seg of v.path) {
+      if (typeof current !== 'object' || current === null) { canonPath.push(seg); break; }
+      const obj = current as Record<string, unknown>;
+
+      // 1. Direct key match (already canonical or same-locale)
+      if (seg in obj) {
+        const entry = obj[seg];
+        canonPath.push(seg);
+        current = isFieldAspect(entry) ? null : (entry as AspectGroup);
+        continue;
+      }
+
+      // 2. Localized display name → canonical key
+      let matched = false;
+      for (const [k, v2] of Object.entries(obj)) {
+        if (k.startsWith('_')) continue;
+        const localKey = isFieldAspect(v2)
+          ? (normalizeLabel((v2 as FieldAspect).display) ?? k)
+          : (normalizeLabel((v2 as AspectGroup)._display) ?? k);
+        if (localKey === seg) {
+          canonPath.push(k);
+          current = isFieldAspect(v2) ? null : (v2 as AspectGroup);
+          matched = true;
+          break;
+        }
+      }
+      if (!matched) { canonPath.push(seg); break; }
+    }
+
+    const canonical = canonPath.length ? `#${canonCtx}.${canonPath.join('.')}` : `#${canonCtx}`;
+    result = result.substring(0, v.startIndex) + canonical + result.substring(v.endIndex);
+  }
+  return result;
+}
+
+/**
  * Validate all variables in a formula
  * @param formula The formula string
  * @param context The familiar context
@@ -422,8 +591,11 @@ function validateVariable(variable: FormulaVariable, context: FamiliarSchema): V
   let contextSchema = context[variable.context];
 
   if (!contextSchema) {
-    // Try to find by alias
-    const foundKey = Object.keys(context).find(k => context[k].aliases?.includes(variable.context));
+    // Try to find by alias or localized display name
+    const foundKey = Object.keys(context).find(k =>
+      context[k].aliases?.includes(variable.context)
+      || (normalizeLabel(context[k].display) ?? '') === variable.context
+    );
     if (foundKey) {
       contextSchema = context[foundKey];
     }
@@ -471,21 +643,41 @@ function validateVariable(variable: FormulaVariable, context: FamiliarSchema): V
     if (key in obj) {
       current = obj[key];
     } else {
-      // Alias fallback — check if any sibling FieldAspect has this as an alias
-      const aliasMatch = Object.entries(obj).find(([, v]) =>
+      // Alias fallback — check leaf aliases then branch _aliases
+      const leafAlias = Object.entries(obj).find(([, v]) =>
         isFieldAspect(v) && v.aliases?.includes(key)
       );
-      if (aliasMatch) {
-        current = aliasMatch[1];
+      if (leafAlias) {
+        current = leafAlias[1];
       } else {
-        return {
-          variable: variable.variable,
-          context: variable.context,
-          path: variable.path,
-          error: `Property '${key}' not found on ${variable.context}${pathTraversed.length > 0 ? '.' + pathTraversed.join('.') : ''}`,
-          severity: 'error',
-          index: variable.startIndex,
-        };
+        const branchAlias = Object.entries(obj).find(([, v]) =>
+          typeof v === 'object' && v !== null && !isFieldAspect(v)
+          && (v as { _aliases?: string[] })._aliases?.includes(key)
+        );
+        if (branchAlias) {
+          current = branchAlias[1];
+        } else {
+          // Localized display name fallback
+          const localDisplay = Object.entries(obj).find(([k, v]) => {
+            if (k.startsWith('_')) return false;
+            const localKey = isFieldAspect(v)
+              ? normalizeLabel((v as FieldAspect).display)
+              : normalizeLabel((v as AspectGroup)._display);
+            return localKey === key;
+          });
+          if (localDisplay) {
+            current = localDisplay[1];
+          } else {
+            return {
+              variable: variable.variable,
+              context: variable.context,
+              path: variable.path,
+              error: `Property '${key}' not found on ${variable.context}${pathTraversed.length > 0 ? '.' + pathTraversed.join('.') : ''}`,
+              severity: 'error',
+              index: variable.startIndex,
+            };
+          }
+        }
       }
     }
     pathTraversed.push(key);
@@ -543,21 +735,27 @@ export function getAutocompleteOptions(
     const seenOptions = new Set<string>();
 
     for (const [name, schema] of Object.entries(context)) {
-      // Check if partial input matches the primary name or any alias
-      const matchesPrimary = !contextName || name.toLowerCase().startsWith(contextName.toLowerCase());
+      // Check if partial input matches the primary name, display label, or any alias
+      const displayName = schema.display ?? name;
+      const matchesPrimary = !contextName
+        || name.toLowerCase().startsWith(contextName.toLowerCase())
+        || displayName.toLowerCase().startsWith(contextName.toLowerCase());
       const matchesAlias = !matchesPrimary && schema.aliases?.some(
         alias => alias.toLowerCase().startsWith(contextName.toLowerCase())
       );
 
       if (matchesPrimary || matchesAlias) {
         if (!seenOptions.has(name)) {
-          const aliasHint = schema.aliases?.length ? ` (${schema.aliases.join(', ')})` : '';
+          // Show all aliases EXCEPT the display name itself to avoid redundancy
+          const otherAliases = schema.aliases?.filter(a => a !== displayName) ?? [];
+          const aliasHint = otherAliases.length ? ` (${otherAliases.join(', ')})` : '';
+          const insertCtx = normalizeLabel(displayName) ?? name;
           options.push({
-            path: name,
-            display: `${name}${aliasHint}`,
+            path: insertCtx,
+            display: `${displayName}${aliasHint}`,
             value: null,
             isLeaf: false,
-            fullPath: formatFull(name, '', ''),
+            fullPath: formatFull(insertCtx, '', ''),
           });
           seenOptions.add(name);
         }
@@ -575,10 +773,12 @@ export function getAutocompleteOptions(
     });
   }
 
-  // Find the context (or its alias)
+  // Find the context: direct key, localized display name, or alias
   let contextSchema = context[contextName];
   if (!contextSchema) {
-    const foundContext = Object.entries(context).find(([, schema]) => schema.aliases?.includes(contextName));
+    const foundContext = Object.entries(context).find(([, sch]) =>
+      sch.aliases?.includes(contextName) || (normalizeLabel(sch.display) ?? '') === contextName
+    );
     if (foundContext) {
       contextSchema = foundContext[1];
     }
@@ -593,10 +793,31 @@ export function getAutocompleteOptions(
 
   for (let i = 0; i < partialPath.length - 1; i++) {
     const key = partialPath[i];
-    if (typeof currentObj !== 'object' || currentObj === null || !(key in currentObj)) {
-      return [];
+    if (typeof currentObj !== 'object' || currentObj === null) return [];
+    const obj = currentObj as Record<string, unknown>;
+    if (key in obj) {
+      currentObj = obj[key];
+    } else {
+      // Leaf alias fallback
+      const leafMatch = Object.entries(obj).find(([, v]) => isFieldAspect(v) && v.aliases?.includes(key));
+      if (leafMatch) { currentObj = leafMatch[1]; continue; }
+      // Branch alias fallback
+      const branchMatch = Object.entries(obj).find(([, v]) =>
+        typeof v === 'object' && v !== null && !isFieldAspect(v)
+        && (v as { _aliases?: string[] })._aliases?.includes(key)
+      );
+      if (branchMatch) { currentObj = branchMatch[1]; continue; }
+      // Localized display name fallback
+      const localMatch = Object.entries(obj).find(([k, v]) => {
+        if (k.startsWith('_')) return false;
+        const localKey = isFieldAspect(v)
+          ? normalizeLabel((v as FieldAspect).display)
+          : normalizeLabel((v as AspectGroup)._display);
+        return localKey === key;
+      });
+      if (localMatch) { currentObj = localMatch[1]; }
+      else { return []; }
     }
-    currentObj = (currentObj as Record<string, unknown>)[key];
   }
 
   if (typeof currentObj !== 'object' || currentObj === null) {
@@ -617,8 +838,13 @@ export function getAutocompleteOptions(
     // Skip private properties
     if (key.startsWith('_')) continue;
 
-    // Match partial key against property name or aliases (case-insensitive)
-    const matchesKey = key.toLowerCase().startsWith(partialKey.toLowerCase());
+    // Compute the localized name for this entry (what gets inserted into the formula)
+    const localKey = isFieldAspect(value)
+      ? (normalizeLabel((value as FieldAspect).display) ?? key)
+      : (normalizeLabel((value as AspectGroup)._display) ?? key);
+    // Match partial key against canonical key, localized name, or leaf aliases (case-insensitive)
+    const matchesKey = key.toLowerCase().startsWith(partialKey.toLowerCase())
+      || localKey.toLowerCase().startsWith(partialKey.toLowerCase());
     const matchesAlias = !matchesKey && isFieldAspect(value) && value.aliases?.some(
       alias => alias.toLowerCase().startsWith(partialKey.toLowerCase())
     );
@@ -627,21 +853,22 @@ export function getAutocompleteOptions(
     if (isFieldAspect(value)) {
       const aliasHint = value.aliases?.length ? ` (${value.aliases.join(', ')})` : '';
       options.push({
-        path: key,
+        path: localKey,
         display: (value.display || key) + aliasHint,
         value: value.value ?? null,
         isLeaf: true,
-        fullPath: buildFullPath(key),
+        fullPath: buildFullPath(localKey),
         accessPath: value.accessPath,
       });
     } else if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
       // It's a branch object
+      const branchDisplay = (value as { _display?: string })._display ?? key;
       options.push({
-        path: key,
-        display: key,
+        path: localKey,
+        display: branchDisplay,
         value: null,
         isLeaf: false,
-        fullPath: buildFullPath(key) + '.',
+        fullPath: buildFullPath(localKey) + '.',
       });
     }
   }
@@ -707,12 +934,18 @@ function hasPartialAspectMatch(context: FamiliarSchema, contextName: string, pat
     if (path[i] in obj) {
       current = obj[path[i]];
     } else {
-      // Alias fallback
-      const aliasMatch = Object.entries(obj).find(([, v]) =>
+      // Leaf alias fallback
+      const leafAlias = Object.entries(obj).find(([, v]) =>
         isFieldAspect(v) && v.aliases?.includes(path[i])
       );
-      if (aliasMatch) {
-        current = aliasMatch[1];
+      if (leafAlias) { current = leafAlias[1]; continue; }
+      // Branch alias fallback
+      const branchAlias = Object.entries(obj).find(([, v]) =>
+        typeof v === 'object' && v !== null && !isFieldAspect(v)
+        && (v as { _aliases?: string[] })._aliases?.includes(path[i])
+      );
+      if (branchAlias) {
+        current = branchAlias[1];
       } else {
         return false;
       }

--- a/src/helpers/formulae/utils.mts
+++ b/src/helpers/formulae/utils.mts
@@ -524,7 +524,28 @@ export function canonicalizeFormula(formula: string, schema: FamiliarSchema): st
         continue;
       }
 
-      // 2. Localized display name → canonical key
+      // 2. Leaf alias fallback (FieldAspect.aliases)
+      const leafAlias = Object.entries(obj).find(([, v2]) =>
+        isFieldAspect(v2) && v2.aliases?.includes(seg)
+      );
+      if (leafAlias) {
+        canonPath.push(leafAlias[0]);
+        current = null;
+        continue;
+      }
+
+      // 3. Branch alias fallback (AspectGroup._aliases)
+      const branchAlias = Object.entries(obj).find(([, v2]) =>
+        typeof v2 === 'object' && v2 !== null && !isFieldAspect(v2)
+        && (v2 as { _aliases?: string[] })._aliases?.includes(seg)
+      );
+      if (branchAlias) {
+        canonPath.push(branchAlias[0]);
+        current = branchAlias[1] as AspectGroup;
+        continue;
+      }
+
+      // 4. Localized display name → canonical key
       let matched = false;
       for (const [k, v2] of Object.entries(obj)) {
         if (k.startsWith('_')) continue;
@@ -749,7 +770,10 @@ export function getAutocompleteOptions(
           // Show all aliases EXCEPT the display name itself to avoid redundancy
           const otherAliases = schema.aliases?.filter(a => a !== displayName) ?? [];
           const aliasHint = otherAliases.length ? ` (${otherAliases.join(', ')})` : '';
-          const insertCtx = normalizeLabel(displayName) ?? name;
+          // Only PascalCase when display is explicitly set — inserting a normalized canonical
+          // key (e.g. 'Weapon' from 'weapon') produces a token that context resolution can't
+          // find back when display is undefined.
+          const insertCtx = schema.display ? (normalizeLabel(schema.display) ?? name) : name;
           options.push({
             path: insertCtx,
             display: `${displayName}${aliasHint}`,

--- a/src/lang/en/common.json
+++ b/src/lang/en/common.json
@@ -48,6 +48,11 @@
       "EditField": "Edit {field}",
       "Content": "content"
     },
+    "Formula": {
+      "Context": {
+        "Self": "Self"
+      }
+    },
     "DOCUMENT": {
       "FIELDS": {
         "version": {

--- a/src/vue/components/Fields/FormGroups/AspectPicker.vue
+++ b/src/vue/components/Fields/FormGroups/AspectPicker.vue
@@ -34,7 +34,7 @@
 <script setup lang="ts">
   import type { AutocompleteOption, FamiliarContext, FamiliarSchema, ValidationError } from '@helpers/formulae/types.mjs';
   import { useFamiliarOverlayInput } from '@helpers/formulae/useFamiliarOverlayInput.mjs';
-  import { findAspectByAccessPath, parseFormula, renderFormulaHTML, validateFormula } from '@helpers/formulae/utils.mjs';
+  import { canonicalizeFormula, findAspectByAccessPath, localizeFormula, parseFormula, renderFormulaHTML, validateFormula } from '@helpers/formulae/utils.mjs';
   import FamiliarOverlayInput from '@vc/Fields/FormGroups/FamiliarOverlayInput.vue';
   import { computed, nextTick, onUnmounted, type PropType, ref, watch } from 'vue';
 
@@ -85,14 +85,15 @@
   });
 
   /**
-   * Translate a stored raw accessPath to familiar display syntax.
-   * e.g. 'system.hardness.value' → '#item.hardness'
+   * Translate a stored raw accessPath to familiar display syntax (localized).
+   * e.g. 'system.hardness' → '#item.Hardness' (English) / '#item.Twardość' (Polish)
    */
   function rawToFamiliar(rawPath: string): string {
     if (!rawPath || !props.familiarContext) return rawPath;
     const result = findAspectByAccessPath(props.familiarContext.properties, rawPath);
     if (result) {
-      return `#${props.contextName}.${result.treePath.join('.')}`;
+      const canonical = `#${props.contextName}.${result.treePath.join('.')}`;
+      return localizeFormula(canonical, wrappedSchema.value);
     }
     // Unresolvable — show raw path as-is
     return rawPath;
@@ -100,17 +101,21 @@
 
   /**
    * Translate familiar display syntax back to raw accessPath.
-   * e.g. '#item.hardness' → 'system.hardness.value'
+   * Handles both localized (#item.Twardość) and canonical (#item.hardness) input.
    *
-   * Walks the context tree following the path segments to find the leaf FieldAspect.
+   * Canonicalizes first so localized display names map to canonical tree keys,
+   * then walks the tree to find the leaf FieldAspect's accessPath.
    */
   function familiarToRaw(familiarPath: string): string {
     if (!props.familiarContext) return familiarPath;
 
+    // Canonicalize: e.g. '#item.Twardość' → '#item.hardness'
+    const canonical = canonicalizeFormula(familiarPath, wrappedSchema.value);
+
     // Strip the '#contextName.' prefix
     const prefix = `#${props.contextName}.`;
-    if (!familiarPath.startsWith(prefix)) return familiarPath;
-    const innerPath = familiarPath.slice(prefix.length);
+    if (!canonical.startsWith(prefix)) return familiarPath;
+    const innerPath = canonical.slice(prefix.length);
     if (!innerPath) return familiarPath;
 
     // Walk the context tree
@@ -143,10 +148,9 @@
 
   const dynamicHint = computed(() => {
     if (!props.familiarContext) return '';
-    const contexts = [props.contextName].filter(Boolean);
-    if (contexts.length === 0) return '';
-    const capitalized = contexts.map(k => k.charAt(0).toUpperCase() + k.slice(1));
-    return `Available Contexts: [${capitalized.join(', ')}]`;
+    const ctx = wrappedSchema.value[props.contextName];
+    const displayName = ctx?.display ?? (props.contextName.charAt(0).toUpperCase() + props.contextName.slice(1));
+    return `Available Contexts: [${displayName}]`;
   });
 
   const displayHint = computed(() => props.disabled ? '' : dynamicHint.value);


### PR DESCRIPTION
# Phase 3 Task 3.1: Formula Familiar — Localized Autocomplete — Implementation PR

**Date**: April 24, 2026  
**Branch**: `feature/phase3/bonusLanguageFeat_for_formulaFamiliar`  
**Status**: ✅ Complete  
**Implementation cycles**: 1 cycle  
**Files modified**: 14 files  
**Lines**: +495 / −104  
**Build status**: Passes `npm run build` cleanly (392 modules)

---

## What We Built

Formula Familiar autocomplete now shows and accepts **localized field labels** instead of raw schema property names. Storage remains canonical (`#self.hardness`); everything the user sees and types is localized (`#Self.Hardness` in English, `#Siebie.Twardość` in Polish).

### The Problem

Before this change, the FormulaFamiliar autocomplete showed raw schema property names (`hardness`, `damageNotes`, `weaponType`). Several fields also had no display label at all — Foundry's `localizeDataModel` sets `field.label` directly on the field instance after `i18nInit`, but the schema walker was calling `ModelClass.defineSchema()` (which creates fresh, unlabeled field instances) instead of reading `ModelClass.schema.fields` (the cached, already-localized instance).

### Architecture

The implementation uses a **translate-on-load / canonicalize-on-save** pattern. The localized form is purely a display and input layer; the canonical form is always what gets stored:

```
Storage:  #self.hardness
   ↓ localizeFormula()
Display:  #Self.Hardness (en) / #Siebie.Twardość (pl)
   ↑ canonicalizeFormula()
Input:    user types localized form
```

---

## Changes by File

### `src/helpers/formulae/schemaWalker.mts`

- **`gatherAspectsFromSchema()` now uses `ModelClass.schema.fields`** instead of `ModelClass.defineSchema()`. The cached schema has field labels already set by Foundry's `localizeDataModel` via `LOCALIZATION_PREFIXES`. Fresh instances from `defineSchema()` have no labels.
- **`field.label` vs `field.options.label`**: Foundry's `localizeDataModel` sets `field.label` directly on the instance (not `field.options.label`). Both `addLeafToGroup()` and the SchemaField branch handler now read `field.label` first, falling back to `field.options.label`.
- **`AspectGroup` keys remain canonical** (raw schema field names). Localized labels live in `FieldAspect.display` and `AspectGroup._display` — never as tree keys.
- **New export: `normalizeLabel(label)`** — converts a display label to a valid PascalCase identifier segment (e.g. `"Hit Points"` → `"HitPoints"`, `"Twardość"` → `"Twardość"`). Unicode-aware (`\p{L}\p{N}`). Used exclusively by `localizeFormula`/`canonicalizeFormula` for identifier generation — **not** for tree keys.
  - `@todo` added: PascalCasing is inappropriate for some languages (Japanese passthrough, German noun casing, CJK/Arabic no uppercase). Planned fix in Phase 31: `CONFIG.dnd35e.localization[locale].normalizeIdentifier()` hook. Tracked in phase-31-community-hardening.md.

### `src/helpers/formulae/types.mts`

- **`FamiliarContext.display?: string`** — localized label for the context shown in autocomplete (e.g. `'Self'` or `'Siebie'`).
- **`AspectGroup`** — index type broadened to allow `string[] | string | undefined` values alongside `FieldAspect | AspectGroup`. Added JSDoc for `_display` and `_aliases` metadata keys.

### `src/helpers/formulae/utils.mts`

- **New export: `localizeFormula(formula, schema)`** — translates a canonical formula to the current locale's display form. Walks each variable's context and path, mapping canonical keys → `normalizeLabel(entry.display)`. Custom quoted paths (`#self.'raw.path'`) and unresolvable segments are left unchanged.
- **New export: `canonicalizeFormula(formula, schema)`** — reverses `localizeFormula`. Matches each localized segment against `normalizeLabel(entry.display)` to find the canonical key. Safe to call on already-canonical formulas (direct key match short-circuits the display lookup).
- **`VARIABLE_REGEX`** updated to `[\p{L}\p{N}_]+` with `u` flag — recognizes Polish, Czech, and other non-ASCII variable name segments.
- **`getAutocompleteOptions()`** — context list now uses `normalizeLabel(displayName)` as the `path` (insert value) and `displayName` as the `display`; `fullPath` uses the localized context name. Property list computes `localKey = normalizeLabel(display) ?? key` and inserts the localized form.
- **`getFieldAspect()` / `validateVariable()`** — alias fallback chains now include a localized display name match (`normalizeLabel(entry.display) === segment`) so typed localized paths resolve correctly.
- **`filterExcludedFields()`** — also deletes the PascalCase-normalized form of each excluded key to handle localized key variants.
- **`resolveFormula()`** — context lookup now bridges localized context names (e.g. `'Self'`) to internal keys (`'self'`) via `FamiliarContext.aliases`.

### `src/helpers/formulae/registry.mts`

- **`buildDocumentFamiliar()`** — `self` context now gets:
  - `display: selfLabel` — from `game.i18n.localize('dnd35e.Formula.Context.Self')`
  - `aliases` — includes `normalizeLabel(selfLabel)` plus type-based document aliases
- **New helper `buildContextAliases()`** — generates localized document-type aliases by looking up `TYPES.{docType}.{subtype}` in `game.i18n`. Added to all non-self context registrations.

### `src/helpers/formulae/index.mts`

- Exports `localizeFormula` and `canonicalizeFormula`.

### `src/helpers/formulae/FormulaFormGroup.vue`

- **`localValue`** (the string the user edits) is now the localized form, not the canonical form.
- **On mount and when `effectiveFormula` changes**: `localizeFormula(effectiveFormula, contexts)` → `localValue`.
- **`commitValue()`**: applies `canonicalizeFormula(localValue, contexts)` before calling `props.onUpdate`.
- **Escape/revert**: restores `localizeFormula(effectiveFormula, contexts)`.
- **Dynamic hint** uses `ctx.display` for context names in the hint bar.

### `src/vue/components/Fields/FormGroups/AspectPicker.vue`

- **`rawToFamiliar()`**: `findAspectByAccessPath` → canonical tree path → `localizeFormula` → localized display string for the pill.
- **`familiarToRaw()`**: `canonicalizeFormula` first → strip `#context.` prefix → tree walk → `accessPath`.
- **Dynamic hint** uses `ctx.display`.

### `src/lang/en/common.json`

- Added `"Formula": { "Context": { "Self": "Self" } }` — localizable context name for the self reference.

---

## Behavior Summary

| Scenario | Before | After |
|----------|--------|-------|
| Autocomplete dropdown | `hardness`, `damageNotes` | `Hardness`, `Damage Notes` |
| Typing in formula field | `#self.hardness` | `#Self.Hardness` |
| Stored value | `#self.hardness` | `#self.hardness` (unchanged) |
| Polish locale | `#self.hardness` | `#Siebie.Twardość` |
| Custom quoted paths | `#self.'system.foo'` | `#Self.'system.foo'` (passthrough) |
| Already-canonical formula on load | — | Transparently localized on display |

---

## Deferred / Known Limitations

- **PascalCase casing for non-Latin scripts** — deferred to Phase 31. Planned: `CONFIG.dnd35e.localization[locale].normalizeIdentifier()` hook. Japanese is a straight passthrough (no spaces or casing concepts). German noun casing, Arabic/CJK scripts, etc. need locale-aware handling. Changing this for a locale is a storage-breaking migration for any formulas that used localized identifiers in that locale.

---

## Planning / Agent Doc Updates

- `docs/migration-plan/README.md` — Phase 1 → `✅ Complete`, Phase 2 → `🔶 In Progress`, Phase 3 → `✅ Complete`
- `docs/migration-plan/phase-02-active-effect-on-item.md` — status updated to `🔶 In Progress`
- `docs/migration-plan/phase-03-localization.md` — Task 3.1 description updated to reflect actual implementation; status updated to `✅ Complete`
- `docs/migration-plan/phase-31-community-hardening.md` — added PascalCase/locale identifier normalization as a deferred checklist item
- `.github/agents/silversmith.agent.md` — added "Critical rule" to update phase status in both phase doc and README on every status transition; Phase 2 Section Completion step added for dual-location status update
- `.github/agents/planning.agent.md` — added `## Phase Status Transitions` section documenting the dual-location update requirement and status progression order
