### PR TITLE
refactor(pr04): Architectural rename of cross-document base (G4a-G4b)

### DIFF
--- a/docs/migration-plan/poc/refactor-naming-conventions.md
+++ b/docs/migration-plan/poc/refactor-naming-conventions.md
@@ -429,17 +429,17 @@ Every numbered task ends with `npm run build` exit 0. Failures block the next ta
 - [x] G3e.4 — `npm run build` clean; commit
 
 ### Group 4a: `Dnd35eDocument` (mixin + types) → `DocumentDnd35e`
-- [ ] G4a.1 — Rename file `Dnd35eDocument.mts` → `DocumentDnd35e.mts`
-- [ ] G4a.2 — Rename: `Dnd35eDocument` → `DocumentDnd35e`, `Dnd35eDocumentMixin` → `DocumentMixin`, `Dnd35eDocumentProperties` → `DocumentProperties`, `Dnd35eDocumentConstructor` → `DocumentConstructor` (escalate to `DocumentConstructorDnd35e` if build fails on collision)
-- [ ] G4a.3 — Rename file `Dnd35eDocumentFlags.mts` → `DocumentFlagsDnd35e.mts`; rename type `Dnd35eDocumentFlags` → `DocumentFlagsDnd35e` (**verified collision** with Foundry `DocumentFlags`)
-- [ ] G4a.4 — Update all imports / re-export barrels
-- [ ] G4a.5 — `npm run build` clean; commit
+- [x] G4a.1 — Rename file `Dnd35eDocument.mts` → `DocumentDnd35e.mts`
+- [x] G4a.2 — Rename: `Dnd35eDocument` → `DocumentDnd35e`, `Dnd35eDocumentMixin` → `DocumentMixin`, `Dnd35eDocumentProperties` → `DocumentProperties`, `Dnd35eDocumentConstructor` → `DocumentConstructor` (no Foundry collision)
+- [x] G4a.3 — Rename file `Dnd35eDocumentFlags.mts` → `DocumentFlagsDnd35e.mts`; rename type `Dnd35eDocumentFlags` → `DocumentFlagsDnd35e` (**verified collision** with Foundry `DocumentFlags`)
+- [x] G4a.4 — Update all imports / re-export barrels
+- [x] G4a.5 — `npm run build` clean; commit
 
 ### Group 4b: `Dnd35eDocumentSystemModel` → `DocumentSystemModel`
-- [ ] G4b.1 — Rename file `Dnd35eDocumentSystemModel.mts` → `DocumentSystemModel.mts`
-- [ ] G4b.2 — Rename class symbol
-- [ ] G4b.3 — Update imports
-- [ ] G4b.4 — `npm run build` clean; commit
+- [x] G4b.1 — Rename file `Dnd35eDocumentSystemModel.mts` → `DocumentSystemModel.mts`
+- [x] G4b.2 — Rename class symbol
+- [x] G4b.3 — Update imports
+- [x] G4b.4 — `npm run build` clean; commit
 
 ### Group 4c: `Dnd35eActiveEffect` → `ActiveEffectDnd35e`
 - [ ] G4c.1 — Rename file `Dnd35eActiveEffect.mts` → `ActiveEffectDnd35e.mts`

--- a/src/entities/activeEffects/BaseActiveEffect/Dnd35eActiveEffect.mts
+++ b/src/entities/activeEffects/BaseActiveEffect/Dnd35eActiveEffect.mts
@@ -1,6 +1,6 @@
 import type { ActorDnd35e } from '@actors/baseActor/index.mjs';
 import type { DocumentConstructionContext } from '@common/_types.mjs';
-import { Dnd35eDocumentMixin } from '@ec/CoreMixin/Dnd35eDocument.mjs';
+import { DocumentMixin } from '@ec/CoreMixin/DocumentDnd35e.mjs';
 import { getDisplayName } from '@ec/CoreMixin/index.mjs';
 import type { ActiveEffectSystemData, Dnd35eActiveEffectSystemSource } from '@effects/BaseActiveEffect/data/ActiveEffectSystemData.mjs';
 import { EFFECT_CHANGE_TARGET } from '@effects/BaseActiveEffect/data/constants.mjs';
@@ -22,7 +22,7 @@ type Dnd35eActiveEffectSource<
 // Apply mixin at runtime but cast to preserve generic parameter compatibility.
 // TypeScript mixins erase generics; this cast is safe because the mixin only adds
 // methods/properties and doesn't alter the constructor signature's generic behavior.
-const Dnd35eActiveEffectBase = Dnd35eDocumentMixin(foundry.documents.ActiveEffect) as unknown as typeof foundry.documents.ActiveEffect;
+const Dnd35eActiveEffectBase = DocumentMixin(foundry.documents.ActiveEffect) as unknown as typeof foundry.documents.ActiveEffect;
 
 class Dnd35eActiveEffect<
   TParent extends ActorDnd35e | ItemDnd35e<ItemType> | null = ActorDnd35e | ItemDnd35e<ItemType> | null,

--- a/src/entities/activeEffects/BaseActiveEffect/data/ActiveEffectSystemModel.mts
+++ b/src/entities/activeEffects/BaseActiveEffect/data/ActiveEffectSystemModel.mts
@@ -1,4 +1,4 @@
-import { Dnd35eDocumentSystemModel } from '@ec/CoreMixin/data/Dnd35eDocumentSystemModel.mjs';
+import { DocumentSystemModel } from '@ec/CoreMixin/data/DocumentSystemModel.mjs';
 import { EFFECT_TARGET } from '@effects/effectTypes.mjs';
 import { requiredBooleanField } from '@helpers/fieldBuilders.mjs';
 import { ensureNameFormula } from '@helpers/formulae/index.mjs';
@@ -15,7 +15,7 @@ const {
   AnyField,
 } = foundry.data.fields;
 
-class ActiveEffectSystemModel extends Dnd35eDocumentSystemModel<foundry.documents.ActiveEffect> {
+class ActiveEffectSystemModel extends DocumentSystemModel<foundry.documents.ActiveEffect> {
   /**
    * Declares which item/actor subtypes this effect type can target.
    * Used by AspectPicker to build autocomplete contexts.

--- a/src/entities/activeEffects/material/Material.mts
+++ b/src/entities/activeEffects/material/Material.mts
@@ -1,5 +1,5 @@
 import type { ActiveEffectSource } from '@common/documents/active-effect.mjs';
-import type { Dnd35eDocumentFlags } from '@ec/CoreMixin/index.mjs';
+import type { DocumentFlagsDnd35e } from '@ec/CoreMixin/index.mjs';
 import { Dnd35eActiveEffect } from '@effects/BaseActiveEffect/Dnd35eActiveEffect.mjs';
 import { LogHelper } from '@helpers/index.mjs';
 import { COMBAT_KEYS } from '@settings/combat/index.mjs';
@@ -18,7 +18,7 @@ interface MaterialEffectFlags {
 class Material extends Dnd35eActiveEffect {
   declare type: MaterialEffectType;
   declare system: MaterialSystemData;
-  declare flags: Dnd35eDocumentFlags<MaterialEffectFlags>;
+  declare flags: DocumentFlagsDnd35e<MaterialEffectFlags>;
 
   override get transfer (): boolean {
     return false;

--- a/src/entities/actors/baseActor/data/ActorSystemModel.mts
+++ b/src/entities/actors/baseActor/data/ActorSystemModel.mts
@@ -1,8 +1,8 @@
-import { Dnd35eDocumentSystemModel } from '@ec/CoreMixin/data/Dnd35eDocumentSystemModel.mjs';
+import { DocumentSystemModel } from '@ec/CoreMixin/data/DocumentSystemModel.mjs';
 
 import type { ActorSystemData } from './ActorSystemData.mjs';
 
-abstract class ActorSystemModel extends Dnd35eDocumentSystemModel<foundry.documents.Actor> {
+abstract class ActorSystemModel extends DocumentSystemModel<foundry.documents.Actor> {
   static override defineSchema (): Record<string, any> {
     const schema = super.defineSchema();
 

--- a/src/entities/components/CoreMixin/DocumentDnd35e.mts
+++ b/src/entities/components/CoreMixin/DocumentDnd35e.mts
@@ -6,11 +6,11 @@ import {
   evaluateRegisteredFormulas,
   evaluateRegisteredFormulasForCreate,
 } from './formulaRegistrationHelpers.mjs';
-import type { Dnd35eDocumentFlags, FormulaRegistration } from './index.mjs';
+import type { DocumentFlagsDnd35e, FormulaRegistration } from './index.mjs';
 
 interface DocumentProperties {
   readonly localizedType: string;
-  flags: Dnd35eDocumentFlags;
+  flags: DocumentFlagsDnd35e;
   registeredFormulas: Set<FormulaRegistration>;
 }
 
@@ -32,7 +32,7 @@ const DocumentMixin = <TBase extends AbstractConstructorOf<ClientDocument>>(Base
       this.registeredFormulas = new Set([derived, name]);
     }
 
-    declare flags: Dnd35eDocumentFlags;
+    declare flags: DocumentFlagsDnd35e;
 
     declare registeredFormulas: Set<FormulaRegistration>;
 

--- a/src/entities/components/CoreMixin/DocumentDnd35e.mts
+++ b/src/entities/components/CoreMixin/DocumentDnd35e.mts
@@ -8,24 +8,24 @@ import {
 } from './formulaRegistrationHelpers.mjs';
 import type { Dnd35eDocumentFlags, FormulaRegistration } from './index.mjs';
 
-interface Dnd35eDocumentProperties {
+interface DocumentProperties {
   readonly localizedType: string;
   flags: Dnd35eDocumentFlags;
   registeredFormulas: Set<FormulaRegistration>;
 }
 
 // Instance type: the base document extended with mixin properties
-type Dnd35eDocument<TBase extends AbstractConstructorOf<ClientDocument>> = 
-  InstanceType<TBase> & Dnd35eDocumentProperties;
+type DocumentDnd35e<TBase extends AbstractConstructorOf<ClientDocument>> = 
+  InstanceType<TBase> & DocumentProperties;
 
 // Constructor type: TBase extended with abstract mixin members
 // The abstract class adds localizedType (abstract), flags, registeredFormulas
-type Dnd35eDocumentConstructor<TBase extends AbstractConstructorOf<ClientDocument>> = 
-  (abstract new (...args: ConstructorParameters<TBase>) => Dnd35eDocument<TBase>) & { [K in keyof TBase]: TBase[K] };
+type DocumentConstructor<TBase extends AbstractConstructorOf<ClientDocument>> = 
+  (abstract new (...args: ConstructorParameters<TBase>) => DocumentDnd35e<TBase>) & { [K in keyof TBase]: TBase[K] };
 
 
-const Dnd35eDocumentMixin = <TBase extends AbstractConstructorOf<ClientDocument>>(Base: TBase): Dnd35eDocumentConstructor<TBase> => {
-  abstract class Dnd35eDocument extends Base {
+const DocumentMixin = <TBase extends AbstractConstructorOf<ClientDocument>>(Base: TBase): DocumentConstructor<TBase> => {
+  abstract class DocumentDnd35e extends Base {
     constructor (...args: any[]) {
       super(...args);
       const [derived, name] = createDefaultNameRegistrations(this as any);
@@ -56,15 +56,15 @@ const Dnd35eDocumentMixin = <TBase extends AbstractConstructorOf<ClientDocument>
     }
   }
   
-  return Dnd35eDocument as unknown as Dnd35eDocumentConstructor<TBase>;
+  return DocumentDnd35e as unknown as DocumentConstructor<TBase>;
 };
 
 export {
-  Dnd35eDocumentMixin,
+  DocumentMixin,
 };
 
 export type {
-  Dnd35eDocument,
-  Dnd35eDocumentConstructor,
-  Dnd35eDocumentProperties,
+  DocumentConstructor,
+  DocumentDnd35e,
+  DocumentProperties,
 };

--- a/src/entities/components/CoreMixin/data/DocumentFlagsDnd35e.mts
+++ b/src/entities/components/CoreMixin/data/DocumentFlagsDnd35e.mts
@@ -14,12 +14,12 @@ interface Dnd35eBaseFlags {
  * Generic document flags type that includes dnd35e namespace with optional extensions.
  * @template T - Additional dnd35e-specific flags to include
  */
-type Dnd35eDocumentFlags<T extends object = object> = Record<string, Record<string, unknown>> & {
+type DocumentFlagsDnd35e<T extends object = object> = Record<string, Record<string, unknown>> & {
   dnd35e: Dnd35eBaseFlags & T;
 };
 
 
 export type {
   Dnd35eBaseFlags,
-  Dnd35eDocumentFlags,
+  DocumentFlagsDnd35e,
 };

--- a/src/entities/components/CoreMixin/data/DocumentSystemModel.mts
+++ b/src/entities/components/CoreMixin/data/DocumentSystemModel.mts
@@ -15,13 +15,13 @@ const {
   SchemaField,
 } = foundry.data.fields;
 
-interface Dnd35eDocumentSystemModel<TDocType extends foundry.abstract.DataModel | null> extends foundry.abstract.TypeDataModel<
+interface DocumentSystemModel<TDocType extends foundry.abstract.DataModel | null> extends foundry.abstract.TypeDataModel<
   TDocType,
   foundry.abstract.DataSchema
 >, DocumentSystemData {
 }
 
-abstract class Dnd35eDocumentSystemModel<TDocType extends foundry.abstract.DataModel | null> extends foundry.abstract.TypeDataModel<
+abstract class DocumentSystemModel<TDocType extends foundry.abstract.DataModel | null> extends foundry.abstract.TypeDataModel<
   TDocType,
   foundry.abstract.DataSchema
 > {
@@ -127,5 +127,5 @@ abstract class Dnd35eDocumentSystemModel<TDocType extends foundry.abstract.DataM
 }
 
 export {
-  Dnd35eDocumentSystemModel,
+  DocumentSystemModel,
 };

--- a/src/entities/components/CoreMixin/data/index.mts
+++ b/src/entities/components/CoreMixin/data/index.mts
@@ -1,13 +1,13 @@
 import type {
   Dnd35eBaseFlags,
-  Dnd35eDocumentFlags,
-} from './Dnd35eDocumentFlags.mjs';
+  DocumentFlagsDnd35e,
+} from './DocumentFlagsDnd35e.mjs';
 import type {
   DocumentSystemData,
 } from './DocumentSystemData.mjs';
 
 export type {
   Dnd35eBaseFlags,
-  Dnd35eDocumentFlags,
+  DocumentFlagsDnd35e,
   DocumentSystemData,
 };

--- a/src/entities/components/CoreMixin/index.mts
+++ b/src/entities/components/CoreMixin/index.mts
@@ -1,6 +1,6 @@
 import type {
   Dnd35eBaseFlags,
-  Dnd35eDocumentFlags,
+  DocumentFlagsDnd35e,
   DocumentSystemData,
 } from './data/index.mjs';
 import type {
@@ -77,7 +77,7 @@ export {
 
 export type {
   Dnd35eBaseFlags,
-  Dnd35eDocumentFlags,
+  DocumentFlagsDnd35e,
   DocumentSheetStore,
   DocumentSheetStoreDocumentActions,
   DocumentSheetStoreDocumentGetters,

--- a/src/entities/components/Identifiable/IdentifiableItem.mts
+++ b/src/entities/components/Identifiable/IdentifiableItem.mts
@@ -1,4 +1,4 @@
-import type { Dnd35eDocumentProperties } from '@ec/CoreMixin/Dnd35eDocument.mjs';
+import type { DocumentProperties } from '@ec/CoreMixin/DocumentDnd35e.mjs';
 import type { EvaluationDocument, FormulaRegistration } from '@ec/CoreMixin/index.mjs';
 import { secretEffectType } from '@effects/secret/secretEffectType.mjs';
 import type { ItemSourceDnd35e } from '@items/baseItem/index.mjs';
@@ -37,7 +37,7 @@ interface IdentifiableEffect {
  * Satisfied by Items (now) and Actors (Phase 6+) — both have `effects` collections.
  * Excludes ActiveEffects which lack embedded effect collections.
  */
-interface IdentifiableHostDocument extends Dnd35eDocumentProperties {
+interface IdentifiableHostDocument extends DocumentProperties {
   effects: Iterable<IdentifiableEffect>;
   prepareDerivedData(): void;
   updateEmbeddedDocuments(embeddedName: string, updates: Record<string, unknown>[]): Promise<unknown>;
@@ -49,9 +49,9 @@ type IdentifiableDocumentCtor = AbstractConstructorOf<IdentifiableHostDocument>;
 
 /**
  * Public properties added by {@link IdentifiableDocumentMixin}.
- * Extends Dnd35eDocumentProperties so the mixin chain's shape is flat for TS.
+ * Extends DocumentProperties so the mixin chain's shape is flat for TS.
  */
-interface IdentifiableDocumentProperties extends Dnd35eDocumentProperties {
+interface IdentifiableDocumentProperties extends DocumentProperties {
   /** Whether this document has any Secret AEs (even disabled). */
   readonly isIdentifiable: boolean;
   /** Whether all Secret AEs are disabled/absent — derived in prepareDerivedData. */

--- a/src/entities/components/Identifiable/data/applyIdentifiableSchema.mts
+++ b/src/entities/components/Identifiable/data/applyIdentifiableSchema.mts
@@ -1,6 +1,6 @@
-import type { Dnd35eDocumentSystemModel } from '@ec/CoreMixin/data/Dnd35eDocumentSystemModel.mjs';
+import type { DocumentSystemModel } from '@ec/CoreMixin/data/DocumentSystemModel.mjs';
 
-type SystemModelCtor = AbstractConstructorOf<Dnd35eDocumentSystemModel<any>> & {
+type SystemModelCtor = AbstractConstructorOf<DocumentSystemModel<any>> & {
   defineSchema(): Record<string, any>;
   LOCALIZATION_PREFIXES: string[];
 };

--- a/src/entities/items/baseItem/data/ItemSystemModel.mts
+++ b/src/entities/items/baseItem/data/ItemSystemModel.mts
@@ -1,4 +1,4 @@
-import { Dnd35eDocumentSystemModel } from '@ec/CoreMixin/data/Dnd35eDocumentSystemModel.mjs';
+import { DocumentSystemModel } from '@ec/CoreMixin/data/DocumentSystemModel.mjs';
 import {
   requiredBooleanField,
   requiredStringField,
@@ -10,7 +10,7 @@ const {
   SchemaField,
 } = foundry.data.fields;
 
-abstract class ItemSystemModel extends Dnd35eDocumentSystemModel<foundry.documents.Item> {
+abstract class ItemSystemModel extends DocumentSystemModel<foundry.documents.Item> {
   static override LOCALIZATION_PREFIXES = [...super.LOCALIZATION_PREFIXES, 'dnd35e.ITEM'];
 
   static override defineSchema (): Record<string, any> {

--- a/src/entities/items/components/Physical/PhysicalItemDnd35e.mts
+++ b/src/entities/items/components/Physical/PhysicalItemDnd35e.mts
@@ -1,4 +1,4 @@
-import { Dnd35eDocumentMixin } from '@ec/CoreMixin/Dnd35eDocument.mjs';
+import { DocumentMixin } from '@ec/CoreMixin/DocumentDnd35e.mjs';
 import type { IdentifiableDocumentSourceProps } from '@ec/Identifiable/index.mjs';
 import {
   IdentifiableDocumentMixin,
@@ -19,8 +19,8 @@ type PhysicalItemSource<TItemType extends ItemType = ItemType> =
     & PhysicalItemSourceProps;
 
 // ─── Pre-composed mixin base ────────────────────────────────────────────────
-/** ItemDnd35e → Dnd35eDocumentMixin → IdentifiableDocumentMixin */
-const IdentifiableItemBase = IdentifiableDocumentMixin(Dnd35eDocumentMixin(ItemDnd35eClass));
+/** ItemDnd35e → DocumentMixin → IdentifiableDocumentMixin */
+const IdentifiableItemBase = IdentifiableDocumentMixin(DocumentMixin(ItemDnd35eClass));
 
 // ─── Abstract class layer ───────────────────────────────────────────────────
 


### PR DESCRIPTION
# PR 4 — Architectural rename of cross-document base (Groups G4a–G4b)

Fourth PR in the 14-PR naming-convention refactor series tracked in [`docs/migration-plan/poc/refactor-naming-conventions.md`](docs/migration-plan/poc/refactor-naming-conventions.md).

## Scope

Rename the shared cross-document mixin/base layer (`Dnd35eDocument*` family) to obey R.2.3 (suffix rule) and R.2.5 (file = primary export):

| Old | New | Note |
|---|---|---|
| `Dnd35eDocument` (instance type) | `DocumentDnd35e` | |
| `Dnd35eDocumentMixin` | `DocumentMixin` | |
| `Dnd35eDocumentProperties` | `DocumentProperties` | |
| `Dnd35eDocumentConstructor` | `DocumentConstructor` | No Foundry collision; suffix not needed |
| `Dnd35eDocumentFlags` (file + type) | `DocumentFlagsDnd35e` | **Verified collision** with Foundry `DocumentFlags`; suffix retained |
| `Dnd35eDocumentSystemModel` | `DocumentSystemModel` | |

## Checklist items completed

### Group 4a — `Dnd35eDocument` family
- [x] G4a.1 — File rename `Dnd35eDocument.mts` → `DocumentDnd35e.mts`
- [x] G4a.2 — Symbol renames inside the file
- [x] G4a.3 — `Dnd35eDocumentFlags.mts` → `DocumentFlagsDnd35e.mts` + type rename (Foundry collision)
- [x] G4a.4 — Importers + re-export barrels updated
- [x] G4a.5 — Build clean

### Group 4b — `Dnd35eDocumentSystemModel` → `DocumentSystemModel`
- [x] G4b.1 — File rename
- [x] G4b.2 — Class + interface mirror renamed
- [x] G4b.3 — Importers updated
- [x] G4b.4 — Build clean

## Commit strategy

| # | Commit | Group |
|---|---|---|
| 1 | `905b664` | G4a core (file + 4 symbols + 3 importers) |
| 2 | `0495c3a` | G4a.3 Flags rename (suffix form, Foundry collision) |
| 3 | `e71c529` | G4b SystemModel rename |
| 4 | `13b3cdb` | docs: mark G4a–G4b complete |

Each refactor commit independently buildable and `tsc --noEmit`-clean.

## Verification

| Gate                       | Result                                |
|----------------------------|---------------------------------------|
| `npm run build`            | ✅ clean per commit                   |
| `npx tsc --noEmit`         | ✅ zero errors                        |
| `npx vitest run`           | ✅ 181 passed, 8 todo (20 files)      |
| `npx playwright test`      | ✅ 20/20 passed (6.8m)                |

## Next up

- **PR 5** (G4c + G4d) — `Dnd35eActiveEffect` → `ActiveEffectDnd35e` + `Dnd35eActiveEffectConfig` → `ActiveEffectConfigDnd35e`.
