### PR TITLE
Insert alpha.9 Buff AE Core; wave-restart phase doc headers

### DIFF
--- a/docs/architecture/property-maps/PropertyMap-ActiveEffects.md
+++ b/docs/architecture/property-maps/PropertyMap-ActiveEffects.md
@@ -54,17 +54,19 @@ These are the things that CREATE Active Effects in the system. Each needs consid
 
 ### 5. Buffs (AE type, not item type)
 - **Buff is a custom Active Effect type** — NOT an item type in dnd35e
-- D35E `buff` items are migrated to Buff AEs during data migration (Phase 27)
-- Buff AEs extend the standard AE schema with:
+- Implementation is **split across two phases**:
+  - **alpha.9 (Buff AE Core)** — minimum schema for Paladin alpha spells: `system.active`, `system.duration.{rounds, elapsed, deleteOnExpiry}`, `description`, plus inherited `changes[]` with `bonusType`. Combat-tracker turn-start tick, activation/deactivation, non-transferring placement on the target actor.
+  - **beta.3 (Buff AE Expansion & Conditions Full)** — full schema extensions (see below) and the D35E `buff` item → Buff AE data migration.
+- Buff AEs extend the standard AE schema. The **alpha core fields** are listed above; **beta expansion adds**:
   - `buffType`: "temp"\|"perm"\|"item"\|"shapechange"\|"misc"
-  - `timeline`: duration tracking (total rounds, elapsed, formula, deleteOnExpiry)
+  - `timeline.formula` — formula-driven durations (replaces / augments the alpha `duration.rounds`)
   - `damagePool`: max/current absorb (e.g. Stoneskin 150 HP pool)
   - `shapechange`: polymorph/wildshape data
   - `hideFromToken`: suppress icon display
-- Buff AEs are activated/deactivated (toggle on/off)
-- Timeline ticks down via combat tracker integration
-- When a spell creates a buff on a target, it creates a Buff AE directly on the target actor
-- Buff AEs appear in a dedicated "Buffs" section on the character sheet
+- Buff AEs are activated/deactivated (toggle on/off) — alpha.9.
+- Timeline ticks down via combat tracker integration — alpha.9 (round-based); beta.3 expands to formula-driven.
+- When a spell creates a buff on a target, it creates a Buff AE directly on the target actor.
+- Buff AEs appear in a dedicated "Buffs" section on the character sheet — beta.3. In alpha.9 they render in the generic effects list.
 
 ### 6. Spells
 - Cast spells may create buff items on targets, which in turn create AEs

--- a/docs/migration-plan/alpha/phase-01-races-progression.md
+++ b/docs/migration-plan/alpha/phase-01-races-progression.md
@@ -1,4 +1,4 @@
-# Phase 8: Races
+# Alpha Phase 1: Races
 
 **Status**: 📋 Outlined (Grant system, ability adjustments, racial traits, progression component)
 

--- a/docs/migration-plan/alpha/phase-02-classes-level-history.md
+++ b/docs/migration-plan/alpha/phase-02-classes-level-history.md
@@ -1,4 +1,4 @@
-# Phase 9: Classes & Level History
+# Alpha Phase 2: Classes & Level History
 
 **Status**: 📋 Outlined (Class progression, multiclass stacking, level history, edit rules)
 

--- a/docs/migration-plan/alpha/phase-03-action-system.md
+++ b/docs/migration-plan/alpha/phase-03-action-system.md
@@ -1,4 +1,4 @@
-# Phase 10: Action System
+# Alpha Phase 3: Action System
 
 **Status**: 📋 Outlined (ActionDataModel, execution engine, chains)
 

--- a/docs/migration-plan/alpha/phase-04-feats.md
+++ b/docs/migration-plan/alpha/phase-04-feats.md
@@ -1,4 +1,4 @@
-# Phase 11: Feats (Alpha)
+# Alpha Phase 4: Feats (Alpha)
 
 **Status**: 📋 Outlined (Feat types, EffectTriggers, passive/toggle/trigger patterns)
 

--- a/docs/migration-plan/alpha/phase-05-natural-attacks.md
+++ b/docs/migration-plan/alpha/phase-05-natural-attacks.md
@@ -1,4 +1,4 @@
-# Phase 12: Natural & Special Attacks
+# Alpha Phase 5: Natural & Special Attacks
 
 **Status**: 📖 Rough Sketch (350+ item checklist, iterative attacks, TWF)
 

--- a/docs/migration-plan/alpha/phase-06-class-features.md
+++ b/docs/migration-plan/alpha/phase-06-class-features.md
@@ -1,4 +1,4 @@
-# Phase 13: Class Features (Alpha)
+# Alpha Phase 6: Class Features (Alpha)
 
 **Status**: 📋 Outlined
 

--- a/docs/migration-plan/alpha/phase-07-combat-tracker.md
+++ b/docs/migration-plan/alpha/phase-07-combat-tracker.md
@@ -274,7 +274,7 @@ Per Phase 8 (§18.13), the combat tracker respects these settings:
 - [ ] Implement `startOfTurn(combatant)` hook
 - [ ] Reset `system.turnBudget` to fresh state via `combatant.update()` (persisted to DB)
 - [ ] Set `system.turnBudget.movementBudget` from actor speed: `combatant.actor.system.attributes.speed.land`
-- [ ] Process start-of-turn effects: duration countdowns, buff expirations (stub for Phase 20)
+- [ ] Process start-of-turn effects: duration countdowns, buff expirations (Buff AE tick implemented in alpha.9 — increment `system.duration.elapsed` and expire per `deleteOnExpiry`)
 - [ ] Set `system.turnBudget.flatFooted`: true if first turn
 - [ ] Emit 'phaseStartOfTurn' event for listeners (conditions, auras, etc.)
 - [ ] Implement `duringTurn(action)` hook for each action spent

--- a/docs/migration-plan/alpha/phase-07-combat-tracker.md
+++ b/docs/migration-plan/alpha/phase-07-combat-tracker.md
@@ -1,4 +1,4 @@
-# Phase 14: Combat Tracker & Turn Economy
+# Alpha Phase 7: Combat Tracker & Turn Economy
 
 **Status**: 📋 Outlined (TurnActionBudget, action economy state machine)
 

--- a/docs/migration-plan/alpha/phase-08-conditions.md
+++ b/docs/migration-plan/alpha/phase-08-conditions.md
@@ -1,4 +1,4 @@
-# Phase 14 — Conditions (Minimal)
+# Alpha Phase 8 — Conditions (Minimal)
 
 **Status**: 📋 Outlined (Prone condition, condition system, maneuver→condition pipeline)
 
@@ -8,7 +8,7 @@
 
 ---
 
-## 14.1 Why Prone in POC
+## 8.1 Why Prone in POC
 
 The POC includes the Trip combat maneuver (Phase 8, §7.7). For trip to be meaningful, the Prone condition must exist and affect combat stats. This phase proves the full pipeline:
 
@@ -24,7 +24,7 @@ Beta Phase 3 (Buff AE Expansion & Conditions Full) builds on this foundation to 
 
 ---
 
-## 14.2 Prone Condition Definition
+## 8.2 Prone Condition Definition
 
 ```typescript
 // src/module/config/conditions.ts
@@ -53,7 +53,7 @@ export const CONDITIONS = {
 
 ---
 
-## 14.3 Condition as Active Effect
+## 8.3 Condition as Active Effect
 
 Conditions are implemented as Active Effects with a `conditionType` flag:
 
@@ -76,7 +76,7 @@ await target.createEmbeddedDocuments("ActiveEffect", [{
 
 ---
 
-## 14.4 Standing Up Action
+## 8.4 Standing Up Action
 
 The recovery action is a generated action that appears in the character's available actions when they have the Prone condition:
 
@@ -101,7 +101,7 @@ This generates a "Stand Up" action available in the ActionHUD, costs a move acti
 
 ---
 
-## 14.5 Integration Points
+## 8.5 Integration Points
 
 | System | How Prone Integrates |
 |--------|---------------------|
@@ -114,7 +114,7 @@ This generates a "Stand Up" action available in the ActionHUD, costs a move acti
 
 ---
 
-## 14.6 Files to Create
+## 8.6 Files to Create
 
 | File | Purpose |
 |------|---------|
@@ -123,7 +123,7 @@ This generates a "Stand Up" action available in the ActionHUD, costs a move acti
 | `src/module/vue/components/combat/ConditionDisplay.vue` | Shows active conditions on actor sheet |
 | `lang/en/conditions.json` | Localization for condition names and descriptions |
 
-## 14.6.1 Actor Model Changes
+## 8.6.1 Actor Model Changes
 
 This phase adds condition tracking to the actor model. Phase 5's actor sheet already shows Active Effects (Effects tab), but condition-specific UI is introduced here:
 
@@ -136,7 +136,7 @@ No condition flags exist on the actor data schema — conditions are purely AE-d
 
 ---
 
-## 14.7 Deferred to Beta Phase 3
+## 8.7 Deferred to Beta Phase 3
 
 Everything listed here is deferred to beta.3 (Buff AE Expansion & Conditions Full):
 - All other conditions (Blinded, Stunned, Paralyzed, Exhausted, etc.)

--- a/docs/migration-plan/alpha/phase-08-conditions.md
+++ b/docs/migration-plan/alpha/phase-08-conditions.md
@@ -20,7 +20,7 @@ Trip action chain (Phase 8)
   → Standing up = move action (TurnActionBudget cost)
 ```
 
-Phase 21 (Buffs & Conditions Full) builds on this foundation to implement all 25+ D&D 3.5e conditions.
+Beta Phase 3 (Buff AE Expansion & Conditions Full) builds on this foundation to implement all 25+ D&D 3.5e conditions.
 
 ---
 
@@ -72,7 +72,7 @@ await target.createEmbeddedDocuments("ActiveEffect", [{
 }]);
 ```
 
-**Key pattern**: Conditions are Active Effects, not items. They use the same AE pipeline established in Phase 2. The `isCondition` flag distinguishes them from duration buffs (Phase 21) and material effects (Phase 2).
+**Key pattern**: Conditions are Active Effects, not items. They use the same AE pipeline established in poc.2. The `isCondition` flag distinguishes them from duration buffs (Buff AE Core in alpha.9, expansion in beta.3) and material effects (poc.2).
 
 ---
 
@@ -136,15 +136,15 @@ No condition flags exist on the actor data schema — conditions are purely AE-d
 
 ---
 
-## 14.7 Deferred to Phase 21
+## 14.7 Deferred to Beta Phase 3
 
-Everything listed here is deferred to Phase 21 (Buffs & Conditions Full):
+Everything listed here is deferred to beta.3 (Buff AE Expansion & Conditions Full):
 - All other conditions (Blinded, Stunned, Paralyzed, Exhausted, etc.)
 - Condition stacking and interaction rules (e.g., Exhausted + Fatigued)
 - Ability damage/drain as condition-like effects
 - Fear track (Shaken → Frightened → Panicked)
 - Duration-based condition expiry
-- Buff item type and temporary enhancement bonuses
+- Buff AE expansion fields (`buffType` taxonomy, formula-driven timelines, damage pools, shapechange) — alpha.9 introduces the minimal Buff AE; beta.3 expands it
 
 ---
 

--- a/docs/migration-plan/alpha/phase-09-buff-ae-core.md
+++ b/docs/migration-plan/alpha/phase-09-buff-ae-core.md
@@ -1,0 +1,225 @@
+# Alpha Phase 9 — Buff Active Effect (Core)
+
+**Status**: 📖 Rough Sketch
+
+> **Milestone**: Alpha  
+> **Dependencies**: poc.2 (Active Effect on Item — stacking engine, phase system, GeneralSystemModel), poc.6 (Actor Foundation — Buff AEs live on actors). Soft sibling: alpha.8 (Conditions) — both use the "AE subtype with its own SystemModel + actor placement" pattern.  
+> **Goal**: Introduce the **Buff Active Effect subtype** with the minimum surface needed for Paladin alpha spells (Bless, Protection from Evil, Divine Favor). Buff AEs are *AE subtype documents*, not item documents — `Buff` is **not** a D&D 3.5e item type in dnd35e. A spell's cast action creates a Buff AE **directly on the target actor**; the buff carries `bonusType`-tagged changes that flow through the Phase 2 stacking engine; the buff can be toggled on/off; it ticks down with combat rounds and expires.
+
+---
+
+## 9.1 Why Buff AE Core Lives in Alpha
+
+The alpha exit criteria require players to *"cast Bless and Divine Favor (RAW spell slots), see morale stacking collision on fear saves (Aura of Courage +4 suppresses Bless +1)."* That collision is only meaningful if Bless actually applies its +1 morale bonus through a Buff AE.
+
+- alpha.11 (Spells) — Paladin casts Bless / Protection from Evil / Divine Favor; cast action creates a Buff AE on the target.
+- alpha.6 (Class Features) — Aura of Courage applies a `morale` change of `+4` that collides with the Bless buff (suppressed) on fear saves.
+- alpha.8 (Conditions) and alpha.6 already use the AE pipeline; Buff AE Core adds the *temporary, toggleable, duration-tracked, activatable* AE subtype that conditions and class-feature passives don't need.
+
+This phase delivers **only the minimum surface those three spells consume**. Everything else — `buffType` taxonomy, formula-driven timelines, damage pools, shapechange, the dedicated "Buffs" sheet section, and the D35E `buff` item → Buff AE data migration — is **beta.3** (Buff AE Expansion & Conditions Full). See §9.7 below.
+
+---
+
+## 9.2 What's In vs. What's Deferred
+
+### In (alpha.9)
+
+- New AE subtype `buff` registered alongside `general`, `material`, `secret`.
+- `BuffSystemModel` schema with the minimum fields below.
+- `Dnd35eBuffActiveEffect` class extending `Dnd35eActiveEffect`.
+- Non-transferring: created directly on the bearer (target actor), not on an item.
+- Activation/deactivation toggle. Deactivated Buff AE suppresses all its changes but is not deleted.
+- Round-based duration with combat-tracker tick-down and expiry behavior.
+- Changes flow through the Phase 2 stacking engine via `bonusType`.
+- Minimal Buff AE config sheet (read/edit name, description, duration, changes, activation).
+- Tests covering: creation, change application via stacking, deactivation suppression, round tick-down, expiry.
+
+### Deferred to beta.3 (Buff AE Expansion)
+
+- `buffType` taxonomy: `'temp' | 'perm' | 'item' | 'shapechange' | 'misc'`.
+- `timeline.formula` — formula-driven durations replacing the simple `rounds` field.
+- `damagePool: { max, current }` — Stoneskin-style absorb.
+- `shapechange: { type, source, ... }` — polymorph / wildshape integration.
+- `hideFromToken: boolean`.
+- Dedicated **"Buffs" sheet section** UI on the character sheet (alpha.9 buffs render in the generic effects list).
+- D35E `buff` item → Buff AE **data migration**.
+
+> Beta.3 *extends* alpha.9's schema; it does not replace it. The alpha.9 fields below are stable contracts that beta.3 builds on.
+
+---
+
+## 9.3 BuffSystemModel — Schema (Alpha Core)
+
+```ts
+// src/entities/activeEffects/buff/BuffSystemModel.mts
+import { Dnd35eActiveEffectSystemModel } from '...';
+
+export class BuffSystemModel extends Dnd35eActiveEffectSystemModel {
+  static defineSchema() {
+    const fields = foundry.data.fields;
+    return {
+      ...super.defineSchema(),
+
+      // On/off toggle. Cast action sets `true`; expiry or dismissal sets `false`.
+      // Deactivated buffs are NOT deleted (unless `duration.deleteOnExpiry`); their
+      // changes are suppressed in `applyActiveEffects()` via the existing AE pipeline.
+      active: requiredBooleanField({ initial: true }),
+
+      // Round-based duration.
+      // `rounds`: total duration in combat rounds (set by the cast action at cast time).
+      // `elapsed`: rounds ticked so far. Incremented on the bearer's turn start by the
+      //   combat tracker hook.
+      // `deleteOnExpiry`: default true for spell buffs — when `elapsed >= rounds`, the
+      //   AE is deleted. If false, it is marked inactive but retained (for sheet display).
+      duration: new fields.SchemaField({
+        rounds: requiredNumberField({ initial: 0, min: 0 }),
+        elapsed: requiredNumberField({ initial: 0, min: 0 }),
+        deleteOnExpiry: requiredBooleanField({ initial: true }),
+      }),
+
+      // Short human-facing description shown on the AE sheet and chat card.
+      description: new fields.HTMLField({ required: false }),
+    };
+  }
+}
+```
+
+> `bonusType` is **per-change**, already on the base `Dnd35eEffectChangeData` from poc.2 — Buff AE inherits this from the parent AE schema's `changes[]` array. No new field needed at the buff level.
+
+### Flag convention
+
+- `flags.dnd35e.isSpellEffect: true` on Buff AEs created by spell cast actions.  
+  Already referenced by alpha.11 §16.4 — preserves the spell→buff provenance for Dispel Magic logic in beta.
+
+---
+
+## 9.4 Lifecycle Hooks
+
+### Creation (cast-action side)
+
+Owned by alpha.11 (Spells). When a Paladin casts Bless:
+
+1. Cast action selects target token(s).
+2. Action builds an AE document body: `type: 'buff'`, `name: 'Bless'`, `system.duration.rounds: 10 * casterLevel`, `system.active: true`, `changes: [...]` (morale +1 attack, morale +1 saves vs fear), `flags.dnd35e.isSpellEffect: true`.
+3. `Actor.createEmbeddedDocuments('ActiveEffect', [aeData])` on the target — non-transferring (no item parent).
+
+Alpha.9 provides the *target* (the AE subtype + schema) for this flow. It does **not** implement the cast action itself.
+
+### Activation / Deactivation
+
+User-facing toggle on the AE sheet (and on the actor's effects list, post-beta in the dedicated Buffs section). Flips `system.active`. The Phase 2 effect application pipeline already gates change application on `disabled` (Foundry's native flag) — the alpha.9 toggle uses the same mechanism but is exposed as "Active" on the Buff sheet for user-facing clarity.
+
+> Note: `system.active` and core Foundry `disabled` are kept in sync: `active === !disabled`. Stored on `system` so beta.3 can extend with derived activation logic (e.g., activation conditions evaluated by FormulaFamiliar) without restructuring.
+
+### Round tick (combat-tracker side)
+
+alpha.7 (Combat Tracker & Turn Economy) already stubs *"buff expirations (stub for Phase 20)"* in its combat tracker turn-start hook. Alpha.9 fills in the stub:
+
+1. On the bearer actor's turn-start, iterate active Buff AEs on the actor.
+2. For each: `system.duration.elapsed += 1`.
+3. If `elapsed >= rounds && rounds > 0`:
+   - If `deleteOnExpiry` → `effect.delete()`.
+   - Else → `effect.update({ 'system.active': false, disabled: true })`.
+
+Buffs with `rounds === 0` are treated as **indefinite** (no tick) — used by passive/permanent buffs migrated from D35E `buff` items in beta.3, but rejected in alpha.9 since Bless/PfE/Divine Favor all set explicit round durations.
+
+---
+
+## 9.5 Sheet (Alpha — Minimal)
+
+A minimal Vue Buff AE config sheet (`BuffSheet.vue`) extending the base AE sheet:
+
+- Name, description, image — inherited.
+- Changes table — inherited.
+- **Activation row**: toggle for `system.active`.
+- **Duration row**: `rounds` (number), `elapsed` (number, GM-only edit), `deleteOnExpiry` (checkbox).
+- No `buffType` selector, no timeline formula picker, no damage pool — those are beta.3.
+
+The dedicated "Buffs" section on the character sheet is **deferred to beta.3**. In alpha.9, Buff AEs render in the generic effects list with the rest of the AEs.
+
+---
+
+## 9.6 Integration Tests (Alpha Exit Coverage)
+
+The buff AE Core must prove four behaviors before alpha.9 closes:
+
+1. **Creation + change application**: A Buff AE created on a Character actor with a `morale +1` attack change is applied through the stacking engine; the actor's attack derives include the morale bonus.
+2. **Stacking collision**: With Aura of Courage (`morale +4` on fear saves) present, a Bless Buff AE (`morale +1` on fear saves) is **suppressed** by the stacking engine — stacking history records "Bless (+1 morale) — suppressed by Aura of Courage (+4 morale)." This is the alpha exit-criterion stacking proof.
+3. **Round tick + expiry**: A Buff AE with `rounds: 2, deleteOnExpiry: true` ticks to expiry over two combat-tracker turn-starts; the AE is deleted at the end of the second turn-start.
+4. **Deactivation suppression**: Toggling `system.active: false` causes all changes to vanish from the actor's derived data without deleting the AE.
+
+---
+
+## 9.7 Out of Scope (Explicit)
+
+- ❌ `buffType` field and taxonomy.
+- ❌ Formula-driven timelines.
+- ❌ Damage pool, shapechange, hideFromToken.
+- ❌ Dedicated "Buffs" sheet section.
+- ❌ D35E `buff` item → Buff AE data migration.
+- ❌ Buff stacking-by-source rules (multiple Bless from different casters) — alpha.9 lets all buff changes flow through the standard stacking engine, with `bonusType` doing the work.
+- ❌ Dispel Magic interaction beyond setting `flags.dnd35e.isSpellEffect: true` as provenance.
+
+These all land in **beta.3** (Buff AE Expansion & Conditions Full).
+
+---
+
+## 9.8 Files to Create / Modify
+
+### Create
+
+- `src/entities/activeEffects/buff/Buff.mts` — `Dnd35eBuffActiveEffect` class.
+- `src/entities/activeEffects/buff/BuffSystemModel.mts` — schema.
+- `src/entities/activeEffects/buff/BuffSystemData.mts` — runtime types.
+- `src/entities/activeEffects/buff/BuffStore.mts` — Pinia store (mirrors `material/`).
+- `src/entities/activeEffects/buff/components/BuffSheet.vue` — minimal sheet.
+- `src/entities/activeEffects/buff/index.mts` — barrel.
+- `tests/unit/buff-ae-core.test.mts` — schema + lifecycle tests.
+- `tests/e2e/buff-stacking.spec.ts` — alpha exit-criterion stacking proof against real Foundry.
+
+> The `poc/refactor-naming-conventions` refactor already parks the legacy `src/entities/items/Dnd35eBuff/Dnd35eBuff.mts` placeholder at `src/entities/activeEffects/buff/` as obsolete reference. Alpha.9 replaces the placeholder content but inherits the location.
+
+### Modify
+
+- `src/entities/activeEffects/registration.mts` — register `'buff'` subtype.
+- `system.json.template` — add `'buff'` to `documentTypes.ActiveEffect.types`.
+- `src/lang/<locale>/dnd35e.json` — add buff label keys.
+- `src/entities/activeEffects/types.mts` — add Buff AE to the discriminated union.
+
+### Cross-phase touches
+
+- `alpha/phase-07-combat-tracker.md` — the turn-start "buff expirations (stub)" hook becomes the real implementation. Sub-checklist line moves from "stub" to "implemented in alpha.9."
+- `alpha/phase-11-spells.md` — adds alpha.9 as a hard dependency; cast actions for Bless / PfE / Divine Favor construct Buff AE bodies using the alpha.9 schema.
+- `beta/phase-03-buffs-conditions.md` — header retitled to "Buff AE Expansion & Conditions (Full)"; buff sections rescope as expansions over the alpha.9 schema, not greenfield creation.
+- `docs/architecture/property-maps/PropertyMap-ActiveEffects.md` §5 — alpha core vs. beta expansion split called out explicitly.
+
+---
+
+## 9.9 Completion Checklist
+
+- [ ] Create `src/entities/activeEffects/buff/` slice (`Buff.mts`, `BuffSystemModel.mts`, `BuffSystemData.mts`, `BuffStore.mts`, `index.mts`).
+- [ ] Define `BuffSystemModel` schema with `active`, `duration.{rounds, elapsed, deleteOnExpiry}`, `description`.
+- [ ] Implement `Dnd35eBuffActiveEffect` class extending the base AE.
+- [ ] Register `'buff'` subtype in `src/entities/activeEffects/registration.mts` and `system.json.template`.
+- [ ] Add Buff label / description i18n keys.
+- [ ] Implement `system.active` ↔ Foundry `disabled` sync (deactivation suppresses changes without deletion).
+- [ ] Fill in the alpha.7 combat-tracker turn-start hook: tick `duration.elapsed` on each active Buff AE on the bearer; expire per `deleteOnExpiry`.
+- [ ] Minimal Buff AE config sheet (Vue) — name, description, activation toggle, duration row, changes table.
+- [ ] Unit test: schema validation, default values, `active` ↔ `disabled` sync.
+- [ ] Integration test: Buff AE with `morale +1` attack change creates expected derived bonus on a Character actor.
+- [ ] Integration test: Bless Buff AE (`morale +1` fear-save) is suppressed by Aura of Courage (`morale +4` fear-save) in stacking history. **(Alpha exit-criterion proof.)**
+- [ ] Integration test: Buff AE ticks down over two combat-tracker turn-starts and is deleted at expiry.
+- [ ] Integration test: toggling `system.active: false` removes the Buff AE's changes from derived data without deletion.
+- [ ] Cross-phase: update `alpha/phase-07-combat-tracker.md` checklist — buff expiry line moves from "stub" to "implemented (depends on alpha.9)".
+- [ ] Cross-phase: update `alpha/phase-11-spells.md` dependency line + cast-action prose to reference alpha.9 Buff AE.
+- [ ] Cross-phase: update `beta/phase-03-buffs-conditions.md` header + buff sections to "expansion over alpha.9".
+- [ ] Cross-phase: update `docs/architecture/property-maps/PropertyMap-ActiveEffects.md` §5 with alpha/beta split callout.
+
+---
+
+## 9.10 Open Questions
+
+1. **Activation source-of-truth**: `system.active` vs Foundry `disabled`. Proposal: keep both in sync, expose `system.active` on the sheet for clarity, treat `disabled` as the canonical flag for the AE application pipeline. Open to inverting if beta.3 needs `system.active` to be derived (e.g., gated by a formula).
+2. **`rounds: 0` semantics**: Treat as indefinite (no tick, no expiry) per §9.4, or reject as invalid in alpha.9 and require beta.3 to introduce indefinite buffs? Recommended: accept but rejected by the alpha.9 cast actions (Bless/PfE/Divine Favor all set explicit rounds).
+3. **Buff Store scope**: Does the Pinia store carry derived "is this buff a spell effect" / "source caster" data, or do we keep it purely the AE document + reactivity? Recommended: just the document, derived selectors as needed by the sheet.
+4. **Tests against real Foundry vs. mocks**: The stacking-collision proof is best done as an E2E test (Playwright against Foundry). Confirm scope — alpha.9 owns the test, or does alpha.6 (Aura of Courage) / alpha.11 (Bless cast) own the integration?

--- a/docs/migration-plan/alpha/phase-10-breath-weapon.md
+++ b/docs/migration-plan/alpha/phase-10-breath-weapon.md
@@ -1,8 +1,8 @@
-# Phase 16: Breath Weapon & Area Templates
+# Alpha Phase 10: Breath Weapon & Area Templates
 
-> **Status**: Outlined
-> **Milestone**: POC (Layer 5 — Combat Loop)
-> **Dependencies**: Phase 9 (Action System), Phase 12 (Combat Tracker)
+> **Status**: 📋 Outlined
+> **Milestone**: Alpha
+> **Dependencies**: alpha.3 (Action System), alpha.7 (Combat Tracker & Turn Economy)
 
 ---
 

--- a/docs/migration-plan/alpha/phase-11-spells.md
+++ b/docs/migration-plan/alpha/phase-11-spells.md
@@ -1,9 +1,9 @@
-# Phase 17: Spells (Alpha)
+# Alpha Phase 11: Spells
 
 **Status**: 📋 Outlined
 
 > **Milestone**: Alpha
-> **Dependencies**: Phase 5 (Actor Foundation), Phase 6 (Roll Formulas), Phase 9 (Action System)
+> **Dependencies**: poc.6 (Actor Foundation), poc.7 (Roll Formulas), alpha.3 (Action System), alpha.9 (Buff AE Core — spell buffs are created as Buff AEs on the target actor)
 > **Goal**: Minimal spell system for Paladin spellcasting. Spell item type, one spellbook, 1st-level spell slots, cast action, and a small set of 1st-level Paladin spells. RAW implementation — Paladin is a divine prepared caster with a limited spell list.
 
 ---
@@ -19,7 +19,7 @@ The Paladin's spell system is the simplest possible test case for spellcasting:
 - No spontaneous casting, no arcane spell failure, no SR, no concentration
 - CL = Paladin level - 3 (minimum 1), so CL 2 at Paladin level 5
 
-Beta Phase 20 (Spells & Spellbooks Full) expands this to all caster types, all spell levels, SR, concentration, metamagic integration, and counterspelling.
+Beta Phase 2 (Spells & Spellbooks Full) expands this to all caster types, all spell levels, SR, concentration, metamagic integration, and counterspelling.
 
 ---
 
@@ -79,16 +79,17 @@ Casting a prepared spell is an action through the Action System (Phase 9):
 1. Player selects a prepared spell from the spellbook UI
 2. Cast action checks: spell slot available? Components met? (Alpha: no component enforcement)
 3. Spell effect resolves — type depends on the spell:
-   - **Bless**: Apply buff AE to self (and allies in range — Alpha: self only)
-   - **Protection from Evil**: Apply buff AE to touched target
-   - **Divine Favor**: Apply buff AE to self
+   - **Bless**: Apply Buff AE (alpha.9) to self (and allies in range — Alpha: self only)
+   - **Protection from Evil**: Apply Buff AE (alpha.9) to touched target
+   - **Divine Favor**: Apply Buff AE (alpha.9) to self
    - **Cure Light Wounds**: Roll 1d8 + CL healing, apply to touched target
 4. Slot marked as used
 5. Chat card shows: spell name, caster level, effect summary, any rolls
 
-**Buff application**: Spells that grant bonuses create temporary Active Effects with a duration. The AE includes:
-- `bonusType` for stacking resolution
-- `duration` for tracking (rounds/minutes — simplified in Alpha)
+**Buff application**: Spells that grant bonuses create Buff AEs (alpha.9 schema) on the target actor with a duration. The Buff AE includes:
+- `changes[]` with per-change `bonusType` for stacking resolution
+- `system.duration.{rounds, elapsed, deleteOnExpiry}` for tracking (alpha.9 uses simple round counts; beta.3 adds formula timelines)
+- `system.active: true` set at creation; toggle off to suppress without deletion
 - `flags.dnd35e.isSpellEffect: true` to distinguish from other AEs
 
 ---
@@ -134,7 +135,7 @@ Casting a prepared spell is an action through the Action System (Phase 9):
 
 ## 16.6 Alpha Scope Limitations
 
-What this phase does NOT implement (deferred to Beta Phase 20):
+What this phase does NOT implement (deferred to beta.2 Spells & Spellbooks Full):
 - Multiple spellbooks (Wizard/Cleric multiclass)
 - Spell levels 2-9
 - Arcane casting, spontaneous casting

--- a/docs/migration-plan/alpha/phase-12-enhancements.md
+++ b/docs/migration-plan/alpha/phase-12-enhancements.md
@@ -1,9 +1,9 @@
-# Phase 18: Enhancement (Alpha)
+# Alpha Phase 12: Enhancement
 
 **Status**: 📋 Outlined
 
 > **Milestone**: Alpha
-> **Dependencies**: Phase 1 (Weapon), Phase 2 (Active Effect on Item — Material)
+> **Dependencies**: poc.1 (Weapon), poc.2 (Active Effect on Item — Material)
 > **Goal**: Minimal +1 longsword implementation. One enhancement AE on a weapon providing +1 enhancement bonus to attack and damage. Proves the enhancement bonus type exists and stacks correctly.
 
 ---

--- a/docs/migration-plan/beta/phase-01-equipment-loot.md
+++ b/docs/migration-plan/beta/phase-01-equipment-loot.md
@@ -1,4 +1,4 @@
-# Phase 19: Equipment, Loot & Bonus Stacking
+# Beta Phase 1: Equipment, Loot & Bonus Stacking
 
 **Status**: 📖 Rough Sketch (250+ item checklist, AC calculations, equipment slots)
 

--- a/docs/migration-plan/beta/phase-02-spells-spellbooks.md
+++ b/docs/migration-plan/beta/phase-02-spells-spellbooks.md
@@ -1,4 +1,4 @@
-# Phase 20: Spells & Spellbooks (Full)
+# Beta Phase 2: Spells & Spellbooks (Full)
 
 **Status**: 📖 Rough Sketch (200+ item checklist, spellbooks, spell slots)
 

--- a/docs/migration-plan/beta/phase-03-buffs-conditions.md
+++ b/docs/migration-plan/beta/phase-03-buffs-conditions.md
@@ -1,6 +1,10 @@
-# Phase 21: Buffs & Conditions (Full)
+# Beta Phase 3: Buff AE Expansion & Conditions (Full)
 
 **Status**: 📖 Rough Sketch (500+ item checklist, 27 bonus types, all conditions)
+
+> **Predecessors**: alpha.8 (Conditions — Prone, fear stub), alpha.9 (Buff AE Core — minimum Buff AE schema and lifecycle), beta.1 (Equipment & Loot).
+>
+> **Builds on alpha.9.** Alpha.9 introduced the minimum Buff AE surface (`system.active`, `system.duration.{rounds, elapsed, deleteOnExpiry}`, `description`, plus inherited `changes[]` with `bonusType`). This phase **extends** the same `BuffSystemModel` with the full schema: `buffType` taxonomy, formula-driven timelines, damage pools, shapechange, `hideFromToken`, and the dedicated "Buffs" section on the character sheet. It also performs the D35E `buff` item → Buff AE **data migration**.
 
 > **Milestone**: Beta  
 > **Dependencies**: Phase 13 (Conditions POC), Phase 15 (Equipment)  
@@ -10,7 +14,7 @@
 
 ## 16.1 Buff Active Effect Type
 
-**Buff is an Active Effect, not an Item.** D35E `buff` items are migrated to Buff AEs during data migration (Phase 27). The Buff AE carries its own timeline, damage pool, and activation state — no item→AE indirection.
+**Buff is an Active Effect, not an Item.** D35E `buff` items are migrated to Buff AEs during this phase's data migration. The Buff AE carries its own timeline, damage pool, and activation state — no item→AE indirection. Alpha.9 introduced the minimum Buff AE surface; this phase adds the full schema and migrates legacy data.
 
 ```
 BuffSystemModel extends Dnd35eActiveEffectSystemModel

--- a/docs/migration-plan/beta/phase-04-advanced-classes.md
+++ b/docs/migration-plan/beta/phase-04-advanced-classes.md
@@ -1,4 +1,4 @@
-# Phase 4: Advanced Classes
+# Beta Phase 4: Advanced Classes
 
 **Status**: 📄 Stub
 

--- a/docs/migration-plan/beta/phase-05-consumables.md
+++ b/docs/migration-plan/beta/phase-05-consumables.md
@@ -1,4 +1,4 @@
-# Phase 22: Consumables
+# Beta Phase 5: Consumables
 
 **Status**: 📖 Rough Sketch (300+ item checklist, consumable types, use chains)
 

--- a/docs/migration-plan/beta/phase-06-advanced-actors.md
+++ b/docs/migration-plan/beta/phase-06-advanced-actors.md
@@ -1,4 +1,4 @@
-# Phase 23: Advanced Actor Types
+# Beta Phase 6: Advanced Actor Types
 
 **Status**: 📖 Rough Sketch (300+ item checklist, NPC/Trap/Object types + Companion mixin)
 

--- a/docs/migration-plan/beta/phase-07-area-effects-auras.md
+++ b/docs/migration-plan/beta/phase-07-area-effects-auras.md
@@ -1,4 +1,4 @@
-# Phase 24: Area Effects & Auras
+# Beta Phase 7: Area Effects & Auras
 
 **Status**: 📖 Rough Sketch (350+ item checklist, AoE templates, aura proximity)
 

--- a/docs/migration-plan/beta/phase-08-enhancements.md
+++ b/docs/migration-plan/beta/phase-08-enhancements.md
@@ -1,4 +1,4 @@
-# Phase 25: Enhancements
+# Beta Phase 8: Enhancements
 
 **Status**: 📖 Rough Sketch (350+ item checklist, weapon & armor enhancements)
 

--- a/docs/migration-plan/beta/phase-09-metamagic.md
+++ b/docs/migration-plan/beta/phase-09-metamagic.md
@@ -1,4 +1,4 @@
-# Phase 26: Metamagic
+# Beta Phase 9: Metamagic
 
 **Status**: 📖 Rough Sketch (200+ item checklist, metamagic feats, PreRollDialog)
 

--- a/docs/migration-plan/beta/phase-10-full-spells.md
+++ b/docs/migration-plan/beta/phase-10-full-spells.md
@@ -1,4 +1,4 @@
-# Phase 27: Full Spells
+# Beta Phase 10: Full Spells
 
 **Status**: 📖 Rough Sketch (400+ item checklist, spell resistance, concentration, counterspelling)
 

--- a/docs/migration-plan/beta/phase-11-psionics.md
+++ b/docs/migration-plan/beta/phase-11-psionics.md
@@ -1,4 +1,4 @@
-# Phase 28: Psionics
+# Beta Phase 11: Psionics
 
 **Status**: 📖 Rough Sketch (250+ item checklist, power points, augmentation)
 

--- a/docs/migration-plan/phases.json
+++ b/docs/migration-plan/phases.json
@@ -24,9 +24,10 @@
     { "wave": "alpha",   "number": "06", "title": "Class Features",                   "file": "alpha/phase-06-class-features.md",                   "status": "outlined"     },
     { "wave": "alpha",   "number": "07", "title": "Combat Tracker & Turn Economy",    "file": "alpha/phase-07-combat-tracker.md",                   "status": "outlined"     },
     { "wave": "alpha",   "number": "08", "title": "Conditions",                       "file": "alpha/phase-08-conditions.md",                       "status": "outlined"     },
-    { "wave": "alpha",   "number": "09", "title": "Breath Weapon & Area Templates",   "file": "alpha/phase-09-breath-weapon.md",                    "status": "outlined"     },
-    { "wave": "alpha",   "number": "10", "title": "Spells",                           "file": "alpha/phase-10-spells.md",                           "status": "outlined"     },
-    { "wave": "alpha",   "number": "11", "title": "Enhancement",                      "file": "alpha/phase-11-enhancements.md",                     "status": "outlined"     },
+    { "wave": "alpha",   "number": "09", "title": "Buff AE Core",                     "file": "alpha/phase-09-buff-ae-core.md",                     "status": "rough-sketch" },
+    { "wave": "alpha",   "number": "10", "title": "Breath Weapon & Area Templates",   "file": "alpha/phase-10-breath-weapon.md",                    "status": "outlined"     },
+    { "wave": "alpha",   "number": "11", "title": "Spells",                           "file": "alpha/phase-11-spells.md",                           "status": "outlined"     },
+    { "wave": "alpha",   "number": "12", "title": "Enhancement",                      "file": "alpha/phase-12-enhancements.md",                     "status": "outlined"     },
 
     { "wave": "beta",    "number": "01", "title": "Equipment & Loot",                 "file": "beta/phase-01-equipment-loot.md",                    "status": "rough-sketch" },
     { "wave": "beta",    "number": "02", "title": "Spells & Spellbooks",              "file": "beta/phase-02-spells-spellbooks.md",                 "status": "rough-sketch" },

--- a/docs/migration-plan/poc/phase-01-item-foundation.md
+++ b/docs/migration-plan/poc/phase-01-item-foundation.md
@@ -1,4 +1,4 @@
-# Phase 1: Item Foundation (Weapon PoC)
+# POC Phase 1: Item Foundation (Weapon PoC)
 
 **Status**: **COMPLETE** (April 16, 2026)
 

--- a/docs/migration-plan/poc/phase-02-active-effect-on-item.md
+++ b/docs/migration-plan/poc/phase-02-active-effect-on-item.md
@@ -1,4 +1,4 @@
-# Phase 2: Active Effect on Item (Material)
+# POC Phase 2: Active Effect on Item (Material)
 
 **Status**: 🔶 In Progress
 

--- a/docs/migration-plan/poc/phase-02-task-decomposition.md
+++ b/docs/migration-plan/poc/phase-02-task-decomposition.md
@@ -1,4 +1,4 @@
-# Phase 2 Task Decomposition: Active Effect on Item (Material)
+# POC Phase 2 Task Decomposition: Active Effect on Item (Material)
 
 **Milestone**: POC  
 **Phase Duration**: N/A (structure, no timeline)  

--- a/docs/migration-plan/poc/phase-03-localization.md
+++ b/docs/migration-plan/poc/phase-03-localization.md
@@ -1,4 +1,4 @@
-# Phase 3: Localization Pattern
+# POC Phase 3: Localization Pattern
 
 **Status**: ✅ Complete
 

--- a/docs/migration-plan/poc/phase-04-testing-infrastructure.md
+++ b/docs/migration-plan/poc/phase-04-testing-infrastructure.md
@@ -1,4 +1,4 @@
-# Phase 4: Testing Infrastructure
+# POC Phase 4: Testing Infrastructure
 
 
 **Status**: ✅ Complete

--- a/docs/migration-plan/poc/phase-05-compendium-foundation.md
+++ b/docs/migration-plan/poc/phase-05-compendium-foundation.md
@@ -1,4 +1,4 @@
-# Phase 5: Compendium Foundation
+# POC Phase 5: Compendium Foundation
 
 **Status**: ✅ Approved (pack pipeline, origin tracking, authoring workflow, Foundry integration)
 

--- a/docs/migration-plan/poc/phase-06-actor-foundation.md
+++ b/docs/migration-plan/poc/phase-06-actor-foundation.md
@@ -1,4 +1,4 @@
-# Phase 6: Actor Foundation
+# POC Phase 6: Actor Foundation
 
 **Status**: 📋 Outlined (Actor schema, multiclass stacking, ability scores)
 

--- a/docs/migration-plan/poc/phase-07-roll-formulas.md
+++ b/docs/migration-plan/poc/phase-07-roll-formulas.md
@@ -1,4 +1,4 @@
-# Phase 7: Roll Formulas & Custom Rolls
+# POC Phase 7: Roll Formulas & Custom Rolls
 
 **Status**: 📋 Outlined (FormulaFamiliar system, action formulas)
 

--- a/docs/migration-plan/poc/phase-08-pipeline-and-branching.md
+++ b/docs/migration-plan/poc/phase-08-pipeline-and-branching.md
@@ -1,4 +1,4 @@
-# Phase 8: Pipeline & Branching
+# POC Phase 8: Pipeline & Branching
 
 **Status**: 🔶 In Progress
 

--- a/docs/migration-plan/post-release/phase-01-art-module-support.md
+++ b/docs/migration-plan/post-release/phase-01-art-module-support.md
@@ -1,4 +1,4 @@
-# Phase 33: 3rd Party Art Module Support
+# Post-Release Phase 1: 3rd Party Art Module Support
 
 **Status**: 📖 Rough Sketch (300+ item checklist, art module lookup, GM config)
 

--- a/docs/migration-plan/post-release/phase-02-module-integration.md
+++ b/docs/migration-plan/post-release/phase-02-module-integration.md
@@ -1,4 +1,4 @@
-# Phase 34: Module Integration Testing
+# Post-Release Phase 2: Module Integration Testing
 
 **Status**: 📖 Rough Sketch (400+ item checklist, compatibility matrix, testing)
 

--- a/docs/migration-plan/post-release/phase-03-sight-concealment.md
+++ b/docs/migration-plan/post-release/phase-03-sight-concealment.md
@@ -1,4 +1,4 @@
-# Phase 38: Sight Distance / Concealment (Regions)
+# Post-Release Phase 3: Sight Distance / Concealment (Regions)
 
 | Field | Value |
 |-------|-------|

--- a/docs/migration-plan/post-release/phase-04-stat-block-sheet.md
+++ b/docs/migration-plan/post-release/phase-04-stat-block-sheet.md
@@ -1,4 +1,4 @@
-# Phase 39: Stat Block Sheet (NPC Alternate View)
+# Post-Release Phase 4: Stat Block Sheet (NPC Alternate View)
 
 | Field | Value |
 |-------|-------|

--- a/docs/migration-plan/post-release/phase-05-vigor-wound-hp.md
+++ b/docs/migration-plan/post-release/phase-05-vigor-wound-hp.md
@@ -1,4 +1,4 @@
-# Phase 40: Vigor/Wound Variant HP
+# Post-Release Phase 5: Vigor/Wound Variant HP
 
 | Field | Value |
 |-------|-------|

--- a/docs/migration-plan/post-release/phase-06-environmental-hazards.md
+++ b/docs/migration-plan/post-release/phase-06-environmental-hazards.md
@@ -1,4 +1,4 @@
-# Phase 41: Environmental Hazards & Overland Travel
+# Post-Release Phase 6: Environmental Hazards & Overland Travel
 
 | Field | Value |
 |-------|-------|

--- a/docs/migration-plan/post-release/phase-07-divine-rules.md
+++ b/docs/migration-plan/post-release/phase-07-divine-rules.md
@@ -1,4 +1,4 @@
-# Phase 42: Divine Rules (Divine Ranks & Powers)
+# Post-Release Phase 7: Divine Rules (Divine Ranks & Powers)
 
 | Field | Value |
 |-------|-------|

--- a/docs/migration-plan/post-release/phase-08-variant-rules.md
+++ b/docs/migration-plan/post-release/phase-08-variant-rules.md
@@ -1,4 +1,4 @@
-# Phase 43: Variant Rules (Unearthed Arcana OGC)
+# Post-Release Phase 8: Variant Rules (Unearthed Arcana OGC)
 
 | Field | Value |
 |-------|-------|

--- a/docs/migration-plan/post-release/phase-09-random-treasure.md
+++ b/docs/migration-plan/post-release/phase-09-random-treasure.md
@@ -1,4 +1,4 @@
-# Phase 44: Random Treasure Generation
+# Post-Release Phase 9: Random Treasure Generation
 
 | Field | Value |
 |-------|-------|

--- a/docs/migration-plan/release/phase-01-compendium-browser.md
+++ b/docs/migration-plan/release/phase-01-compendium-browser.md
@@ -1,4 +1,4 @@
-# Phase 29: Compendium Browser & Management
+# Release Phase 1: Compendium Browser & Management
 
 **Status**: 📖 Rough Sketch (200+ item checklist, compendium browser, version tracking)
 

--- a/docs/migration-plan/release/phase-02-documentation-srd.md
+++ b/docs/migration-plan/release/phase-02-documentation-srd.md
@@ -1,4 +1,4 @@
-# Phase 32: User Guide & Documentation Finalization + SRD Housing
+# Release Phase 2: User Guide & Documentation Finalization + SRD Housing
 
 **Status**: 📖 Rough Sketch (350+ item checklist, user guide, SRD housing)
 

--- a/docs/migration-plan/release/phase-03-epic-level-rules.md
+++ b/docs/migration-plan/release/phase-03-epic-level-rules.md
@@ -1,4 +1,4 @@
-# Phase 35: Epic Level Rules
+# Release Phase 3: Epic Level Rules
 
 | Field | Value |
 |-------|-------|
@@ -15,7 +15,7 @@ Characters beyond 20th level enter the **epic** tier. BAB and saves switch to a 
 
 ---
 
-## 35.1 Epic Level Detection
+## 3.1 Epic Level Detection
 
 The epic threshold is **total base + prestige class levels ≥ 21**. Racial HD do not count toward this threshold (matching SRD and D35E behavior).
 
@@ -30,7 +30,7 @@ The level-up flow (Phase 9 §8.6) needs no structural change — epic characters
 
 ---
 
-## 35.2 Epic BAB & Saves
+## 3.2 Epic BAB & Saves
 
 ### BAB
 
@@ -54,7 +54,7 @@ The class AE generation in `prepareDerivedData()` (Phase 9) splits at the epic t
 
 ---
 
-## 35.3 Epic Milestones
+## 3.3 Epic Milestones
 
 | Milestone | Non-Epic Schedule | Epic Schedule |
 |-----------|------------------|---------------|
@@ -67,7 +67,7 @@ The level-up flow detects epic feat milestones at `(totalClassLevels - 20) % 3 =
 
 ---
 
-## 35.4 Epic Feats
+## 3.4 Epic Feats
 
 Epic feats use the existing `FeatSystemModel` (Phase 11) with an `isEpic: true` flag — not a separate item type. This matches D35E's `itemDescription.epic` field approach.
 
@@ -90,7 +90,7 @@ The prerequisite registry (Phase 9) already supports all these check types — n
 
 ---
 
-## 35.5 Epic Spellcasting
+## 3.5 Epic Spellcasting
 
 Epic spells (level 10+) use the **Spellcraft DC** system, not standard spell slots.
 
@@ -120,7 +120,7 @@ Epic spells appear in a dedicated "Epic" section of the spellbook (matching D35E
 
 ---
 
-## 35.6 Epic Enhancements & DR
+## 3.6 Epic Enhancements & DR
 
 ### Epic Weapons for DR
 
@@ -132,7 +132,7 @@ A new DR type entry: `epic`. Only epic weapons bypass it. Fits into the existing
 
 ---
 
-## 35.7 D35E Migration Notes
+## 3.7 D35E Migration Notes
 
 | D35E Feature | dnd35e Equivalent |
 |--------------|-------------------|

--- a/docs/migration-plan/release/phase-04-psionic-rules-full.md
+++ b/docs/migration-plan/release/phase-04-psionic-rules-full.md
@@ -1,4 +1,4 @@
-# Phase 36: Psionic Rules (Full)
+# Release Phase 4: Psionic Rules (Full)
 
 | Field | Value |
 |-------|-------|
@@ -15,7 +15,7 @@ Phase 28 (Beta) builds the psionic foundation: power item type (`isPsionic` on S
 
 ---
 
-## 36.1 Psi-Spell Transparency
+## 4.1 Psi-Spell Transparency
 
 The SRD default: **psionics and magic are transparent to each other**. This is the most impactful architectural decision because it determines whether psionic effects interact with the existing spell infrastructure or need a parallel system.
 
@@ -49,7 +49,7 @@ With separate mode:
 
 ---
 
-## 36.2 Psionic Prestige Classes
+## 4.2 Psionic Prestige Classes
 
 Psionic prestige classes use the existing Class item with `isPsionic: true` on their progression. Key SRD psionic prestige classes:
 
@@ -78,7 +78,7 @@ The level-up flow prompts the player to select which arcane class and which psio
 
 ---
 
-## 36.3 Psionic Feats
+## 4.3 Psionic Feats
 
 Psionic feats use the existing `FeatSystemModel` with `isPsionic: true`. Key categories:
 
@@ -108,7 +108,7 @@ Regaining focus: Full-round action, Concentration check DC 20. The Psionic Medit
 
 ---
 
-## 36.4 Psionic Items
+## 4.4 Psionic Items
 
 Psionic items parallel magic item categories and use the existing Enhancement (Phase 25) and Consumable (Phase 22) infrastructure.
 
@@ -147,7 +147,7 @@ totalAvailablePP = spellbook.spellPoints.value + sum(equippedCognizanceCrystals.
 
 ---
 
-## 36.5 Full Power Compendium
+## 4.5 Full Power Compendium
 
 Phase 28 implements 3 POC powers. This phase packs all SRD psionic powers (approximately 200+) into compendium packs.
 
@@ -167,7 +167,7 @@ Each power's `system.school` field maps to a discipline when `isPsionic` is true
 
 ---
 
-## 36.6 Epic Psionics
+## 4.6 Epic Psionics
 
 Mirrors epic spellcasting (Phase 35 §35.5) for psionic manifesters. Requires Phase 35 to be implemented first.
 
@@ -180,7 +180,7 @@ Epic psionic items (e.g., Rings of Epic Psionics referenced in D35E's changelog)
 
 ---
 
-## 36.7 D35E Migration Notes
+## 4.7 D35E Migration Notes
 
 | D35E Feature | dnd35e Equivalent |
 |--------------|-------------------|

--- a/docs/migration-plan/release/phase-05-cards.md
+++ b/docs/migration-plan/release/phase-05-cards.md
@@ -1,4 +1,4 @@
-# Phase 37: Cards
+# Release Phase 5: Cards
 
 **Status**: 📖 Rough Sketch (200+ item checklist, card types, counter mechanics)
 

--- a/docs/migration-plan/release/phase-06-content-migration.md
+++ b/docs/migration-plan/release/phase-06-content-migration.md
@@ -1,4 +1,4 @@
-# Phase 30: Content Migration
+# Release Phase 6: Content Migration
 
 **Status**: 📖 Rough Sketch (300+ item checklist, D35E→dnd35e migration, world transformer)
 

--- a/docs/migration-plan/release/phase-07-community-hardening.md
+++ b/docs/migration-plan/release/phase-07-community-hardening.md
@@ -1,4 +1,4 @@
-# Phase 31: Community Hardening
+# Release Phase 7: Community Hardening
 
 **Status**: 📖 Rough Sketch (300+ item checklist, feedback collection, balance tuning)
 
@@ -8,7 +8,7 @@
 
 ---
 
-## 31.1 Why Community Hardening First
+## 7.1 Why Community Hardening First
 
 Release (Phase 27) is technically complete but not battle-tested at scale. Defaults might be wrong. GMs might want visibility controls we didn't anticipate. Players might find combinations that break balance. Phase 31 is about:
 - **Collecting feedback** from real GMs running real campaigns
@@ -19,7 +19,7 @@ Release (Phase 27) is technically complete but not battle-tested at scale. Defau
 
 ---
 
-## 31.2 Feedback Collection
+## 7.2 Feedback Collection
 
 Target **100+ active campaign reports** across 4-8 weeks:
 
@@ -44,7 +44,7 @@ This gives comparable data: "In 50 test runs, combat took X minutes on average."
 
 ---
 
-## 31.3 Default Value Tuning
+## 7.3 Default Value Tuning
 
 ### Ability Modifier Formula
 Current: `floor((score - 10) / 2)`  
@@ -69,7 +69,7 @@ Possible tuning:
 
 ---
 
-## 31.4 Visibility/Editability Survey
+## 7.4 Visibility/Editability Survey
 
 Create a **sheet layout questionnaire**:
 
@@ -94,7 +94,7 @@ Create a **sheet layout questionnaire**:
 
 ---
 
-## 31.5 Community Settings Migration
+## 7.5 Community Settings Migration
 
 Based on feedback, create `system.json` settings:
 
@@ -128,7 +128,7 @@ Each setting has a rationale from community feedback.
 
 ---
 
-## 31.6 Balance Report
+## 7.6 Balance Report
 
 Publish findings:
 - **Encounter Time**: "Average encounters took X minutes. Outliers: Y."
@@ -140,7 +140,7 @@ Use this to justify any Phase 29+ changes.
 
 ---
 
-## 31.7 Documentation of Field Overrides
+## 7.7 Documentation of Field Overrides
 
 Create a reference document:
 
@@ -166,7 +166,7 @@ This becomes the foundation for Phase 29 (Documentation) field-by-field breakdow
 
 ---
 
-## 31.8 Known Issues Log
+## 7.8 Known Issues Log
 
 If issues are found:
 - **Critical** (breaks core functionality): Fix immediately, don't wait for Phase 29
@@ -182,7 +182,7 @@ Example:
 
 ---
 
-## 31.9 Files to Create/Modify
+## 7.9 Files to Create/Modify
 
 | Action | Path |
 |--------|------|
@@ -614,7 +614,7 @@ Example:
 
 ---
 
-## 31.10 Success Criteria
+## 7.10 Success Criteria
 
 ✅ **100+ reports** from active campaigns  
 ✅ **Canonical test scenario** completed by 50+ testers with timing data  
@@ -626,7 +626,7 @@ Example:
 
 ---
 
-## 31.11 Timeline
+## 7.11 Timeline
 
 - **Week 1**: Release survey + canonical test scenario
 - **Weeks 2-6**: Active collection + spot-check reports
@@ -636,7 +636,7 @@ Example:
 
 ---
 
-## 31.12 3-State AE Visibility (from Phase 2 §2.12)
+## 7.12 3-State AE Visibility (from Phase 2 §2.12)
 
 Upgrade from 2-state (hidden/identified) to 3-state (unknown / known-unidentified / identified). Community hardening is the natural fit for UX refinements informed by beta feedback.
 
@@ -646,7 +646,7 @@ Upgrade from 2-state (hidden/identified) to 3-state (unknown / known-unidentifie
 
 ---
 
-## 31.13 Deferred to Phase 29
+## 7.13 Deferred to Phase 29
 
 - Full user guide (waits for Phase 28 feedback)
 - Balanced feat recommendations (after Phase 28 balance data)

--- a/docs/migration-plan/roadmap.md
+++ b/docs/migration-plan/roadmap.md
@@ -189,7 +189,7 @@ Dependencies use `wave.N` notation (e.g. `poc.1`, `alpha.3`, `beta.2`).
 
 ### Wave: Alpha — Paladin vs Dragon
 
-`docs/migration-plan/alpha/` | alpha.1–alpha.11
+`docs/migration-plan/alpha/` | alpha.1–alpha.12
 
 **Goal**: A playable combat scenario proving "one of everything." A level 5 Paladin (Human) with a +1 longsword vs a Young Adult Black Dragon.
 
@@ -203,9 +203,10 @@ Dependencies use `wave.N` notation (e.g. `poc.1`, `alpha.3`, `beta.2`).
 | 6 | [Class Features](alpha/phase-06-class-features.md) | 📋 Outlined | alpha.2, alpha.3, alpha.4 | Paladin: Divine Grace (CHA→saves), Smite Evil (per-day toggle), Lay on Hands (pool healing), Aura of Courage (+4 morale vs fear) |
 | 7 | [Combat Tracker & Turn Economy](alpha/phase-07-combat-tracker.md) | 📋 Outlined | alpha.3 | Initiative, TurnActionBudget state machine, progressive full attack, token movement with action cost, turn hooks, flat-footed |
 | 8 | [Conditions](alpha/phase-08-conditions.md) | 📋 Outlined | alpha.3 | Prone (trip pipeline), Frightful Presence → Shaken/Frightened (fear track stub), condition manager, token icons, stand-up action |
-| 9 | [Breath Weapon & Area Templates](alpha/phase-09-breath-weapon.md) | 📋 Outlined | alpha.3, alpha.7 | Line and cone MeasuredTemplate placement, Reflex save workflow, area damage application, breath weapon recharge |
-| 10 | [Spells](alpha/phase-10-spells.md) | 📋 Outlined | poc.6, poc.7, alpha.3 | Spell item type, Paladin spellbook, 1st-level slots, cast action, Bless/Protection from Evil/Divine Favor/Cure Light Wounds |
-| 11 | [Enhancement](alpha/phase-11-enhancements.md) | 📋 Outlined | poc.1, poc.2 | +1 longsword: minimal EnhancementSystemModel, one AE with +1 enhancement to attack/damage |
+| 9 | [Buff AE Core](alpha/phase-09-buff-ae-core.md) | 📖 Rough Sketch | poc.2, poc.6 | Buff AE subtype: `BuffSystemModel` (active, round-based duration, description), combat-tracker turn-start tick → expiry, deactivation suppression. Minimum surface for alpha.11 spell buffs. Stacking collision proof (Aura of Courage suppresses Bless on fear saves). |
+| 10 | [Breath Weapon & Area Templates](alpha/phase-10-breath-weapon.md) | 📋 Outlined | alpha.3, alpha.7 | Line and cone MeasuredTemplate placement, Reflex save workflow, area damage application, breath weapon recharge |
+| 11 | [Spells](alpha/phase-11-spells.md) | 📋 Outlined | poc.6, poc.7, alpha.3, alpha.9 | Spell item type, Paladin spellbook, 1st-level slots, cast action, Bless/Protection from Evil/Divine Favor/Cure Light Wounds |
+| 12 | [Enhancement](alpha/phase-12-enhancements.md) | 📋 Outlined | poc.1, poc.2 | +1 longsword: minimal EnhancementSystemModel, one AE with +1 enhancement to attack/damage |
 
 **Exit criteria**: A GM can create a level 5 Paladin (Human) with a +1 longsword and a Young Adult Black Dragon, enter combat, roll initiative, take turns with the progressive full attack state machine, apply Power Attack per-attack, get a Cleave bonus attack on kill, activate Smite Evil via PreRollDialog, use Lay on Hands to heal, cast Bless and Divine Favor (RAW spell slots), see morale stacking collision on fear saves (Aura of Courage +4 suppresses Bless +1), trip an enemy to apply Prone, use a breath weapon (line template with Reflex save), trigger Frightful Presence (Will save vs fear with Aura of Courage granting +4 morale), see natural attacks use primary/secondary rules, and view all results in per-attack chat cards.
 
@@ -225,7 +226,7 @@ Dependencies use `wave.N` notation (e.g. `poc.1`, `alpha.3`, `beta.2`).
 |---|-------|--------|--------------|-------|
 | 1 | [Equipment & Loot](beta/phase-01-equipment-loot.md) | 📖 Rough Sketch | poc.6, poc.7 | Armor, Shield, Equipment, Loot, Container, Ammo. Full AC calculation. ACP, spell failure, encumbrance. |
 | 2 | [Spells & Spellbooks (Full)](beta/phase-02-spells-spellbooks.md) | 📖 Rough Sketch | poc.7, alpha.3, alpha.10 | All caster types, all spell levels, SR, concentration, counterspelling stubs. Multiple spellbooks. |
-| 3 | [Buffs & Conditions (Full)](beta/phase-03-buffs-conditions.md) | 📖 Rough Sketch | alpha.8, beta.1 | All 25+ conditions, BuffSystemModel AE, ability damage/drain, energy drain, fast healing, regeneration, disease, full fear track |
+| 3 | [Buff AE Expansion & Conditions (Full)](beta/phase-03-buffs-conditions.md) | 📖 Rough Sketch | alpha.8, alpha.9, beta.1 | Buff AE expansion over alpha.9 (`buffType` taxonomy, timeline formulas, damage pools, shapechange, dedicated Buffs sheet section), all 25+ conditions, ability damage/drain, energy drain, fast healing, regeneration, disease, full fear track, D35E `buff` item → Buff AE data migration |
 | 4 | [Advanced Classes](beta/phase-04-advanced-classes.md) | 📄 Stub | alpha.2 | Prestige classes, NPC classes, racial paragon, substitution levels. Stub — design not started. |
 | 5 | [Consumables](beta/phase-05-consumables.md) | 📖 Rough Sketch | alpha.3 | Potion, scroll, wand, poison. Action snapshot pattern. Charges/uses. Splash weapons. |
 | 6 | [Advanced Actors](beta/phase-06-advanced-actors.md) | 📖 Rough Sketch | poc.6, alpha.1, alpha.2 | NPC, Trap, Object actor types. Companion bond system (familiar, animal companion, mount, summon, cohort). Portrait Bar (Party HUD). |
@@ -309,9 +310,10 @@ flowchart TD
         A6["alpha.6 Class Features"]
         A7["alpha.7 Combat Tracker"]
         A8["alpha.8 Conditions"]
-        A9["alpha.9 Breath Weapon"]
-        A10["alpha.10 Spells"]
-        A11["alpha.11 Enhancement"]
+        A9["alpha.9 Buff AE Core"]
+        A10["alpha.10 Breath Weapon"]
+        A11["alpha.11 Spells"]
+        A12["alpha.12 Enhancement"]
         A1 --> A2
         A2 --> A3
         A3 --> A4
@@ -321,17 +323,20 @@ flowchart TD
         A2 --> A6
         A3 --> A7
         A3 --> A8
-        A3 --> A9
-        A7 --> A9
         A3 --> A10
+        A7 --> A10
+        A3 --> A11
+        A9 --> A11
     end
     P5 --> A1
     P7 --> A1
     P6 --> A4
-    P6 --> A10
-    P7 --> A10
-    P1 --> A11
-    P2 --> A11
+    P6 --> A11
+    P7 --> A11
+    P2 --> A9
+    P6 --> A9
+    P1 --> A12
+    P2 --> A12
 
     subgraph BETA["🟭 Beta — Full System Coverage"]
         B1["beta.1 Equipment"]
@@ -350,17 +355,18 @@ flowchart TD
     P7 --> B1
     P7 --> B2
     A3 --> B2
-    A10 --> B2
+    A11 --> B2
     A8 --> B3
+    A9 --> B3
     B1 --> B3
     A2 --> B4
     A3 --> B5
     P6 --> B6
     A1 --> B6
     A2 --> B6
-    A9 --> B7
+    A10 --> B7
     B2 --> B7
-    A11 --> B8
+    A12 --> B8
     B1 --> B8
     A4 --> B9
     B2 --> B9
@@ -511,7 +517,7 @@ Some spells and effects target **items**, not creatures (Magic Weapon, Magic Ves
 | Class | Class item | 9 | Restructured progression |
 | Spell | Spell item | 17 (Alpha), 20 (Full) | Restructured |
 | Feat | Feat item | 11 | combatChanges → AE pattern |
-| Buff | **Buff Active Effect** | 21 | Item → AE migration |
+| Buff | **Buff Active Effect** | alpha.9 (core), beta.3 (expansion + item→AE migration) | Alpha introduces the minimal AE subtype (active, round duration, changes via stacking engine); beta.3 adds buffType / timeline / damage pool / shapechange and migrates D35E `buff` items |
 | Attack | Attack item | 10 | Actions via Action System |
 | Race | Race item | 8 | Restructured with grants |
 | Enhancement | **Enhancement Active Effect** | 18 (Alpha), 25 (Full) | Item → AE |
@@ -549,7 +555,7 @@ Every D35E feature, every SRD rule area, accounted for. Nothing dropped.
 | class | Class item | 9 | Restructured progression |
 | spell | Spell item | 17 (Alpha), 20 (Full) | Restructured |
 | feat | Feat item | 11 | combatChanges → AE pattern |
-| buff | **Buff Active Effect** | 21 | Item → AE migration |
+| buff | **Buff Active Effect** | alpha.9 (core), beta.3 (expansion + item→AE migration) | Alpha introduces the minimal AE subtype; beta.3 adds the full schema and migrates D35E `buff` items |
 | attack | Natural Attack item | 12 | Actions via Action System |
 | race | Race item | 8 | Restructured with grants |
 | enhancement | **Enhancement Active Effect** | 18 (Alpha), 25 (Full) | Item → AE |

--- a/docs/migration-plan/roadmap.md
+++ b/docs/migration-plan/roadmap.md
@@ -225,13 +225,13 @@ Dependencies use `wave.N` notation (e.g. `poc.1`, `alpha.3`, `beta.2`).
 | # | Phase | Status | Dependencies | Notes |
 |---|-------|--------|--------------|-------|
 | 1 | [Equipment & Loot](beta/phase-01-equipment-loot.md) | 📖 Rough Sketch | poc.6, poc.7 | Armor, Shield, Equipment, Loot, Container, Ammo. Full AC calculation. ACP, spell failure, encumbrance. |
-| 2 | [Spells & Spellbooks (Full)](beta/phase-02-spells-spellbooks.md) | 📖 Rough Sketch | poc.7, alpha.3, alpha.10 | All caster types, all spell levels, SR, concentration, counterspelling stubs. Multiple spellbooks. |
+| 2 | [Spells & Spellbooks (Full)](beta/phase-02-spells-spellbooks.md) | 📖 Rough Sketch | poc.7, alpha.3, alpha.11 | All caster types, all spell levels, SR, concentration, counterspelling stubs. Multiple spellbooks. |
 | 3 | [Buff AE Expansion & Conditions (Full)](beta/phase-03-buffs-conditions.md) | 📖 Rough Sketch | alpha.8, alpha.9, beta.1 | Buff AE expansion over alpha.9 (`buffType` taxonomy, timeline formulas, damage pools, shapechange, dedicated Buffs sheet section), all 25+ conditions, ability damage/drain, energy drain, fast healing, regeneration, disease, full fear track, D35E `buff` item → Buff AE data migration |
 | 4 | [Advanced Classes](beta/phase-04-advanced-classes.md) | 📄 Stub | alpha.2 | Prestige classes, NPC classes, racial paragon, substitution levels. Stub — design not started. |
 | 5 | [Consumables](beta/phase-05-consumables.md) | 📖 Rough Sketch | alpha.3 | Potion, scroll, wand, poison. Action snapshot pattern. Charges/uses. Splash weapons. |
 | 6 | [Advanced Actors](beta/phase-06-advanced-actors.md) | 📖 Rough Sketch | poc.6, alpha.1, alpha.2 | NPC, Trap, Object actor types. Companion bond system (familiar, animal companion, mount, summon, cohort). Portrait Bar (Party HUD). |
-| 7 | [Area Effects & Auras (Full)](beta/phase-07-area-effects-auras.md) | 📖 Rough Sketch | alpha.9, beta.2 | Foundry V14 Region behaviors, persistent auras, AE delivery, duration tracking, DoT. Aura of Courage expands to affect allies in 10ft. |
-| 8 | [Enhancements (Full)](beta/phase-08-enhancements.md) | 📖 Rough Sketch | alpha.11, beta.1 | +1 through +5, special weapon/armor abilities, cursed items (minimal). Magic Weapon spell stacking proof. |
+| 7 | [Area Effects & Auras (Full)](beta/phase-07-area-effects-auras.md) | 📖 Rough Sketch | alpha.10, beta.2 | Foundry V14 Region behaviors, persistent auras, AE delivery, duration tracking, DoT. Aura of Courage expands to affect allies in 10ft. |
+| 8 | [Enhancements (Full)](beta/phase-08-enhancements.md) | 📖 Rough Sketch | alpha.12, beta.1 | +1 through +5, special weapon/armor abilities, cursed items (minimal). Magic Weapon spell stacking proof. |
 | 9 | [Metamagic](beta/phase-09-metamagic.md) | 📖 Rough Sketch | alpha.4, beta.2 | Metamagic feats, spell level adjustment, prepared vs spontaneous timing. |
 | 10 | [Full Spells](beta/phase-10-full-spells.md) | 📖 Rough Sketch | beta.7, beta.9 | SR, concentration, counterspelling, all delivery types, AoE spell chains. |
 | 11 | [Psionics](beta/phase-11-psionics.md) | 📖 Rough Sketch | beta.2 | Power item, power points, augmentation, psionic disciplines, manifester level. |


### PR DESCRIPTION
﻿## Summary

Inserts a dedicated **alpha.9 Buff AE Core** phase into the roadmap so alpha.11 Spells (Bless, Protection from Evil, Divine Favor) has the Buff Active Effect subtype it needs. Renumbers former alpha.9/10/11 to alpha.10/11/12 and retitles beta.3 to `Buff AE Expansion & Conditions (Full)` to reflect that it now extends the alpha core rather than introducing buffs from scratch.

Also performs a mechanical sweep that updates every phase doc's H1 header and in-body section number prefixes from the legacy global numbering to the wave-restart scheme.

## Why

Buff AEs were only scheduled in beta.3, but alpha.11 spells need them. Scheduling a minimum Buff AE in alpha closes that gap and gives us the stacking-collision proof (Aura of Courage suppresses Bless on fear saves) as the alpha exit criterion it was always meant to be.

## Commits

1. `plan: insert alpha.9 Buff AE Core; renumber alpha.10/11/12` ΓÇö new phase doc, renames, `phases.json` update, `roadmap.md` table/dep graph/mapping rows, cross-refs in alpha 07/08/11 + beta.3, PropertyMap-ActiveEffects.md alpha/beta split.
2. `plan: wave-restart headers and section prefixes across phase docs` ΓÇö mechanical rewrite of H1 headers (e.g. `# Phase 14 ΓÇö Conditions` → `# Alpha Phase 8 ΓÇö Conditions`) and section prefixes (e.g. `## 14.1` → `## 8.1`) across 43 phase docs.

## Deferred

Cross-phase **prose** references like `Phase 27 (Content Migration)` still appear inline. A flat substitution is unsafe ΓÇö the same legacy number maps to different things in different docs (e.g. `Phase 21` is used for both Buffs and Consumables in different files). Those will land in a follow-up PR with per-doc contextual translation.

## Test Plan

Docs-only PR ΓÇö no build/test impact. Review the new `alpha/phase-09-buff-ae-core.md` for design soundness; spot-check the dependency graph and alpha/beta tables in `roadmap.md`.
