### PR TITLE
refactor(pr02): DnD35e -> Dnd35e casing sweep

### DIFF
--- a/docs/migration-plan/poc/refactor-naming-conventions.md
+++ b/docs/migration-plan/poc/refactor-naming-conventions.md
@@ -390,14 +390,14 @@ Every numbered task ends with `npm run build` exit 0. Failures block the next ta
 - [x] G1.4 — `npm run build` clean; commit
 
 ### Group 2: `DnD` → `Dnd` casing
-- [ ] G2.1 — Rename file `DnD35eActiveEffect.mts` → `Dnd35eActiveEffect.mts` (use temp-name two-step on Windows)
-- [ ] G2.2 — Rename class `DnD35eActiveEffect` → `Dnd35eActiveEffect`
-- [ ] G2.3 — Rename type `DnD35eActiveEffectFlags` → `Dnd35eActiveEffectFlags`
-- [ ] G2.4 — Rename local const `DnD35eActiveEffectBase` → `Dnd35eActiveEffectBase`
-- [ ] G2.5 — Workspace-wide replace of all `DnD35e` → `Dnd35e` (case-sensitive)
-- [ ] G2.6 — Re-run eslint --fix on touched files
-- [ ] G2.7 — `grep_search` for `DnD35e` workspace-wide; expect zero matches in `src/` and `tests/`
-- [ ] G2.8 — `npm run build` clean; commit
+- [x] G2.1 — Rename file `DnD35eActiveEffect.mts` → `Dnd35eActiveEffect.mts` (use temp-name two-step on Windows)
+- [x] G2.2 — Rename class `DnD35eActiveEffect` → `Dnd35eActiveEffect`
+- [x] G2.3 — Rename type `DnD35eActiveEffectFlags` → `Dnd35eActiveEffectFlags`
+- [x] G2.4 — Rename local const `DnD35eActiveEffectBase` → `Dnd35eActiveEffectBase`
+- [x] G2.5 — Workspace-wide replace of all `DnD35e` → `Dnd35e` (case-sensitive)
+- [x] G2.6 — Re-run eslint --fix on touched files
+- [x] G2.7 — `grep_search` for `DnD35e` workspace-wide; expect zero matches in `src/` and `tests/`
+- [x] G2.8 — `npm run build` clean; commit
 
 ### Group 3a: `BaseDnd35eSystemData` → `DocumentSystemData`
 - [ ] G3a.1 — Rename file `BaseDnd35eSystemData.mts` → `DocumentSystemData.mts`

--- a/docs/migration-plan/poc/refactor-naming-conventions.md
+++ b/docs/migration-plan/poc/refactor-naming-conventions.md
@@ -394,9 +394,9 @@ Every numbered task ends with `npm run build` exit 0. Failures block the next ta
 - [x] G2.2 — Rename class `DnD35eActiveEffect` → `Dnd35eActiveEffect`
 - [x] G2.3 — Rename type `DnD35eActiveEffectFlags` → `Dnd35eActiveEffectFlags`
 - [x] G2.4 — Rename local const `DnD35eActiveEffectBase` → `Dnd35eActiveEffectBase`
-- [x] G2.5 — Workspace-wide replace of all `DnD35e` → `Dnd35e` (case-sensitive)
+- [x] G2.5 — Replace `DnD35e` → `Dnd35e` across production-code paths (case-sensitive; e.g. `src/`, `tests/`, and related type/runtime files), not attribution/docs-only references
 - [x] G2.6 — Re-run eslint --fix on touched files
-- [x] G2.7 — `grep_search` for `DnD35e` workspace-wide; expect zero matches in `src/` and `tests/`
+- [x] G2.7 — Run `grep_search` for `DnD35e` from the workspace root; expect zero matches in `src/` and `tests/` (non-code references such as README/docs/scripts may remain intentionally)
 - [x] G2.8 — `npm run build` clean; commit
 
 ### Group 3a: `BaseDnd35eSystemData` → `DocumentSystemData`

--- a/src/entities/activeEffects/BaseActiveEffect/Dnd35eActiveEffect.mts
+++ b/src/entities/activeEffects/BaseActiveEffect/Dnd35eActiveEffect.mts
@@ -10,7 +10,7 @@ import { LogHelper } from '@helpers/logHelper.mjs';
 import type { ItemDnd35e } from '@items/baseItem/index.mjs';
 import type { ItemType } from '@items/itemTypes.mjs';
 
-type DnD35eActiveEffectFlags<T extends object = Record<string, unknown>> = Record<string, Record<string, unknown>> & {
+type Dnd35eActiveEffectFlags<T extends object = Record<string, unknown>> = Record<string, Record<string, unknown>> & {
   dnd35e: T;
 };
 
@@ -22,15 +22,15 @@ type Dnd35eActiveEffectSource<
 // Apply mixin at runtime but cast to preserve generic parameter compatibility.
 // TypeScript mixins erase generics; this cast is safe because the mixin only adds
 // methods/properties and doesn't alter the constructor signature's generic behavior.
-const DnD35eActiveEffectBase = Dnd35eDocumentMixin(foundry.documents.ActiveEffect) as unknown as typeof foundry.documents.ActiveEffect;
+const Dnd35eActiveEffectBase = Dnd35eDocumentMixin(foundry.documents.ActiveEffect) as unknown as typeof foundry.documents.ActiveEffect;
 
-class DnD35eActiveEffect<
+class Dnd35eActiveEffect<
   TParent extends ActorDnd35e | ItemDnd35e<ItemType> | null = ActorDnd35e | ItemDnd35e<ItemType> | null,
   TEffectType extends EffectType = EffectType,
   TSystemData extends ActiveEffectSystemData = ActiveEffectSystemData
 >
-  extends DnD35eActiveEffectBase<TParent> {
-  declare flags: DnD35eActiveEffectFlags;
+  extends Dnd35eActiveEffectBase<TParent> {
+  declare flags: Dnd35eActiveEffectFlags;
   declare system: TSystemData;
   declare type: TEffectType;
 
@@ -68,7 +68,7 @@ class DnD35eActiveEffect<
   }
 }
 
-const ActiveEffectProxyDnd35e = new Proxy(DnD35eActiveEffect, {
+const ActiveEffectProxyDnd35e = new Proxy(Dnd35eActiveEffect, {
   construct (
     _target,
     args: [source: PreCreate<Dnd35eActiveEffectSource>, context?: DocumentConstructionContext<ActorDnd35e | ItemDnd35e<ItemType> | null>]
@@ -84,16 +84,16 @@ const ActiveEffectProxyDnd35e = new Proxy(DnD35eActiveEffect, {
     }
 
     if (type === GENERAL_EFFECT_TYPE) {
-      return new DnD35eActiveEffect(...args);
+      return new Dnd35eActiveEffect(...args);
     }
-    const ItemClass = CONFIG.dnd35e.activeEffect.documentClasses[type] as unknown as typeof DnD35eActiveEffect;
+    const ItemClass = CONFIG.dnd35e.activeEffect.documentClasses[type] as unknown as typeof Dnd35eActiveEffect;
     if (!ItemClass) {
       LogHelper.error(`ActiveEffect type ${type} does not exist or is not properly supported for ActiveEffectProxyDnd35e`);
-      return new DnD35eActiveEffect(...args);
+      return new Dnd35eActiveEffect(...args);
     }
     return new ItemClass(...args);
   },
 });
 
-export { ActiveEffectProxyDnd35e, DnD35eActiveEffect };
-export type { DnD35eActiveEffectFlags };
+export { ActiveEffectProxyDnd35e, Dnd35eActiveEffect };
+export type { Dnd35eActiveEffectFlags };

--- a/src/entities/activeEffects/BaseActiveEffect/index.mts
+++ b/src/entities/activeEffects/BaseActiveEffect/index.mts
@@ -22,12 +22,12 @@ import {
   SYSTEM_CHANGE_TYPE,
 } from './data/index.mjs';
 import type {
-  DnD35eActiveEffectFlags,
-} from './DnD35eActiveEffect.mjs';
+  Dnd35eActiveEffectFlags,
+} from './Dnd35eActiveEffect.mjs';
 import {
   ActiveEffectProxyDnd35e,
-  DnD35eActiveEffect,
-} from './DnD35eActiveEffect.mjs';
+  Dnd35eActiveEffect,
+} from './Dnd35eActiveEffect.mjs';
 import type {
   ActiveEffectConfigStore,
   ActiveEffectConfigStoreDocumentActions,
@@ -53,7 +53,7 @@ export type {
   ActiveEffectSystemData,
   ActiveEffectTarget,
   ActiveEffectTargetLocalizationValues,
-  DnD35eActiveEffectFlags,
+  Dnd35eActiveEffectFlags,
   Dnd35eActiveEffectSystemSource,
   Dnd35eChangeType,
   Dnd35eEffectChangeData,
@@ -67,7 +67,7 @@ export {
   ActiveEffectProxyDnd35e,
   ActiveEffectSystemModelBase,
   ALL_CHANGE_TYPES,
-  DnD35eActiveEffect,
+  Dnd35eActiveEffect,
   Dnd35eActiveEffectConfig,
   EFFECT_CHANGE_PHASES,
   EFFECT_CHANGE_TARGET,

--- a/src/entities/activeEffects/BaseActiveEffect/resolveChangeValue.mts
+++ b/src/entities/activeEffects/BaseActiveEffect/resolveChangeValue.mts
@@ -3,7 +3,7 @@ import { EFFECT_CHANGE_TARGET } from '@effects/BaseActiveEffect/data/constants.m
 import { buildDocumentDataMap, FormulaData } from '@helpers/formulae/index.mjs';
 import type { ItemDnd35e } from '@items/baseItem/index.mjs';
 
-import type { DnD35eActiveEffect } from './DnD35eActiveEffect.mjs';
+import type { Dnd35eActiveEffect } from './Dnd35eActiveEffect.mjs';
 
 const {
   BooleanField,
@@ -14,7 +14,7 @@ const {
 type SupportedEffectParent = foundry.documents.Actor | ItemDnd35e | null;
 
 function getEffectContexts(
-  effect: DnD35eActiveEffect,
+  effect: Dnd35eActiveEffect,
   change: Dnd35eEffectChangeData
 ): {
   targetDocument: foundry.abstract.Document | null;
@@ -85,7 +85,7 @@ function tryEvaluateNumber(expression: string): number | null {
 }
 
 function resolveActiveEffectChangeValue(
-  effect: DnD35eActiveEffect,
+  effect: Dnd35eActiveEffect,
   change: Dnd35eEffectChangeData
 ): unknown {
   const rawValue = change.value;
@@ -113,7 +113,7 @@ function resolveActiveEffectChangeValue(
 }
 
 function resolveMaskedActiveEffectChangeValue(
-  effect: DnD35eActiveEffect,
+  effect: Dnd35eActiveEffect,
   change: Dnd35eEffectChangeData
 ): unknown {
   const resolvedValue = resolveActiveEffectChangeValue(effect, change);
@@ -156,7 +156,7 @@ function resolveMaskedActiveEffectChangeValue(
 }
 
 function resolveActiveEffectChange(
-  effect: DnD35eActiveEffect,
+  effect: Dnd35eActiveEffect,
   change: Dnd35eEffectChangeData
 ): Dnd35eEffectChangeData {
   const resolvedValue = resolveActiveEffectChangeValue(effect, change);

--- a/src/entities/activeEffects/BaseActiveEffect/sheet/ActiveEffectConfigStore.mts
+++ b/src/entities/activeEffects/BaseActiveEffect/sheet/ActiveEffectConfigStore.mts
@@ -4,7 +4,7 @@ import type { DocumentSheetStore, DocumentSheetStoreDocumentActions, DocumentShe
 import { useDocumentSheetStore } from '@ec/CoreMixin/index.mjs';
 import type { Dnd35eEffectChangeData } from '@effects/BaseActiveEffect/data/ActiveEffectSystemData.mjs';
 import type { ActiveEffectSystemModelBase } from '@effects/BaseActiveEffect/data/ActiveEffectSystemModelBase.mjs';
-import type { DnD35eActiveEffect } from '@effects/BaseActiveEffect/DnD35eActiveEffect.mjs';
+import type { Dnd35eActiveEffect } from '@effects/BaseActiveEffect/Dnd35eActiveEffect.mjs';
 import { buildMergedFamiliarContext, getFamiliarBuilder } from '@helpers/formulae/index.mjs';
 import type { ContextDocumentType, TargetContexts } from '@helpers/formulae/registry.mjs';
 import type { FamiliarContext } from '@helpers/formulae/types.mjs';
@@ -23,7 +23,7 @@ const syncOpenSheetTitle = (sheet: { rendered?: boolean; title?: string; window?
   }
 };
 
-const useActiveEffectConfigStore = <TDocument extends DnD35eActiveEffect>(
+const useActiveEffectConfigStore = <TDocument extends Dnd35eActiveEffect>(
   context: VueApplicationContext<TDocument>
 ) => {
   const baseStore = useDocumentSheetStore(context, {
@@ -273,7 +273,7 @@ type ActiveEffectConfigStoreDocumentGetters = DocumentSheetStoreDocumentGetters 
   getTargetFamiliarContextName: (target: string) => string;
 };
 
-type ActiveEffectConfigStoreDocumentActions<TDocument extends DnD35eActiveEffect> = DocumentSheetStoreDocumentActions<TDocument> & {
+type ActiveEffectConfigStoreDocumentActions<TDocument extends Dnd35eActiveEffect> = DocumentSheetStoreDocumentActions<TDocument> & {
   addChange: (changeData: Dnd35eEffectChangeData) => Promise<boolean>;
   removeChange?: (index: number) => Promise<boolean>;
   updateChangeField: (index: number, field: string, value: unknown) => Promise<boolean>;
@@ -281,7 +281,7 @@ type ActiveEffectConfigStoreDocumentActions<TDocument extends DnD35eActiveEffect
   updateDurationUnits: (units: string) => Promise<boolean>;
 };
 
-type ActiveEffectConfigStore<TDocument extends DnD35eActiveEffect = DnD35eActiveEffect> = DocumentSheetStore<TDocument> & {
+type ActiveEffectConfigStore<TDocument extends Dnd35eActiveEffect = Dnd35eActiveEffect> = DocumentSheetStore<TDocument> & {
   documentGetters: ActiveEffectConfigStoreDocumentGetters;
   documentActions: ActiveEffectConfigStoreDocumentActions<TDocument>;
 };

--- a/src/entities/activeEffects/general/General.mts
+++ b/src/entities/activeEffects/general/General.mts
@@ -1,11 +1,11 @@
-import { DnD35eActiveEffect } from '@effects/BaseActiveEffect/DnD35eActiveEffect.mjs';
+import { Dnd35eActiveEffect } from '@effects/BaseActiveEffect/Dnd35eActiveEffect.mjs';
 import type { GeneralSystemData } from '@effects/general/data/index.mjs';
 
 /**
  * General active effect document class — the standard effect type for dnd35e.
- * No specialized behavior; delegates to DnD35eActiveEffect base.
+ * No specialized behavior; delegates to Dnd35eActiveEffect base.
  */
-class General extends DnD35eActiveEffect {
+class General extends Dnd35eActiveEffect {
   declare type: 'general';
   declare system: GeneralSystemData;
 }

--- a/src/entities/activeEffects/index.mts
+++ b/src/entities/activeEffects/index.mts
@@ -1,4 +1,4 @@
-import { DnD35eActiveEffect } from './BaseActiveEffect/DnD35eActiveEffect.mjs';
+import { Dnd35eActiveEffect } from './BaseActiveEffect/Dnd35eActiveEffect.mjs';
 import type {
   EffectTarget,
   EffectType,
@@ -11,7 +11,7 @@ import {
 } from './effectTypes.mjs';
 
 export {
-  DnD35eActiveEffect,
+  Dnd35eActiveEffect,
   EFFECT_TARGET,
   EFFECT_TYPES,
   GENERAL_EFFECT_TYPE,

--- a/src/entities/activeEffects/material/Material.mts
+++ b/src/entities/activeEffects/material/Material.mts
@@ -1,6 +1,6 @@
 import type { ActiveEffectSource } from '@common/documents/active-effect.mjs';
 import type { Dnd35eDocumentFlags } from '@ec/CoreMixin/index.mjs';
-import { DnD35eActiveEffect } from '@effects/BaseActiveEffect/DnD35eActiveEffect.mjs';
+import { Dnd35eActiveEffect } from '@effects/BaseActiveEffect/Dnd35eActiveEffect.mjs';
 import { LogHelper } from '@helpers/index.mjs';
 import { COMBAT_KEYS } from '@settings/combat/index.mjs';
 import { SYSTEM_ID } from '@settings/shared.mjs';
@@ -15,7 +15,7 @@ interface MaterialEffectFlags {
   // Add material-specific flags here as needed
 }
 
-class Material extends DnD35eActiveEffect {
+class Material extends Dnd35eActiveEffect {
   declare type: MaterialEffectType;
   declare system: MaterialSystemData;
   declare flags: Dnd35eDocumentFlags<MaterialEffectFlags>;

--- a/src/entities/activeEffects/registration.mts
+++ b/src/entities/activeEffects/registration.mts
@@ -2,7 +2,7 @@ import { EffectConfig } from '@constants/config/activeEffect.mjs';
 import type { NameFormulaDocument } from '@ec/CoreMixin/index.mjs';
 import { ensureNameFormulaOnCreate } from '@ec/CoreMixin/index.mjs';
 import { EFFECT_CHANGE_PHASES } from '@effects/BaseActiveEffect/data/index.mjs';
-import { ActiveEffectProxyDnd35e } from '@effects/BaseActiveEffect/DnD35eActiveEffect.mjs';
+import { ActiveEffectProxyDnd35e } from '@effects/BaseActiveEffect/Dnd35eActiveEffect.mjs';
 import { GENERAL_EFFECT_TYPE, GeneralSystemModel } from '@effects/general/index.mjs';
 import { MaterialSystemModel } from '@effects/material/data/MaterialSystemModel.mjs';
 import { validateSingleMaterial } from '@effects/material/Material.mjs';

--- a/src/entities/activeEffects/secret/Secret.mts
+++ b/src/entities/activeEffects/secret/Secret.mts
@@ -1,4 +1,4 @@
-import { DnD35eActiveEffect } from '@effects/BaseActiveEffect/DnD35eActiveEffect.mjs';
+import { Dnd35eActiveEffect } from '@effects/BaseActiveEffect/Dnd35eActiveEffect.mjs';
 
 import type { SecretSystemData } from './data/index.mjs';
 import type { SecretEffectType } from './secretEffectType.mjs';
@@ -9,7 +9,7 @@ import { secretEffectType } from './secretEffectType.mjs';
  * Uses MASK change mode entries to define which fields are masked and with what values.
  * An item with active (non-disabled) Secret AEs is considered unidentified.
  */
-class Secret extends DnD35eActiveEffect {
+class Secret extends Dnd35eActiveEffect {
   declare type: SecretEffectType;
   declare system: SecretSystemData;
 

--- a/src/entities/actors/baseActor/ActorDnd35e.mts
+++ b/src/entities/actors/baseActor/ActorDnd35e.mts
@@ -4,7 +4,7 @@ import type EmbeddedCollection from '@common/abstract/embedded-collection.mjs';
 import type { EffectChangeData } from '@common/documents/active-effect.mjs';
 import type { Dnd35eEffectChangeData } from '@effects/BaseActiveEffect/data/ActiveEffectSystemData.mjs';
 import { EFFECT_CHANGE_TARGET, EFFECT_CHANGE_TYPE } from '@effects/BaseActiveEffect/data/constants.mjs';
-import type { DnD35eActiveEffect } from '@effects/BaseActiveEffect/DnD35eActiveEffect.mjs';
+import type { Dnd35eActiveEffect } from '@effects/BaseActiveEffect/Dnd35eActiveEffect.mjs';
 import { resolveActiveEffectChange } from '@effects/BaseActiveEffect/resolveChangeValue.mjs';
 import { LogHelper } from '@helpers/logHelper.mjs';
 import type { ItemDnd35e } from '@items/baseItem/index.mjs';
@@ -14,7 +14,7 @@ import type { TokenDocumentDnd35e } from '@scene/token-document/TokenDocumentDnd
 import type { ActorSystemData } from './index.mjs';
 
 interface AppliedActorEffectChange extends Dnd35eEffectChangeData {
-  effect: DnD35eActiveEffect;
+  effect: Dnd35eActiveEffect;
 }
 
 
@@ -23,7 +23,7 @@ class ActorDnd35e<
   TActorType extends ActorType = ActorType,
   TSystemData extends ActorSystemData = ActorSystemData
 > extends Actor<TToken> {
-  declare readonly effects: EmbeddedCollection<DnD35eActiveEffect<this>>;
+  declare readonly effects: EmbeddedCollection<Dnd35eActiveEffect<this>>;
   declare readonly items: EmbeddedCollection<ItemDnd35e<ItemType, this>>;
   declare type: TActorType;
   declare system: TSystemData;
@@ -56,7 +56,7 @@ class ActorDnd35e<
         const changeTarget = change.target ?? EFFECT_CHANGE_TARGET.ACTOR;
         if ( !change.key || (change.phase !== phase) || (changeTarget !== EFFECT_CHANGE_TARGET.ACTOR) ) continue;
         const copy = foundry.utils.deepClone(resolveActiveEffectChange(effect, change)) as AppliedActorEffectChange;
-        copy.effect = effect as DnD35eActiveEffect;
+        copy.effect = effect as Dnd35eActiveEffect;
         copy.type ??= EFFECT_CHANGE_TYPE.ADD;
         copy.priority ??= 0;
         changes.push(copy);
@@ -85,7 +85,7 @@ class ActorDnd35e<
   /**
    * Override to iterate all applicable effects from actor and transferred item effects.
    */
-  override *allApplicableEffects(): Generator<DnD35eActiveEffect<this | ItemDnd35e<ItemType, this>>, void, void> {
+  override *allApplicableEffects(): Generator<Dnd35eActiveEffect<this | ItemDnd35e<ItemType, this>>, void, void> {
     for ( const effect of this.effects ) {
       yield effect;
     }

--- a/src/entities/components/CoreMixin/formulaRegistrationHelpers.mts
+++ b/src/entities/components/CoreMixin/formulaRegistrationHelpers.mts
@@ -6,7 +6,7 @@ import type { EvaluationDocument, FormulaRegistration } from './sheet/index.mjs'
 
 /**
  * Minimal interface for documents that support formula registration.
- * Both the mixin and DnD35eActiveEffect satisfy this.
+ * Both the mixin and Dnd35eActiveEffect satisfy this.
  */
 interface FormulaRegistrationHost {
   system: any;

--- a/src/entities/components/CoreMixin/sheet/DocumentSheetStore.mts
+++ b/src/entities/components/CoreMixin/sheet/DocumentSheetStore.mts
@@ -1,6 +1,6 @@
 import type { ActorType } from '@actors/actorTypes.mjs';
 import type { DatabaseUpdateOperation } from '@common/abstract/_types.mjs';
-import type { DnD35eActiveEffect, EffectType } from '@effects/index.mjs';
+import type { Dnd35eActiveEffect, EffectType } from '@effects/index.mjs';
 import { addOrUpdatePlayerEditMask, findOrCreatePlayerEditSecret } from '@effects/secret/playerEditSecret.mjs';
 import { buildDocumentFamiliar } from '@helpers/formulae/index.mjs';
 import type { FamiliarSchema } from '@helpers/formulae/types.mjs';
@@ -38,7 +38,7 @@ import { resolveViewAwareFieldPlan } from './viewAwareFieldPlan.mjs';
 // Types
 // ---------------------------------------------------------------------------
 
-type SheetDocument = ItemDnd35e | DnD35eActiveEffect;
+type SheetDocument = ItemDnd35e | Dnd35eActiveEffect;
 
 type DocumentSheetStoreUtils<TDocument extends SheetDocument> = FieldOverridesStoreUtils & {
   document: ShallowRef<TDocument>;

--- a/src/entities/items/baseItem/ItemDnd35e.mts
+++ b/src/entities/items/baseItem/ItemDnd35e.mts
@@ -5,7 +5,7 @@ import type { EffectChangeData } from '@common/documents/active-effect.mjs';
 import { getDisplayName } from '@ec/CoreMixin/logic/index.mjs';
 import type { Dnd35eEffectChangeData } from '@effects/BaseActiveEffect/data/ActiveEffectSystemData.mjs';
 import { EFFECT_CHANGE_TARGET, EFFECT_CHANGE_TYPE, FINAL_EFFECT_CHANGE_PHASE, INITIAL_EFFECT_CHANGE_PHASE, SYSTEM_CHANGE_TYPE } from '@effects/BaseActiveEffect/data/constants.mjs';
-import type { DnD35eActiveEffect } from '@effects/BaseActiveEffect/DnD35eActiveEffect.mjs';
+import type { Dnd35eActiveEffect } from '@effects/BaseActiveEffect/Dnd35eActiveEffect.mjs';
 import { resolveActiveEffectChange, resolveMaskedActiveEffectChangeValue } from '@effects/BaseActiveEffect/resolveChangeValue.mjs';
 import { secretEffectType } from '@effects/secret/secretEffectType.mjs';
 import { FormulaData } from '@helpers/formulae/FormulaData.mjs';
@@ -30,7 +30,7 @@ class ItemDnd35e<TItemType extends ItemType = ItemType, TParent extends ActorDnd
     super(source, context);
     this._completedActiveEffectPhases = new Set();
   }
-  declare readonly effects: EmbeddedCollection<DnD35eActiveEffect<this>>;
+  declare readonly effects: EmbeddedCollection<Dnd35eActiveEffect<this>>;
   declare type: TItemType;
   declare system: ItemSystemData;
   declare _source: ItemSourceDnd35e<TItemType>;
@@ -203,7 +203,7 @@ class ItemDnd35e<TItemType extends ItemType = ItemType, TParent extends ActorDnd
     this._completedActiveEffectPhases.add(phase);
 
     type AppliedItemEffectChange = EffectChangeData<ItemDnd35e<TItemType, TParent>>
-      & { type: string; effect: DnD35eActiveEffect<ItemDnd35e<TItemType, TParent>> };
+      & { type: string; effect: Dnd35eActiveEffect<ItemDnd35e<TItemType, TParent>> };
     const changes: AppliedItemEffectChange[] = [];
     for ( const effect of this.allApplicableEffects() ) {
       if ( !effect.active ) continue;

--- a/src/entities/items/baseItem/sheet/ItemSheetStore.mts
+++ b/src/entities/items/baseItem/sheet/ItemSheetStore.mts
@@ -6,7 +6,7 @@ import type {
   SheetTab,
 } from '@ec/CoreMixin/index.mjs';
 import { defaultDetailsTab, useDocumentSheetStore } from '@ec/CoreMixin/index.mjs';
-import { DnD35eActiveEffect } from '@effects/BaseActiveEffect/DnD35eActiveEffect.mjs';
+import { Dnd35eActiveEffect } from '@effects/BaseActiveEffect/Dnd35eActiveEffect.mjs';
 import type { EffectType } from '@effects/effectTypes.mjs';
 import { EFFECT_TYPES } from '@effects/effectTypes.mjs';
 import type { ItemDnd35e } from '@items/baseItem/ItemDnd35e.mjs';
@@ -44,12 +44,12 @@ const useItemSheetStore = <TDocument extends ItemDnd35e>(context: VueApplication
   // with Foundry's EmbeddedCollection proxy (non-configurable property error)
   const hiddenEffectTypeIds = ref<Set<string>>(new Set());
   const allEffects = computed(() => [...(document.value.effects ?? [])]
-    .filter((effect: DnD35eActiveEffect) => !hiddenEffectTypeIds.value.has(effect.type))
+    .filter((effect: Dnd35eActiveEffect) => !hiddenEffectTypeIds.value.has(effect.type))
   );
   // Non-GM users cannot see effects with isHidden: true
   const effects = computed(() => isGM
     ? allEffects.value
-    : allEffects.value.filter((e: DnD35eActiveEffect) => !e.system.isHidden)
+    : allEffects.value.filter((e: Dnd35eActiveEffect) => !e.system.isHidden)
   );
   const getEffectsForField = (fieldPath: string) => computed(() => document.value.overrides?.[fieldPath]
     ? document.value.overrides?.[fieldPath] as []
@@ -58,9 +58,9 @@ const useItemSheetStore = <TDocument extends ItemDnd35e>(context: VueApplication
   const itemDocumentGetters = {
     ...baseStore.documentGetters,
     effects,
-    temporaryEffects: computed(() => effects.value.filter((e: DnD35eActiveEffect) => !e.disabled && e.isTemporary)),
-    passiveEffects: computed(() => effects.value.filter((e: DnD35eActiveEffect) => !e.disabled && !e.isTemporary)),
-    inactiveEffects: computed(() => effects.value.filter((e: DnD35eActiveEffect) => e.disabled)),
+    temporaryEffects: computed(() => effects.value.filter((e: Dnd35eActiveEffect) => !e.disabled && e.isTemporary)),
+    passiveEffects: computed(() => effects.value.filter((e: Dnd35eActiveEffect) => !e.disabled && !e.isTemporary)),
+    inactiveEffects: computed(() => effects.value.filter((e: Dnd35eActiveEffect) => e.disabled)),
     hasOwner,
     getEffectsForField,
     hasEffectsForField: (fieldPath: string) => computed(() => getEffectsForField(fieldPath).value.length > 0),
@@ -97,13 +97,13 @@ const useItemSheetStore = <TDocument extends ItemDnd35e>(context: VueApplication
         origin: document.value.uuid,
         disabled: false,
       };
-      // TODO(Phase 7): fix type definitions — add createDialog static method signature to DnD35eActiveEffect
-      await (DnD35eActiveEffect as any).createDialog(effectData, {
+      // TODO(Phase 7): fix type definitions — add createDialog static method signature to Dnd35eActiveEffect
+      await (Dnd35eActiveEffect as any).createDialog(effectData, {
         parent: document.value,
       }, {
         types: Object.keys(EFFECT_TYPES),
       });
-      // const createData = DnD35eActiveEffect.createDialog(effectData);
+      // const createData = Dnd35eActiveEffect.createDialog(effectData);
       // await document.value.createEmbeddedDocuments('ActiveEffect', [createData]);
       triggerRef(document);
     },
@@ -140,10 +140,10 @@ const useItemSheetStore = <TDocument extends ItemDnd35e>(context: VueApplication
 };
 
 type ItemDocumentGetters = DocumentSheetStoreDocumentGetters & {
-  effects: ComputedRef<DnD35eActiveEffect[]>,
-  temporaryEffects: ComputedRef<DnD35eActiveEffect[]>,
-  passiveEffects: ComputedRef<DnD35eActiveEffect[]>,
-  inactiveEffects: ComputedRef<DnD35eActiveEffect[]>,
+  effects: ComputedRef<Dnd35eActiveEffect[]>,
+  temporaryEffects: ComputedRef<Dnd35eActiveEffect[]>,
+  passiveEffects: ComputedRef<Dnd35eActiveEffect[]>,
+  inactiveEffects: ComputedRef<Dnd35eActiveEffect[]>,
   hasOwner: ComputedRef<boolean>;
   getEffectsForField: (fieldPath: string) => ComputedRef<object[]>;
 };

--- a/src/entities/items/baseItem/sheet/components/EffectCategory.vue
+++ b/src/entities/items/baseItem/sheet/components/EffectCategory.vue
@@ -71,7 +71,7 @@
 
 <script setup lang="ts">
   import { DocumentSheetStoreSymbol } from '@ec/CoreMixin/index.mjs';
-  import type { DnD35eActiveEffect } from '@effects/index.mjs';
+  import type { Dnd35eActiveEffect } from '@effects/index.mjs';
   import { inject, ref, useSlots } from 'vue';
 
   import type { ItemSheetStore } from '../ItemSheetStore.mjs';
@@ -81,7 +81,7 @@
     defaultCollapsed = false,
   } = defineProps<{
     label: string;
-    effects: DnD35eActiveEffect[];
+    effects: Dnd35eActiveEffect[];
     canEdit: boolean;
     showVisibilityToggle?: boolean;
     defaultCollapsed?: boolean;
@@ -103,23 +103,23 @@
       createLocalizedComputed,
     },
   } = inject(DocumentSheetStoreSymbol) as ItemSheetStore;
-  const effectEnablementTitle = (effect: DnD35eActiveEffect) => effect.disabled
+  const effectEnablementTitle = (effect: Dnd35eActiveEffect) => effect.disabled
     ? createLocalizedComputed('dnd35e.EFFECT.Enable')
     : createLocalizedComputed('dnd35e.EFFECT.Disable');
 
-  const handleDelete = async (effect: DnD35eActiveEffect) => {
+  const handleDelete = async (effect: Dnd35eActiveEffect) => {
     await removeEffect(effect.id);
   };
 
-  const handleEdit = (effect: DnD35eActiveEffect) => {
+  const handleEdit = (effect: Dnd35eActiveEffect) => {
     editEffect(effect.id);
   };
 
-  const handleToggle = async (effect: DnD35eActiveEffect) => {
+  const handleToggle = async (effect: Dnd35eActiveEffect) => {
     await toggleEffect(effect.id);
   };
 
-  const handleToggleHidden = async (effect: DnD35eActiveEffect) => {
+  const handleToggleHidden = async (effect: Dnd35eActiveEffect) => {
     await toggleEffectHidden(effect.id);
   };
 

--- a/src/global.mts
+++ b/src/global.mts
@@ -5,7 +5,7 @@ import type Hotbar from '@client/applications/ui/hotbar.mjs';
 import type EffectsCanvasGroup from '@client/canvas/groups/effects.mjs';
 import type Config from '@client/config.mjs';
 import type { ActiveEffectConfigStore } from '@effects/BaseActiveEffect/index.mjs';
-import { DnD35eActiveEffect } from '@entities/activeEffects/index.mjs';
+import { Dnd35eActiveEffect } from '@entities/activeEffects/index.mjs';
 import type { ItemSheetStore } from '@items/baseItem/index.mjs';
 import { ItemDnd35e } from '@items/baseItem/index.mjs';
 import type { ItemType } from '@items/itemTypes.mjs';
@@ -70,7 +70,7 @@ declare global {
         documentClasses: Record<string, new (...args: any[]) => ItemDnd35e>;
       },
       activeEffect: {
-        documentClasses: Record<string, new (...args: any[]) => DnD35eActiveEffect>;
+        documentClasses: Record<string, new (...args: any[]) => Dnd35eActiveEffect>;
       },
       gameRules: {
         damageReductionTypes: Record<string, { label: string }>;

--- a/src/helpers/formulae/registry.mts
+++ b/src/helpers/formulae/registry.mts
@@ -10,7 +10,7 @@
 
 import type { ActorType } from '@actors/actorTypes.mjs';
 import type { ActorDnd35e } from '@actors/baseActor/index.mjs';
-import type { DnD35eActiveEffect } from '@effects/BaseActiveEffect/index.mjs';
+import type { Dnd35eActiveEffect } from '@effects/BaseActiveEffect/index.mjs';
 import type { EffectType } from '@effects/effectTypes.mjs';
 import type { ItemDnd35e } from '@items/baseItem/ItemDnd35e.mjs';
 import type { ItemType } from '@items/itemTypes.mjs';
@@ -20,7 +20,7 @@ import type { AspectGroup, FamiliarContext, FamiliarSchema, FormulaFieldData } f
 import { mergeAspectGroups } from './utils.mjs';
 
 /** Union of all Foundry document classes that can serve as familiar context. */
-export type NonNullDocumentContext = ItemDnd35e | ActorDnd35e | DnD35eActiveEffect;
+export type NonNullDocumentContext = ItemDnd35e | ActorDnd35e | Dnd35eActiveEffect;
 export type DocumentContext = NonNullDocumentContext | null;
 
 export type ContextDocumentType = ItemType | EffectType | ActorType;

--- a/src/vue/apps/VueActiveEffectConfig.mts
+++ b/src/vue/apps/VueActiveEffectConfig.mts
@@ -1,15 +1,15 @@
 import type { DocumentSheetConfiguration } from '@client/applications/api/document-sheet.mjs';
 import { VUE_APP_CLASS } from '@constants/cssClasses.mjs';
-import type { DnD35eActiveEffect } from '@entities/activeEffects/index.mjs';
+import type { Dnd35eActiveEffect } from '@entities/activeEffects/index.mjs';
 import { SYSTEM_ID } from '@settings/shared.mjs';
 
 import type { VueApplicationConfiguration, VueRenderOptions } from './VueAppTypes.mjs';
 import { useVueDocumentSheetMixin } from './VueDocumentSheetMixin.mjs';
 
-const EffectConfigBase = foundry.applications.sheets.ActiveEffectConfig<DnD35eActiveEffect, VueApplicationConfiguration<DnD35eActiveEffect>, VueRenderOptions>;
+const EffectConfigBase = foundry.applications.sheets.ActiveEffectConfig<Dnd35eActiveEffect, VueApplicationConfiguration<Dnd35eActiveEffect>, VueRenderOptions>;
 
 abstract class VueActiveEffectConfig extends useVueDocumentSheetMixin(EffectConfigBase) {
-  static override get DEFAULT_OPTIONS (): DeepPartial<DocumentSheetConfiguration<DnD35eActiveEffect>> {
+  static override get DEFAULT_OPTIONS (): DeepPartial<DocumentSheetConfiguration<Dnd35eActiveEffect>> {
     return {
       classes: [SYSTEM_ID, VUE_APP_CLASS],
       actions: {},
@@ -20,7 +20,7 @@ abstract class VueActiveEffectConfig extends useVueDocumentSheetMixin(EffectConf
       window: {
         resizable: true,
       },
-    } as DeepPartial<VueApplicationConfiguration<DnD35eActiveEffect>>;
+    } as DeepPartial<VueApplicationConfiguration<Dnd35eActiveEffect>>;
   }
 }
 

--- a/src/vue/apps/VueAppTypes.mts
+++ b/src/vue/apps/VueAppTypes.mts
@@ -1,10 +1,10 @@
 import type { DocumentSheetConfiguration, DocumentSheetRenderOptions } from '@client/applications/api/document-sheet.mjs';
 import type { DocumentSheetStore } from '@ec/CoreMixin/index.mjs';
-import type { DnD35eActiveEffect } from '@entities/activeEffects/index.mjs';
+import type { Dnd35eActiveEffect } from '@entities/activeEffects/index.mjs';
 import type { ViewMode } from '@helpers/formulae/types.mjs';
 import type { ItemDnd35e } from '@items/baseItem/index.mjs';
 
-interface VueApplicationConfiguration<TDocument extends ItemDnd35e | DnD35eActiveEffect> extends
+interface VueApplicationConfiguration<TDocument extends ItemDnd35e | Dnd35eActiveEffect> extends
   DocumentSheetConfiguration<TDocument>
 {
   document: TDocument;
@@ -20,14 +20,14 @@ interface SheetState {
   viewMode: ViewMode;
 }
 
-interface VueApplicationContext<TDocument extends ItemDnd35e | DnD35eActiveEffect> {
+interface VueApplicationContext<TDocument extends ItemDnd35e | Dnd35eActiveEffect> {
   document: TDocument;
   appConfigOptions: VueApplicationConfiguration<TDocument>;
   renderOptions?: VueRenderOptions;
   close: () => Promise<void>;
 }
 
-interface VueApplicationContextTransfer<TDocument extends ItemDnd35e | DnD35eActiveEffect> extends VueApplicationContext<TDocument> {
+interface VueApplicationContextTransfer<TDocument extends ItemDnd35e | Dnd35eActiveEffect> extends VueApplicationContext<TDocument> {
   store?: DocumentSheetStore<TDocument> | undefined;
 }
 

--- a/src/vue/apps/VueDocumentSheetMixin.mts
+++ b/src/vue/apps/VueDocumentSheetMixin.mts
@@ -9,7 +9,7 @@ import type { DocumentSheetStore } from '@ec/CoreMixin/sheet/DocumentSheetStore.
 import { RenderModeStoreSymbol, useRenderModeStore } from '@ec/CoreMixin/sheet/stores/index.mjs';
 import type { RenderModeStore } from '@ec/CoreMixin/sheet/stores/RenderModeStore.mjs';
 import { secretEffectType } from '@effects/secret/secretEffectType.mjs';
-import type { DnD35eActiveEffect } from '@entities/activeEffects/index.mjs';
+import type { Dnd35eActiveEffect } from '@entities/activeEffects/index.mjs';
 import { EDIT, PLAY } from '@helpers/formulae/types.mjs';
 import type { ItemDnd35e } from '@items/baseItem/ItemDnd35e.mjs';
 import type { App } from 'vue';
@@ -23,7 +23,7 @@ import type { SheetState, VueApplicationConfiguration, VueApplicationContext, Vu
  * Interface describing members added by VueDocumentSheetMixin.
  * Used for explicit typing instead of ReturnType inference.
  */
-interface VueDocumentSheetMembers<TDocument extends ItemDnd35e | DnD35eActiveEffect> extends VueAppBaseMembers {
+interface VueDocumentSheetMembers<TDocument extends ItemDnd35e | Dnd35eActiveEffect> extends VueAppBaseMembers {
   /** Application options with document reference */
   options: VueApplicationConfiguration<TDocument>;
   /** Shared reactive context passed into Vue */
@@ -36,7 +36,7 @@ interface VueDocumentSheetMembers<TDocument extends ItemDnd35e | DnD35eActiveEff
   readonly isEditable: boolean;
 }
 
-const useVueDocumentSheetMixin = <TBase extends AbstractConstructorOf<DocumentSheetV2>, TDocument extends ItemDnd35e | DnD35eActiveEffect> (base: TBase) => {
+const useVueDocumentSheetMixin = <TBase extends AbstractConstructorOf<DocumentSheetV2>, TDocument extends ItemDnd35e | Dnd35eActiveEffect> (base: TBase) => {
   const VueAppBase = useVueAppBaseMixin(base);
 
   abstract class VueDocumentSheet extends VueAppBase {
@@ -176,7 +176,7 @@ const useVueDocumentSheetMixin = <TBase extends AbstractConstructorOf<DocumentSh
  */
 type VueDocumentSheetMixin<
   TBase extends AbstractConstructorOf<DocumentSheetV2>,
-  TDocument extends ItemDnd35e | DnD35eActiveEffect
+  TDocument extends ItemDnd35e | Dnd35eActiveEffect
 > = TBase & AbstractConstructorOf<VueDocumentSheetMembers<TDocument>>;
 
 export {


### PR DESCRIPTION
# PR 2 — `DnD35e` → `Dnd35e` casing sweep (Group 2)

Second PR in the 14-PR naming-convention refactor series tracked in [`docs/migration-plan/poc/refactor-naming-conventions.md`](docs/migration-plan/poc/refactor-naming-conventions.md).

## Scope

Pure case-sensitive rename pass. No semantic changes, no folder moves, no behavioral changes.

Brings the `ActiveEffect` base class into line with the project's PascalCase convention (single initial cap for the `DnD` acronym → `Dnd`).

## Checklist items completed

- [x] **G2.1** — File rename `DnD35eActiveEffect.mts` → `Dnd35eActiveEffect.mts` (Windows two-step `git mv`)
- [x] **G2.2** — Class `DnD35eActiveEffect` → `Dnd35eActiveEffect`
- [x] **G2.3** — Type `DnD35eActiveEffectFlags` → `Dnd35eActiveEffectFlags`
- [x] **G2.4** — Local const `DnD35eActiveEffectBase` → `Dnd35eActiveEffectBase`
- [x] **G2.5** — Workspace-wide case-sensitive replace of `DnD35e` → `Dnd35e`
- [x] **G2.6** — eslint --fix (runs on save in VS Code)
- [x] **G2.7** — `git grep "DnD35e"` over `src/`, `tests/`, `types/` → zero matches
- [x] **G2.8** — `npm run build` clean; committed

## Commit strategy

Single commit (`750d750`) because every intermediate state (file rename without symbol rename, partial symbol rename, etc.) would break the build. The "one commit per buildable unit" rule from `R.2.11` collapses G2.1–G2.8 into one commit; the message body enumerates each sub-item for granular traceability.

## Verification

| Gate           | Result                          |
|----------------|---------------------------------|
| `npm run build`   | ✅ clean (3.36s)                |
| `npx vitest run`  | ✅ 181 passed, 8 todo (20 files) |
| `npx playwright test` | ✅ 20/20 passed (5.8m)       |

## Files touched

21 files: 1 rename + 20 symbol-reference updates across `src/entities/`, `src/vue/`, `src/helpers/`, `src/global.mts`, and the phase-doc checklist.

## Next up

- **PR 3** (G3a/G3b/G3c) — `BaseDnd35eSystemData` → `DocumentSystemData`, `PhysicalSystemData` → `PhysicalItemSystemData`, `ItemSystemModelBase` → `ItemSystemModel`
