### PR TITLE
refactor(pr05): Active Effect class+config rename (G4c-G4d)

### DIFF
--- a/docs/migration-plan/poc/refactor-naming-conventions.md
+++ b/docs/migration-plan/poc/refactor-naming-conventions.md
@@ -442,17 +442,17 @@ Every numbered task ends with `npm run build` exit 0. Failures block the next ta
 - [x] G4b.4 — `npm run build` clean; commit
 
 ### Group 4c: `Dnd35eActiveEffect` → `ActiveEffectDnd35e`
-- [ ] G4c.1 — Rename file `Dnd35eActiveEffect.mts` → `ActiveEffectDnd35e.mts`
-- [ ] G4c.2 — Rename: `Dnd35eActiveEffect` (class) → `ActiveEffectDnd35e`, `Dnd35eActiveEffectFlags` → `ActiveEffectFlags`, `Dnd35eActiveEffectBase` (const) → `ActiveEffectBase`, `Dnd35eActiveEffectSource` → `ActiveEffectSourceDnd35e` (**verified collision**), `Dnd35eActiveEffectSystemSource` → `ActiveEffectSystemSourceDnd35e` (**verified collision**)
-- [ ] G4c.3 — `ActiveEffectProxyDnd35e` already in suffix form — verify, no rename
-- [ ] G4c.4 — Update all imports / re-export barrels
-- [ ] G4c.5 — `npm run build` clean; commit
+- [x] G4c.1 — Rename file `Dnd35eActiveEffect.mts` → `ActiveEffectDnd35e.mts`
+- [x] G4c.2 — Rename: `Dnd35eActiveEffect` (class) → `ActiveEffectDnd35e`, `Dnd35eActiveEffectFlags` → `ActiveEffectFlags`, `Dnd35eActiveEffectBase` (const) → `ActiveEffectBase`, `Dnd35eActiveEffectSource` → `ActiveEffectSourceDnd35e` (**verified collision**), `Dnd35eActiveEffectSystemSource` → `ActiveEffectSystemSourceDnd35e` (**verified collision**)
+- [x] G4c.3 — `ActiveEffectProxyDnd35e` already in suffix form — verify, no rename
+- [x] G4c.4 — Update all imports / re-export barrels
+- [x] G4c.5 — `npm run build` clean; commit
 
 ### Group 4d: `Dnd35eActiveEffectConfig` → `ActiveEffectConfigDnd35e`
-- [ ] G4d.1 — Rename file
-- [ ] G4d.2 — Rename class symbol
-- [ ] G4d.3 — Update imports / re-export barrels (Secret, Material, General sheets all extend this)
-- [ ] G4d.4 — `npm run build` clean; commit
+- [x] G4d.1 — Rename file
+- [x] G4d.2 — Rename class symbol
+- [x] G4d.3 — Update imports / re-export barrels (Secret, Material, General sheets all extend this)
+- [x] G4d.4 — `npm run build` clean; commit
 
 ### Group 5a: `PhysicalItemDnd35e.mts` → `PhysicalItem.mts`
 - [ ] G5a.1 — Rename file (class already named `PhysicalItem`)

--- a/src/entities/activeEffects/BaseActiveEffect/ActiveEffectDnd35e.mts
+++ b/src/entities/activeEffects/BaseActiveEffect/ActiveEffectDnd35e.mts
@@ -86,12 +86,12 @@ const ActiveEffectProxyDnd35e = new Proxy(ActiveEffectDnd35e, {
     if (type === GENERAL_EFFECT_TYPE) {
       return new ActiveEffectDnd35e(...args);
     }
-    const ItemClass = CONFIG.dnd35e.activeEffect.documentClasses[type] as unknown as typeof ActiveEffectDnd35e;
-    if (!ItemClass) {
+    const EffectClass = CONFIG.dnd35e.activeEffect.documentClasses[type] as unknown as typeof ActiveEffectDnd35e;
+    if (!EffectClass) {
       LogHelper.error(`ActiveEffect type ${type} does not exist or is not properly supported for ActiveEffectProxyDnd35e`);
       return new ActiveEffectDnd35e(...args);
     }
-    return new ItemClass(...args);
+    return new EffectClass(...args);
   },
 });
 

--- a/src/entities/activeEffects/BaseActiveEffect/ActiveEffectDnd35e.mts
+++ b/src/entities/activeEffects/BaseActiveEffect/ActiveEffectDnd35e.mts
@@ -2,7 +2,7 @@ import type { ActorDnd35e } from '@actors/baseActor/index.mjs';
 import type { DocumentConstructionContext } from '@common/_types.mjs';
 import { DocumentMixin } from '@ec/CoreMixin/DocumentDnd35e.mjs';
 import { getDisplayName } from '@ec/CoreMixin/index.mjs';
-import type { ActiveEffectSystemData, Dnd35eActiveEffectSystemSource } from '@effects/BaseActiveEffect/data/ActiveEffectSystemData.mjs';
+import type { ActiveEffectSystemData, ActiveEffectSystemSourceDnd35e } from '@effects/BaseActiveEffect/data/ActiveEffectSystemData.mjs';
 import { EFFECT_CHANGE_TARGET } from '@effects/BaseActiveEffect/data/constants.mjs';
 import type { EffectType } from '@effects/effectTypes.mjs';
 import { GENERAL_EFFECT_TYPE } from '@effects/effectTypes.mjs';
@@ -10,27 +10,27 @@ import { LogHelper } from '@helpers/logHelper.mjs';
 import type { ItemDnd35e } from '@items/baseItem/index.mjs';
 import type { ItemType } from '@items/itemTypes.mjs';
 
-type Dnd35eActiveEffectFlags<T extends object = Record<string, unknown>> = Record<string, Record<string, unknown>> & {
+type ActiveEffectFlags<T extends object = Record<string, unknown>> = Record<string, Record<string, unknown>> & {
   dnd35e: T;
 };
 
-type Dnd35eActiveEffectSource<
+type ActiveEffectSourceDnd35e<
   TEffectType extends EffectType = EffectType,
-  TSystemSource extends Dnd35eActiveEffectSystemSource = Dnd35eActiveEffectSystemSource
+  TSystemSource extends ActiveEffectSystemSourceDnd35e = ActiveEffectSystemSourceDnd35e
 > = foundry.documents.ActiveEffectSource<TEffectType, TSystemSource>;
 
 // Apply mixin at runtime but cast to preserve generic parameter compatibility.
 // TypeScript mixins erase generics; this cast is safe because the mixin only adds
 // methods/properties and doesn't alter the constructor signature's generic behavior.
-const Dnd35eActiveEffectBase = DocumentMixin(foundry.documents.ActiveEffect) as unknown as typeof foundry.documents.ActiveEffect;
+const ActiveEffectBase = DocumentMixin(foundry.documents.ActiveEffect) as unknown as typeof foundry.documents.ActiveEffect;
 
-class Dnd35eActiveEffect<
+class ActiveEffectDnd35e<
   TParent extends ActorDnd35e | ItemDnd35e<ItemType> | null = ActorDnd35e | ItemDnd35e<ItemType> | null,
   TEffectType extends EffectType = EffectType,
   TSystemData extends ActiveEffectSystemData = ActiveEffectSystemData
 >
-  extends Dnd35eActiveEffectBase<TParent> {
-  declare flags: Dnd35eActiveEffectFlags;
+  extends ActiveEffectBase<TParent> {
+  declare flags: ActiveEffectFlags;
   declare system: TSystemData;
   declare type: TEffectType;
 
@@ -68,10 +68,10 @@ class Dnd35eActiveEffect<
   }
 }
 
-const ActiveEffectProxyDnd35e = new Proxy(Dnd35eActiveEffect, {
+const ActiveEffectProxyDnd35e = new Proxy(ActiveEffectDnd35e, {
   construct (
     _target,
-    args: [source: PreCreate<Dnd35eActiveEffectSource>, context?: DocumentConstructionContext<ActorDnd35e | ItemDnd35e<ItemType> | null>]
+    args: [source: PreCreate<ActiveEffectSourceDnd35e>, context?: DocumentConstructionContext<ActorDnd35e | ItemDnd35e<ItemType> | null>]
   ) {
     const [source] = args;
     let type = source?.type;
@@ -84,16 +84,16 @@ const ActiveEffectProxyDnd35e = new Proxy(Dnd35eActiveEffect, {
     }
 
     if (type === GENERAL_EFFECT_TYPE) {
-      return new Dnd35eActiveEffect(...args);
+      return new ActiveEffectDnd35e(...args);
     }
-    const ItemClass = CONFIG.dnd35e.activeEffect.documentClasses[type] as unknown as typeof Dnd35eActiveEffect;
+    const ItemClass = CONFIG.dnd35e.activeEffect.documentClasses[type] as unknown as typeof ActiveEffectDnd35e;
     if (!ItemClass) {
       LogHelper.error(`ActiveEffect type ${type} does not exist or is not properly supported for ActiveEffectProxyDnd35e`);
-      return new Dnd35eActiveEffect(...args);
+      return new ActiveEffectDnd35e(...args);
     }
     return new ItemClass(...args);
   },
 });
 
-export { ActiveEffectProxyDnd35e, Dnd35eActiveEffect };
-export type { Dnd35eActiveEffectFlags };
+export { ActiveEffectDnd35e, ActiveEffectProxyDnd35e };
+export type { ActiveEffectFlags, ActiveEffectSourceDnd35e };

--- a/src/entities/activeEffects/BaseActiveEffect/data/ActiveEffectSystemData.mts
+++ b/src/entities/activeEffects/BaseActiveEffect/data/ActiveEffectSystemData.mts
@@ -18,18 +18,18 @@ interface Dnd35eEffectChangeData extends EffectChangeData {
   condition?: string | null;
 }
 
-interface Dnd35eActiveEffectSystemSource extends DocumentSystemData, Omit<ActiveEffectSystemSource, 'changes'> {
+interface ActiveEffectSystemSourceDnd35e extends DocumentSystemData, Omit<ActiveEffectSystemSource, 'changes'> {
   target: ActiveEffectTarget;
   isHidden: boolean;
   changes: Dnd35eEffectChangeData[];
 }
 
-interface ActiveEffectSystemData extends Dnd35eActiveEffectSystemSource {
+interface ActiveEffectSystemData extends ActiveEffectSystemSourceDnd35e {
 }
 
 export type {
   ActiveEffectSystemData,
+  ActiveEffectSystemSourceDnd35e,
   ActiveEffectTarget,
-  Dnd35eActiveEffectSystemSource,
   Dnd35eEffectChangeData,
 };

--- a/src/entities/activeEffects/BaseActiveEffect/data/index.mts
+++ b/src/entities/activeEffects/BaseActiveEffect/data/index.mts
@@ -1,6 +1,6 @@
 import type {
   ActiveEffectSystemData,
-  Dnd35eActiveEffectSystemSource,
+  ActiveEffectSystemSourceDnd35e,
   Dnd35eEffectChangeData,
 } from './ActiveEffectSystemData.mjs';
 import { ActiveEffectSystemModel } from './ActiveEffectSystemModel.mjs';
@@ -41,9 +41,9 @@ export {
 
 export type {
   ActiveEffectSystemData,
+  ActiveEffectSystemSourceDnd35e,
   ActiveEffectTarget,
   ActiveEffectTargetLocalizationValues,
-  Dnd35eActiveEffectSystemSource,
   Dnd35eChangeType,
   Dnd35eEffectChangeData,
   EffectChangePhase,

--- a/src/entities/activeEffects/BaseActiveEffect/index.mts
+++ b/src/entities/activeEffects/BaseActiveEffect/index.mts
@@ -34,7 +34,7 @@ import type {
   ActiveEffectConfigStoreDocumentGetters,
 } from './sheet/index.mjs';
 import {
-  Dnd35eActiveEffectConfig,
+  ActiveEffectConfigDnd35e,
   EffectChanges,
   effectChangesTab,
   EffectChangeValue,
@@ -64,11 +64,11 @@ export type {
 
 export {
   ACTIVE_EFFECT_TARGETS,
+  ActiveEffectConfigDnd35e,
   ActiveEffectDnd35e,
   ActiveEffectProxyDnd35e,
   ActiveEffectSystemModel,
   ALL_CHANGE_TYPES,
-  Dnd35eActiveEffectConfig,
   EFFECT_CHANGE_PHASES,
   EFFECT_CHANGE_TARGET,
   EFFECT_CHANGE_TARGETS,

--- a/src/entities/activeEffects/BaseActiveEffect/index.mts
+++ b/src/entities/activeEffects/BaseActiveEffect/index.mts
@@ -1,8 +1,15 @@
 import type {
+  ActiveEffectFlags,
+} from './ActiveEffectDnd35e.mjs';
+import {
+  ActiveEffectDnd35e,
+  ActiveEffectProxyDnd35e,
+} from './ActiveEffectDnd35e.mjs';
+import type {
   ActiveEffectSystemData,
+  ActiveEffectSystemSourceDnd35e,
   ActiveEffectTarget,
   ActiveEffectTargetLocalizationValues,
-  Dnd35eActiveEffectSystemSource,
   Dnd35eChangeType,
   Dnd35eEffectChangeData,
   EffectChangePhase,
@@ -21,13 +28,6 @@ import {
   INITIAL_EFFECT_CHANGE_PHASE,
   SYSTEM_CHANGE_TYPE,
 } from './data/index.mjs';
-import type {
-  Dnd35eActiveEffectFlags,
-} from './Dnd35eActiveEffect.mjs';
-import {
-  ActiveEffectProxyDnd35e,
-  Dnd35eActiveEffect,
-} from './Dnd35eActiveEffect.mjs';
 import type {
   ActiveEffectConfigStore,
   ActiveEffectConfigStoreDocumentActions,
@@ -50,11 +50,11 @@ export type {
   ActiveEffectConfigStore,
   ActiveEffectConfigStoreDocumentActions,
   ActiveEffectConfigStoreDocumentGetters,
+  ActiveEffectFlags,
   ActiveEffectSystemData,
+  ActiveEffectSystemSourceDnd35e,
   ActiveEffectTarget,
   ActiveEffectTargetLocalizationValues,
-  Dnd35eActiveEffectFlags,
-  Dnd35eActiveEffectSystemSource,
   Dnd35eChangeType,
   Dnd35eEffectChangeData,
   EffectChangePhase,
@@ -64,10 +64,10 @@ export type {
 
 export {
   ACTIVE_EFFECT_TARGETS,
+  ActiveEffectDnd35e,
   ActiveEffectProxyDnd35e,
   ActiveEffectSystemModel,
   ALL_CHANGE_TYPES,
-  Dnd35eActiveEffect,
   Dnd35eActiveEffectConfig,
   EFFECT_CHANGE_PHASES,
   EFFECT_CHANGE_TARGET,

--- a/src/entities/activeEffects/BaseActiveEffect/resolveChangeValue.mts
+++ b/src/entities/activeEffects/BaseActiveEffect/resolveChangeValue.mts
@@ -3,7 +3,7 @@ import { EFFECT_CHANGE_TARGET } from '@effects/BaseActiveEffect/data/constants.m
 import { buildDocumentDataMap, FormulaData } from '@helpers/formulae/index.mjs';
 import type { ItemDnd35e } from '@items/baseItem/index.mjs';
 
-import type { Dnd35eActiveEffect } from './Dnd35eActiveEffect.mjs';
+import type { ActiveEffectDnd35e } from './ActiveEffectDnd35e.mjs';
 
 const {
   BooleanField,
@@ -14,7 +14,7 @@ const {
 type SupportedEffectParent = foundry.documents.Actor | ItemDnd35e | null;
 
 function getEffectContexts(
-  effect: Dnd35eActiveEffect,
+  effect: ActiveEffectDnd35e,
   change: Dnd35eEffectChangeData
 ): {
   targetDocument: foundry.abstract.Document | null;
@@ -85,7 +85,7 @@ function tryEvaluateNumber(expression: string): number | null {
 }
 
 function resolveActiveEffectChangeValue(
-  effect: Dnd35eActiveEffect,
+  effect: ActiveEffectDnd35e,
   change: Dnd35eEffectChangeData
 ): unknown {
   const rawValue = change.value;
@@ -113,7 +113,7 @@ function resolveActiveEffectChangeValue(
 }
 
 function resolveMaskedActiveEffectChangeValue(
-  effect: Dnd35eActiveEffect,
+  effect: ActiveEffectDnd35e,
   change: Dnd35eEffectChangeData
 ): unknown {
   const resolvedValue = resolveActiveEffectChangeValue(effect, change);
@@ -156,7 +156,7 @@ function resolveMaskedActiveEffectChangeValue(
 }
 
 function resolveActiveEffectChange(
-  effect: Dnd35eActiveEffect,
+  effect: ActiveEffectDnd35e,
   change: Dnd35eEffectChangeData
 ): Dnd35eEffectChangeData {
   const resolvedValue = resolveActiveEffectChangeValue(effect, change);

--- a/src/entities/activeEffects/BaseActiveEffect/sheet/ActiveEffectConfigDnd35e.mts
+++ b/src/entities/activeEffects/BaseActiveEffect/sheet/ActiveEffectConfigDnd35e.mts
@@ -3,7 +3,7 @@ import { VueActiveEffectConfig } from '@vueApps/index.mjs';
 import type { Dnd35eEffectChangeData } from '../data/ActiveEffectSystemData.mjs';
 
 
-abstract class Dnd35eActiveEffectConfig extends VueActiveEffectConfig {
+abstract class ActiveEffectConfigDnd35e extends VueActiveEffectConfig {
 
   override async close(
     options?: foundry.applications.ApplicationClosingOptions
@@ -52,5 +52,5 @@ abstract class Dnd35eActiveEffectConfig extends VueActiveEffectConfig {
 }
 
 export {
-  Dnd35eActiveEffectConfig,
+  ActiveEffectConfigDnd35e,
 };

--- a/src/entities/activeEffects/BaseActiveEffect/sheet/ActiveEffectConfigStore.mts
+++ b/src/entities/activeEffects/BaseActiveEffect/sheet/ActiveEffectConfigStore.mts
@@ -2,9 +2,9 @@ import type { ActorDnd35e } from '@actors/baseActor/index.mjs';
 import type Color from '@common/utils/color.mjs';
 import type { DocumentSheetStore, DocumentSheetStoreDocumentActions, DocumentSheetStoreDocumentGetters } from '@ec/CoreMixin/index.mjs';
 import { useDocumentSheetStore } from '@ec/CoreMixin/index.mjs';
+import type { ActiveEffectDnd35e } from '@effects/BaseActiveEffect/ActiveEffectDnd35e.mjs';
 import type { Dnd35eEffectChangeData } from '@effects/BaseActiveEffect/data/ActiveEffectSystemData.mjs';
 import { ActiveEffectSystemModel } from '@effects/BaseActiveEffect/data/ActiveEffectSystemModel.mjs';
-import type { Dnd35eActiveEffect } from '@effects/BaseActiveEffect/Dnd35eActiveEffect.mjs';
 import { buildMergedFamiliarContext, getFamiliarBuilder } from '@helpers/formulae/index.mjs';
 import type { ContextDocumentType, TargetContexts } from '@helpers/formulae/registry.mjs';
 import type { FamiliarContext } from '@helpers/formulae/types.mjs';
@@ -23,7 +23,7 @@ const syncOpenSheetTitle = (sheet: { rendered?: boolean; title?: string; window?
   }
 };
 
-const useActiveEffectConfigStore = <TDocument extends Dnd35eActiveEffect>(
+const useActiveEffectConfigStore = <TDocument extends ActiveEffectDnd35e>(
   context: VueApplicationContext<TDocument>
 ) => {
   const baseStore = useDocumentSheetStore(context, {
@@ -273,7 +273,7 @@ type ActiveEffectConfigStoreDocumentGetters = DocumentSheetStoreDocumentGetters 
   getTargetFamiliarContextName: (target: string) => string;
 };
 
-type ActiveEffectConfigStoreDocumentActions<TDocument extends Dnd35eActiveEffect> = DocumentSheetStoreDocumentActions<TDocument> & {
+type ActiveEffectConfigStoreDocumentActions<TDocument extends ActiveEffectDnd35e> = DocumentSheetStoreDocumentActions<TDocument> & {
   addChange: (changeData: Dnd35eEffectChangeData) => Promise<boolean>;
   removeChange?: (index: number) => Promise<boolean>;
   updateChangeField: (index: number, field: string, value: unknown) => Promise<boolean>;
@@ -281,7 +281,7 @@ type ActiveEffectConfigStoreDocumentActions<TDocument extends Dnd35eActiveEffect
   updateDurationUnits: (units: string) => Promise<boolean>;
 };
 
-type ActiveEffectConfigStore<TDocument extends Dnd35eActiveEffect = Dnd35eActiveEffect> = DocumentSheetStore<TDocument> & {
+type ActiveEffectConfigStore<TDocument extends ActiveEffectDnd35e = ActiveEffectDnd35e> = DocumentSheetStore<TDocument> & {
   documentGetters: ActiveEffectConfigStoreDocumentGetters;
   documentActions: ActiveEffectConfigStoreDocumentActions<TDocument>;
 };

--- a/src/entities/activeEffects/BaseActiveEffect/sheet/index.mts
+++ b/src/entities/activeEffects/BaseActiveEffect/sheet/index.mts
@@ -1,3 +1,4 @@
+import { ActiveEffectConfigDnd35e } from './ActiveEffectConfigDnd35e.mjs';
 import type {
   ActiveEffectConfigStore,
   ActiveEffectConfigStoreDocumentActions,
@@ -7,7 +8,6 @@ import { useActiveEffectConfigStore } from './ActiveEffectConfigStore.mjs';
 import {
   EffectChangeValue,
 } from './components/index.mjs';
-import { Dnd35eActiveEffectConfig } from './Dnd35eActiveEffectConfig.mjs';
 import {
   EffectChanges,
   effectChangesTab,
@@ -19,7 +19,7 @@ import {
 } from './tabs/index.mjs';
 
 export {
-  Dnd35eActiveEffectConfig,
+  ActiveEffectConfigDnd35e,
   EffectChanges,
   effectChangesTab,
   EffectChangeValue,

--- a/src/entities/activeEffects/general/General.mts
+++ b/src/entities/activeEffects/general/General.mts
@@ -1,11 +1,11 @@
-import { Dnd35eActiveEffect } from '@effects/BaseActiveEffect/Dnd35eActiveEffect.mjs';
+import { ActiveEffectDnd35e } from '@effects/BaseActiveEffect/ActiveEffectDnd35e.mjs';
 import type { GeneralSystemData } from '@effects/general/data/index.mjs';
 
 /**
  * General active effect document class — the standard effect type for dnd35e.
- * No specialized behavior; delegates to Dnd35eActiveEffect base.
+ * No specialized behavior; delegates to ActiveEffectDnd35e base.
  */
-class General extends Dnd35eActiveEffect {
+class General extends ActiveEffectDnd35e {
   declare type: 'general';
   declare system: GeneralSystemData;
 }

--- a/src/entities/activeEffects/general/data/GeneralSystemData.mts
+++ b/src/entities/activeEffects/general/data/GeneralSystemData.mts
@@ -1,10 +1,10 @@
-import type { ActiveEffectSystemData, Dnd35eActiveEffectSystemSource } from '@effects/BaseActiveEffect/data/ActiveEffectSystemData.mjs';
+import type { ActiveEffectSystemData, ActiveEffectSystemSourceDnd35e } from '@effects/BaseActiveEffect/data/ActiveEffectSystemData.mjs';
 
 /**
  * General active effect system data — the standard effect data type for dnd35e.
  * No additional fields; pure base AE schema.
  */
-interface GeneralSystemSource extends Dnd35eActiveEffectSystemSource {
+interface GeneralSystemSource extends ActiveEffectSystemSourceDnd35e {
 }
 
 interface GeneralSystemData extends ActiveEffectSystemData {

--- a/src/entities/activeEffects/index.mts
+++ b/src/entities/activeEffects/index.mts
@@ -1,4 +1,4 @@
-import { Dnd35eActiveEffect } from './BaseActiveEffect/Dnd35eActiveEffect.mjs';
+import { ActiveEffectDnd35e } from './BaseActiveEffect/ActiveEffectDnd35e.mjs';
 import type {
   EffectTarget,
   EffectType,
@@ -11,7 +11,7 @@ import {
 } from './effectTypes.mjs';
 
 export {
-  Dnd35eActiveEffect,
+  ActiveEffectDnd35e,
   EFFECT_TARGET,
   EFFECT_TYPES,
   GENERAL_EFFECT_TYPE,

--- a/src/entities/activeEffects/material/Material.mts
+++ b/src/entities/activeEffects/material/Material.mts
@@ -1,6 +1,6 @@
 import type { ActiveEffectSource } from '@common/documents/active-effect.mjs';
 import type { DocumentFlagsDnd35e } from '@ec/CoreMixin/index.mjs';
-import { Dnd35eActiveEffect } from '@effects/BaseActiveEffect/Dnd35eActiveEffect.mjs';
+import { ActiveEffectDnd35e } from '@effects/BaseActiveEffect/ActiveEffectDnd35e.mjs';
 import { LogHelper } from '@helpers/index.mjs';
 import { COMBAT_KEYS } from '@settings/combat/index.mjs';
 import { SYSTEM_ID } from '@settings/shared.mjs';
@@ -15,7 +15,7 @@ interface MaterialEffectFlags {
   // Add material-specific flags here as needed
 }
 
-class Material extends Dnd35eActiveEffect {
+class Material extends ActiveEffectDnd35e {
   declare type: MaterialEffectType;
   declare system: MaterialSystemData;
   declare flags: DocumentFlagsDnd35e<MaterialEffectFlags>;

--- a/src/entities/activeEffects/material/data/MaterialSystemData.mts
+++ b/src/entities/activeEffects/material/data/MaterialSystemData.mts
@@ -1,4 +1,4 @@
-import type { ActiveEffectSystemData, Dnd35eActiveEffectSystemSource, Dnd35eEffectChangeData } from '@effects/BaseActiveEffect/data/ActiveEffectSystemData.mjs';
+import type { ActiveEffectSystemData, ActiveEffectSystemSourceDnd35e, Dnd35eEffectChangeData } from '@effects/BaseActiveEffect/data/ActiveEffectSystemData.mjs';
 import type { Price, PriceSource } from '@settings/index.mjs';
 import type { PriceData } from '@settings/index.mjs';
 
@@ -17,7 +17,7 @@ interface MaterialEffectChangeData extends Dnd35eEffectChangeData {
   value: string | number | Price;
 }
 
-interface MaterialSystemSource extends MaterialSystemStats, Dnd35eActiveEffectSystemSource {
+interface MaterialSystemSource extends MaterialSystemStats, ActiveEffectSystemSourceDnd35e {
   changes: MaterialEffectChangeData[];
 }
 

--- a/src/entities/activeEffects/material/sheet/MaterialSheet.mts
+++ b/src/entities/activeEffects/material/sheet/MaterialSheet.mts
@@ -1,5 +1,5 @@
 import type { DocumentSheetConfiguration } from '@client/applications/api/document-sheet.mjs';
-import { Dnd35eActiveEffectConfig } from '@effects/BaseActiveEffect/sheet/Dnd35eActiveEffectConfig.mjs';
+import { ActiveEffectConfigDnd35e } from '@effects/BaseActiveEffect/sheet/ActiveEffectConfigDnd35e.mjs';
 import { Material } from '@effects/material/Material.mjs';
 
 import MaterialSheetVue from './MaterialSheet.vue';
@@ -9,7 +9,7 @@ type MaterialSheetRenderContext = {
   document: Material;
 };
 
-class MaterialSheet extends Dnd35eActiveEffectConfig {
+class MaterialSheet extends ActiveEffectConfigDnd35e {
   get vueComponent () {
     return MaterialSheetVue;
   }

--- a/src/entities/activeEffects/registration.mts
+++ b/src/entities/activeEffects/registration.mts
@@ -1,8 +1,8 @@
 import { EffectConfig } from '@constants/config/activeEffect.mjs';
 import type { NameFormulaDocument } from '@ec/CoreMixin/index.mjs';
 import { ensureNameFormulaOnCreate } from '@ec/CoreMixin/index.mjs';
+import { ActiveEffectProxyDnd35e } from '@effects/BaseActiveEffect/ActiveEffectDnd35e.mjs';
 import { EFFECT_CHANGE_PHASES } from '@effects/BaseActiveEffect/data/index.mjs';
-import { ActiveEffectProxyDnd35e } from '@effects/BaseActiveEffect/Dnd35eActiveEffect.mjs';
 import { GENERAL_EFFECT_TYPE, GeneralSystemModel } from '@effects/general/index.mjs';
 import { MaterialSystemModel } from '@effects/material/data/MaterialSystemModel.mjs';
 import { validateSingleMaterial } from '@effects/material/Material.mjs';

--- a/src/entities/activeEffects/secret/Secret.mts
+++ b/src/entities/activeEffects/secret/Secret.mts
@@ -1,4 +1,4 @@
-import { Dnd35eActiveEffect } from '@effects/BaseActiveEffect/Dnd35eActiveEffect.mjs';
+import { ActiveEffectDnd35e } from '@effects/BaseActiveEffect/ActiveEffectDnd35e.mjs';
 
 import type { SecretSystemData } from './data/index.mjs';
 import type { SecretEffectType } from './secretEffectType.mjs';
@@ -9,7 +9,7 @@ import { secretEffectType } from './secretEffectType.mjs';
  * Uses MASK change mode entries to define which fields are masked and with what values.
  * An item with active (non-disabled) Secret AEs is considered unidentified.
  */
-class Secret extends Dnd35eActiveEffect {
+class Secret extends ActiveEffectDnd35e {
   declare type: SecretEffectType;
   declare system: SecretSystemData;
 

--- a/src/entities/activeEffects/secret/data/SecretSystemData.mts
+++ b/src/entities/activeEffects/secret/data/SecretSystemData.mts
@@ -1,10 +1,10 @@
-import type { ActiveEffectSystemData, Dnd35eActiveEffectSystemSource } from '@effects/BaseActiveEffect/data/ActiveEffectSystemData.mjs';
+import type { ActiveEffectSystemData, ActiveEffectSystemSourceDnd35e } from '@effects/BaseActiveEffect/data/ActiveEffectSystemData.mjs';
 
 /**
  * Secret active effect system data — masks field values from non-GM users.
  * `isPlayerEditSecret` marks secrets auto-created by player edits on masked fields.
  */
-interface SecretSystemSource extends Dnd35eActiveEffectSystemSource {
+interface SecretSystemSource extends ActiveEffectSystemSourceDnd35e {
   isPlayerEditSecret: boolean;
 }
 

--- a/src/entities/activeEffects/secret/sheet/SecretSheet.mts
+++ b/src/entities/activeEffects/secret/sheet/SecretSheet.mts
@@ -1,5 +1,5 @@
 import type { DocumentSheetConfiguration } from '@client/applications/api/document-sheet.mjs';
-import { Dnd35eActiveEffectConfig } from '@effects/BaseActiveEffect/sheet/Dnd35eActiveEffectConfig.mjs';
+import { ActiveEffectConfigDnd35e } from '@effects/BaseActiveEffect/sheet/ActiveEffectConfigDnd35e.mjs';
 import type { Secret } from '@effects/secret/Secret.mjs';
 
 import SecretSheetVue from './SecretSheet.vue';
@@ -9,7 +9,7 @@ type SecretSheetRenderContext = {
   document: Secret;
 };
 
-class SecretSheet extends Dnd35eActiveEffectConfig {
+class SecretSheet extends ActiveEffectConfigDnd35e {
   get vueComponent () {
     return SecretSheetVue;
   }

--- a/src/entities/actors/baseActor/ActorDnd35e.mts
+++ b/src/entities/actors/baseActor/ActorDnd35e.mts
@@ -2,9 +2,9 @@ import type { ActorType } from '@actors/actorTypes.mjs';
 import type { DocumentConstructionContext } from '@common/_types.mjs';
 import type EmbeddedCollection from '@common/abstract/embedded-collection.mjs';
 import type { EffectChangeData } from '@common/documents/active-effect.mjs';
+import type { ActiveEffectDnd35e } from '@effects/BaseActiveEffect/ActiveEffectDnd35e.mjs';
 import type { Dnd35eEffectChangeData } from '@effects/BaseActiveEffect/data/ActiveEffectSystemData.mjs';
 import { EFFECT_CHANGE_TARGET, EFFECT_CHANGE_TYPE } from '@effects/BaseActiveEffect/data/constants.mjs';
-import type { Dnd35eActiveEffect } from '@effects/BaseActiveEffect/Dnd35eActiveEffect.mjs';
 import { resolveActiveEffectChange } from '@effects/BaseActiveEffect/resolveChangeValue.mjs';
 import { LogHelper } from '@helpers/logHelper.mjs';
 import type { ItemDnd35e } from '@items/baseItem/index.mjs';
@@ -14,7 +14,7 @@ import type { TokenDocumentDnd35e } from '@scene/token-document/TokenDocumentDnd
 import type { ActorSystemData } from './index.mjs';
 
 interface AppliedActorEffectChange extends Dnd35eEffectChangeData {
-  effect: Dnd35eActiveEffect;
+  effect: ActiveEffectDnd35e;
 }
 
 
@@ -23,7 +23,7 @@ class ActorDnd35e<
   TActorType extends ActorType = ActorType,
   TSystemData extends ActorSystemData = ActorSystemData
 > extends Actor<TToken> {
-  declare readonly effects: EmbeddedCollection<Dnd35eActiveEffect<this>>;
+  declare readonly effects: EmbeddedCollection<ActiveEffectDnd35e<this>>;
   declare readonly items: EmbeddedCollection<ItemDnd35e<ItemType, this>>;
   declare type: TActorType;
   declare system: TSystemData;
@@ -56,7 +56,7 @@ class ActorDnd35e<
         const changeTarget = change.target ?? EFFECT_CHANGE_TARGET.ACTOR;
         if ( !change.key || (change.phase !== phase) || (changeTarget !== EFFECT_CHANGE_TARGET.ACTOR) ) continue;
         const copy = foundry.utils.deepClone(resolveActiveEffectChange(effect, change)) as AppliedActorEffectChange;
-        copy.effect = effect as Dnd35eActiveEffect;
+        copy.effect = effect as ActiveEffectDnd35e;
         copy.type ??= EFFECT_CHANGE_TYPE.ADD;
         copy.priority ??= 0;
         changes.push(copy);
@@ -85,7 +85,7 @@ class ActorDnd35e<
   /**
    * Override to iterate all applicable effects from actor and transferred item effects.
    */
-  override *allApplicableEffects(): Generator<Dnd35eActiveEffect<this | ItemDnd35e<ItemType, this>>, void, void> {
+  override *allApplicableEffects(): Generator<ActiveEffectDnd35e<this | ItemDnd35e<ItemType, this>>, void, void> {
     for ( const effect of this.effects ) {
       yield effect;
     }

--- a/src/entities/components/CoreMixin/formulaRegistrationHelpers.mts
+++ b/src/entities/components/CoreMixin/formulaRegistrationHelpers.mts
@@ -6,7 +6,7 @@ import type { EvaluationDocument, FormulaRegistration } from './sheet/index.mjs'
 
 /**
  * Minimal interface for documents that support formula registration.
- * Both the mixin and Dnd35eActiveEffect satisfy this.
+ * Both the mixin and ActiveEffectDnd35e satisfy this.
  */
 interface FormulaRegistrationHost {
   system: any;

--- a/src/entities/components/CoreMixin/sheet/DocumentSheetStore.mts
+++ b/src/entities/components/CoreMixin/sheet/DocumentSheetStore.mts
@@ -1,6 +1,6 @@
 import type { ActorType } from '@actors/actorTypes.mjs';
 import type { DatabaseUpdateOperation } from '@common/abstract/_types.mjs';
-import type { Dnd35eActiveEffect, EffectType } from '@effects/index.mjs';
+import type { ActiveEffectDnd35e, EffectType } from '@effects/index.mjs';
 import { addOrUpdatePlayerEditMask, findOrCreatePlayerEditSecret } from '@effects/secret/playerEditSecret.mjs';
 import { buildDocumentFamiliar } from '@helpers/formulae/index.mjs';
 import type { FamiliarSchema } from '@helpers/formulae/types.mjs';
@@ -38,7 +38,7 @@ import { resolveViewAwareFieldPlan } from './viewAwareFieldPlan.mjs';
 // Types
 // ---------------------------------------------------------------------------
 
-type SheetDocument = ItemDnd35e | Dnd35eActiveEffect;
+type SheetDocument = ItemDnd35e | ActiveEffectDnd35e;
 
 type DocumentSheetStoreUtils<TDocument extends SheetDocument> = FieldOverridesStoreUtils & {
   document: ShallowRef<TDocument>;

--- a/src/entities/items/baseItem/ItemDnd35e.mts
+++ b/src/entities/items/baseItem/ItemDnd35e.mts
@@ -3,9 +3,9 @@ import type { DocumentConstructionContext } from '@common/_types.mjs';
 import type EmbeddedCollection from '@common/abstract/embedded-collection.mjs';
 import type { EffectChangeData } from '@common/documents/active-effect.mjs';
 import { getDisplayName } from '@ec/CoreMixin/logic/index.mjs';
+import type { ActiveEffectDnd35e } from '@effects/BaseActiveEffect/ActiveEffectDnd35e.mjs';
 import type { Dnd35eEffectChangeData } from '@effects/BaseActiveEffect/data/ActiveEffectSystemData.mjs';
 import { EFFECT_CHANGE_TARGET, EFFECT_CHANGE_TYPE, FINAL_EFFECT_CHANGE_PHASE, INITIAL_EFFECT_CHANGE_PHASE, SYSTEM_CHANGE_TYPE } from '@effects/BaseActiveEffect/data/constants.mjs';
-import type { Dnd35eActiveEffect } from '@effects/BaseActiveEffect/Dnd35eActiveEffect.mjs';
 import { resolveActiveEffectChange, resolveMaskedActiveEffectChangeValue } from '@effects/BaseActiveEffect/resolveChangeValue.mjs';
 import { secretEffectType } from '@effects/secret/secretEffectType.mjs';
 import { FormulaData } from '@helpers/formulae/FormulaData.mjs';
@@ -30,7 +30,7 @@ class ItemDnd35e<TItemType extends ItemType = ItemType, TParent extends ActorDnd
     super(source, context);
     this._completedActiveEffectPhases = new Set();
   }
-  declare readonly effects: EmbeddedCollection<Dnd35eActiveEffect<this>>;
+  declare readonly effects: EmbeddedCollection<ActiveEffectDnd35e<this>>;
   declare type: TItemType;
   declare system: ItemSystemData;
   declare _source: ItemSourceDnd35e<TItemType>;
@@ -203,7 +203,7 @@ class ItemDnd35e<TItemType extends ItemType = ItemType, TParent extends ActorDnd
     this._completedActiveEffectPhases.add(phase);
 
     type AppliedItemEffectChange = EffectChangeData<ItemDnd35e<TItemType, TParent>>
-      & { type: string; effect: Dnd35eActiveEffect<ItemDnd35e<TItemType, TParent>> };
+      & { type: string; effect: ActiveEffectDnd35e<ItemDnd35e<TItemType, TParent>> };
     const changes: AppliedItemEffectChange[] = [];
     for ( const effect of this.allApplicableEffects() ) {
       if ( !effect.active ) continue;

--- a/src/entities/items/baseItem/sheet/ItemSheetStore.mts
+++ b/src/entities/items/baseItem/sheet/ItemSheetStore.mts
@@ -6,7 +6,7 @@ import type {
   SheetTab,
 } from '@ec/CoreMixin/index.mjs';
 import { defaultDetailsTab, useDocumentSheetStore } from '@ec/CoreMixin/index.mjs';
-import { Dnd35eActiveEffect } from '@effects/BaseActiveEffect/Dnd35eActiveEffect.mjs';
+import { ActiveEffectDnd35e } from '@effects/BaseActiveEffect/ActiveEffectDnd35e.mjs';
 import type { EffectType } from '@effects/effectTypes.mjs';
 import { EFFECT_TYPES } from '@effects/effectTypes.mjs';
 import type { ItemDnd35e } from '@items/baseItem/ItemDnd35e.mjs';
@@ -44,12 +44,12 @@ const useItemSheetStore = <TDocument extends ItemDnd35e>(context: VueApplication
   // with Foundry's EmbeddedCollection proxy (non-configurable property error)
   const hiddenEffectTypeIds = ref<Set<string>>(new Set());
   const allEffects = computed(() => [...(document.value.effects ?? [])]
-    .filter((effect: Dnd35eActiveEffect) => !hiddenEffectTypeIds.value.has(effect.type))
+    .filter((effect: ActiveEffectDnd35e) => !hiddenEffectTypeIds.value.has(effect.type))
   );
   // Non-GM users cannot see effects with isHidden: true
   const effects = computed(() => isGM
     ? allEffects.value
-    : allEffects.value.filter((e: Dnd35eActiveEffect) => !e.system.isHidden)
+    : allEffects.value.filter((e: ActiveEffectDnd35e) => !e.system.isHidden)
   );
   const getEffectsForField = (fieldPath: string) => computed(() => document.value.overrides?.[fieldPath]
     ? document.value.overrides?.[fieldPath] as []
@@ -58,9 +58,9 @@ const useItemSheetStore = <TDocument extends ItemDnd35e>(context: VueApplication
   const itemDocumentGetters = {
     ...baseStore.documentGetters,
     effects,
-    temporaryEffects: computed(() => effects.value.filter((e: Dnd35eActiveEffect) => !e.disabled && e.isTemporary)),
-    passiveEffects: computed(() => effects.value.filter((e: Dnd35eActiveEffect) => !e.disabled && !e.isTemporary)),
-    inactiveEffects: computed(() => effects.value.filter((e: Dnd35eActiveEffect) => e.disabled)),
+    temporaryEffects: computed(() => effects.value.filter((e: ActiveEffectDnd35e) => !e.disabled && e.isTemporary)),
+    passiveEffects: computed(() => effects.value.filter((e: ActiveEffectDnd35e) => !e.disabled && !e.isTemporary)),
+    inactiveEffects: computed(() => effects.value.filter((e: ActiveEffectDnd35e) => e.disabled)),
     hasOwner,
     getEffectsForField,
     hasEffectsForField: (fieldPath: string) => computed(() => getEffectsForField(fieldPath).value.length > 0),
@@ -97,13 +97,13 @@ const useItemSheetStore = <TDocument extends ItemDnd35e>(context: VueApplication
         origin: document.value.uuid,
         disabled: false,
       };
-      // TODO(Phase 7): fix type definitions — add createDialog static method signature to Dnd35eActiveEffect
-      await (Dnd35eActiveEffect as any).createDialog(effectData, {
+      // TODO(Phase 7): fix type definitions — add createDialog static method signature to ActiveEffectDnd35e
+      await (ActiveEffectDnd35e as any).createDialog(effectData, {
         parent: document.value,
       }, {
         types: Object.keys(EFFECT_TYPES),
       });
-      // const createData = Dnd35eActiveEffect.createDialog(effectData);
+      // const createData = ActiveEffectDnd35e.createDialog(effectData);
       // await document.value.createEmbeddedDocuments('ActiveEffect', [createData]);
       triggerRef(document);
     },
@@ -140,10 +140,10 @@ const useItemSheetStore = <TDocument extends ItemDnd35e>(context: VueApplication
 };
 
 type ItemDocumentGetters = DocumentSheetStoreDocumentGetters & {
-  effects: ComputedRef<Dnd35eActiveEffect[]>,
-  temporaryEffects: ComputedRef<Dnd35eActiveEffect[]>,
-  passiveEffects: ComputedRef<Dnd35eActiveEffect[]>,
-  inactiveEffects: ComputedRef<Dnd35eActiveEffect[]>,
+  effects: ComputedRef<ActiveEffectDnd35e[]>,
+  temporaryEffects: ComputedRef<ActiveEffectDnd35e[]>,
+  passiveEffects: ComputedRef<ActiveEffectDnd35e[]>,
+  inactiveEffects: ComputedRef<ActiveEffectDnd35e[]>,
   hasOwner: ComputedRef<boolean>;
   getEffectsForField: (fieldPath: string) => ComputedRef<object[]>;
 };

--- a/src/entities/items/baseItem/sheet/components/EffectCategory.vue
+++ b/src/entities/items/baseItem/sheet/components/EffectCategory.vue
@@ -71,7 +71,7 @@
 
 <script setup lang="ts">
   import { DocumentSheetStoreSymbol } from '@ec/CoreMixin/index.mjs';
-  import type { Dnd35eActiveEffect } from '@effects/index.mjs';
+  import type { ActiveEffectDnd35e } from '@effects/index.mjs';
   import { inject, ref, useSlots } from 'vue';
 
   import type { ItemSheetStore } from '../ItemSheetStore.mjs';
@@ -81,7 +81,7 @@
     defaultCollapsed = false,
   } = defineProps<{
     label: string;
-    effects: Dnd35eActiveEffect[];
+    effects: ActiveEffectDnd35e[];
     canEdit: boolean;
     showVisibilityToggle?: boolean;
     defaultCollapsed?: boolean;
@@ -103,23 +103,23 @@
       createLocalizedComputed,
     },
   } = inject(DocumentSheetStoreSymbol) as ItemSheetStore;
-  const effectEnablementTitle = (effect: Dnd35eActiveEffect) => effect.disabled
+  const effectEnablementTitle = (effect: ActiveEffectDnd35e) => effect.disabled
     ? createLocalizedComputed('dnd35e.EFFECT.Enable')
     : createLocalizedComputed('dnd35e.EFFECT.Disable');
 
-  const handleDelete = async (effect: Dnd35eActiveEffect) => {
+  const handleDelete = async (effect: ActiveEffectDnd35e) => {
     await removeEffect(effect.id);
   };
 
-  const handleEdit = (effect: Dnd35eActiveEffect) => {
+  const handleEdit = (effect: ActiveEffectDnd35e) => {
     editEffect(effect.id);
   };
 
-  const handleToggle = async (effect: Dnd35eActiveEffect) => {
+  const handleToggle = async (effect: ActiveEffectDnd35e) => {
     await toggleEffect(effect.id);
   };
 
-  const handleToggleHidden = async (effect: Dnd35eActiveEffect) => {
+  const handleToggleHidden = async (effect: ActiveEffectDnd35e) => {
     await toggleEffectHidden(effect.id);
   };
 

--- a/src/global.mts
+++ b/src/global.mts
@@ -5,7 +5,7 @@ import type Hotbar from '@client/applications/ui/hotbar.mjs';
 import type EffectsCanvasGroup from '@client/canvas/groups/effects.mjs';
 import type Config from '@client/config.mjs';
 import type { ActiveEffectConfigStore } from '@effects/BaseActiveEffect/index.mjs';
-import { Dnd35eActiveEffect } from '@entities/activeEffects/index.mjs';
+import { ActiveEffectDnd35e } from '@entities/activeEffects/index.mjs';
 import type { ItemSheetStore } from '@items/baseItem/index.mjs';
 import { ItemDnd35e } from '@items/baseItem/index.mjs';
 import type { ItemType } from '@items/itemTypes.mjs';
@@ -70,7 +70,7 @@ declare global {
         documentClasses: Record<string, new (...args: any[]) => ItemDnd35e>;
       },
       activeEffect: {
-        documentClasses: Record<string, new (...args: any[]) => Dnd35eActiveEffect>;
+        documentClasses: Record<string, new (...args: any[]) => ActiveEffectDnd35e>;
       },
       gameRules: {
         damageReductionTypes: Record<string, { label: string }>;

--- a/src/helpers/formulae/registry.mts
+++ b/src/helpers/formulae/registry.mts
@@ -10,7 +10,7 @@
 
 import type { ActorType } from '@actors/actorTypes.mjs';
 import type { ActorDnd35e } from '@actors/baseActor/index.mjs';
-import type { Dnd35eActiveEffect } from '@effects/BaseActiveEffect/index.mjs';
+import type { ActiveEffectDnd35e } from '@effects/BaseActiveEffect/index.mjs';
 import type { EffectType } from '@effects/effectTypes.mjs';
 import type { ItemDnd35e } from '@items/baseItem/ItemDnd35e.mjs';
 import type { ItemType } from '@items/itemTypes.mjs';
@@ -20,7 +20,7 @@ import type { AspectGroup, FamiliarContext, FamiliarSchema, FormulaFieldData } f
 import { mergeAspectGroups } from './utils.mjs';
 
 /** Union of all Foundry document classes that can serve as familiar context. */
-export type NonNullDocumentContext = ItemDnd35e | ActorDnd35e | Dnd35eActiveEffect;
+export type NonNullDocumentContext = ItemDnd35e | ActorDnd35e | ActiveEffectDnd35e;
 export type DocumentContext = NonNullDocumentContext | null;
 
 export type ContextDocumentType = ItemType | EffectType | ActorType;

--- a/src/vue/apps/VueActiveEffectConfig.mts
+++ b/src/vue/apps/VueActiveEffectConfig.mts
@@ -1,15 +1,15 @@
 import type { DocumentSheetConfiguration } from '@client/applications/api/document-sheet.mjs';
 import { VUE_APP_CLASS } from '@constants/cssClasses.mjs';
-import type { Dnd35eActiveEffect } from '@entities/activeEffects/index.mjs';
+import type { ActiveEffectDnd35e } from '@entities/activeEffects/index.mjs';
 import { SYSTEM_ID } from '@settings/shared.mjs';
 
 import type { VueApplicationConfiguration, VueRenderOptions } from './VueAppTypes.mjs';
 import { useVueDocumentSheetMixin } from './VueDocumentSheetMixin.mjs';
 
-const EffectConfigBase = foundry.applications.sheets.ActiveEffectConfig<Dnd35eActiveEffect, VueApplicationConfiguration<Dnd35eActiveEffect>, VueRenderOptions>;
+const EffectConfigBase = foundry.applications.sheets.ActiveEffectConfig<ActiveEffectDnd35e, VueApplicationConfiguration<ActiveEffectDnd35e>, VueRenderOptions>;
 
 abstract class VueActiveEffectConfig extends useVueDocumentSheetMixin(EffectConfigBase) {
-  static override get DEFAULT_OPTIONS (): DeepPartial<DocumentSheetConfiguration<Dnd35eActiveEffect>> {
+  static override get DEFAULT_OPTIONS (): DeepPartial<DocumentSheetConfiguration<ActiveEffectDnd35e>> {
     return {
       classes: [SYSTEM_ID, VUE_APP_CLASS],
       actions: {},
@@ -20,7 +20,7 @@ abstract class VueActiveEffectConfig extends useVueDocumentSheetMixin(EffectConf
       window: {
         resizable: true,
       },
-    } as DeepPartial<VueApplicationConfiguration<Dnd35eActiveEffect>>;
+    } as DeepPartial<VueApplicationConfiguration<ActiveEffectDnd35e>>;
   }
 }
 

--- a/src/vue/apps/VueAppTypes.mts
+++ b/src/vue/apps/VueAppTypes.mts
@@ -1,10 +1,10 @@
 import type { DocumentSheetConfiguration, DocumentSheetRenderOptions } from '@client/applications/api/document-sheet.mjs';
 import type { DocumentSheetStore } from '@ec/CoreMixin/index.mjs';
-import type { Dnd35eActiveEffect } from '@entities/activeEffects/index.mjs';
+import type { ActiveEffectDnd35e } from '@entities/activeEffects/index.mjs';
 import type { ViewMode } from '@helpers/formulae/types.mjs';
 import type { ItemDnd35e } from '@items/baseItem/index.mjs';
 
-interface VueApplicationConfiguration<TDocument extends ItemDnd35e | Dnd35eActiveEffect> extends
+interface VueApplicationConfiguration<TDocument extends ItemDnd35e | ActiveEffectDnd35e> extends
   DocumentSheetConfiguration<TDocument>
 {
   document: TDocument;
@@ -20,14 +20,14 @@ interface SheetState {
   viewMode: ViewMode;
 }
 
-interface VueApplicationContext<TDocument extends ItemDnd35e | Dnd35eActiveEffect> {
+interface VueApplicationContext<TDocument extends ItemDnd35e | ActiveEffectDnd35e> {
   document: TDocument;
   appConfigOptions: VueApplicationConfiguration<TDocument>;
   renderOptions?: VueRenderOptions;
   close: () => Promise<void>;
 }
 
-interface VueApplicationContextTransfer<TDocument extends ItemDnd35e | Dnd35eActiveEffect> extends VueApplicationContext<TDocument> {
+interface VueApplicationContextTransfer<TDocument extends ItemDnd35e | ActiveEffectDnd35e> extends VueApplicationContext<TDocument> {
   store?: DocumentSheetStore<TDocument> | undefined;
 }
 

--- a/src/vue/apps/VueDocumentSheetMixin.mts
+++ b/src/vue/apps/VueDocumentSheetMixin.mts
@@ -9,7 +9,7 @@ import type { DocumentSheetStore } from '@ec/CoreMixin/sheet/DocumentSheetStore.
 import { RenderModeStoreSymbol, useRenderModeStore } from '@ec/CoreMixin/sheet/stores/index.mjs';
 import type { RenderModeStore } from '@ec/CoreMixin/sheet/stores/RenderModeStore.mjs';
 import { secretEffectType } from '@effects/secret/secretEffectType.mjs';
-import type { Dnd35eActiveEffect } from '@entities/activeEffects/index.mjs';
+import type { ActiveEffectDnd35e } from '@entities/activeEffects/index.mjs';
 import { EDIT, PLAY } from '@helpers/formulae/types.mjs';
 import type { ItemDnd35e } from '@items/baseItem/ItemDnd35e.mjs';
 import type { App } from 'vue';
@@ -23,7 +23,7 @@ import type { SheetState, VueApplicationConfiguration, VueApplicationContext, Vu
  * Interface describing members added by VueDocumentSheetMixin.
  * Used for explicit typing instead of ReturnType inference.
  */
-interface VueDocumentSheetMembers<TDocument extends ItemDnd35e | Dnd35eActiveEffect> extends VueAppBaseMembers {
+interface VueDocumentSheetMembers<TDocument extends ItemDnd35e | ActiveEffectDnd35e> extends VueAppBaseMembers {
   /** Application options with document reference */
   options: VueApplicationConfiguration<TDocument>;
   /** Shared reactive context passed into Vue */
@@ -36,7 +36,7 @@ interface VueDocumentSheetMembers<TDocument extends ItemDnd35e | Dnd35eActiveEff
   readonly isEditable: boolean;
 }
 
-const useVueDocumentSheetMixin = <TBase extends AbstractConstructorOf<DocumentSheetV2>, TDocument extends ItemDnd35e | Dnd35eActiveEffect> (base: TBase) => {
+const useVueDocumentSheetMixin = <TBase extends AbstractConstructorOf<DocumentSheetV2>, TDocument extends ItemDnd35e | ActiveEffectDnd35e> (base: TBase) => {
   const VueAppBase = useVueAppBaseMixin(base);
 
   abstract class VueDocumentSheet extends VueAppBase {
@@ -176,7 +176,7 @@ const useVueDocumentSheetMixin = <TBase extends AbstractConstructorOf<DocumentSh
  */
 type VueDocumentSheetMixin<
   TBase extends AbstractConstructorOf<DocumentSheetV2>,
-  TDocument extends ItemDnd35e | Dnd35eActiveEffect
+  TDocument extends ItemDnd35e | ActiveEffectDnd35e
 > = TBase & AbstractConstructorOf<VueDocumentSheetMembers<TDocument>>;
 
 export {


### PR DESCRIPTION
## PR 5 — Active Effect class+config rename (G4c–G4d)

Continuation of the dnd35e naming-conventions refactor. Aligns the base ActiveEffect classes with the `<DocumentType><Distinction>Dnd35e` suffix convention.

### Commits

| Commit | Group | Summary |
|---|---|---|
| `71f66c4` | G4c | `Dnd35eActiveEffect.mts` → `ActiveEffectDnd35e.mts`; class `Dnd35eActiveEffect` → `ActiveEffectDnd35e`; type `Dnd35eActiveEffectFlags` → `ActiveEffectFlags`; const `Dnd35eActiveEffectBase` → `ActiveEffectBase`; type `Dnd35eActiveEffectSource` → `ActiveEffectSourceDnd35e` (collision); type `Dnd35eActiveEffectSystemSource` → `ActiveEffectSystemSourceDnd35e` (collision); ~24 importer files updated |
| `3ec2c05` | G4d | `sheet/Dnd35eActiveEffectConfig.mts` → `sheet/ActiveEffectConfigDnd35e.mts`; class rename (Foundry `ActiveEffectConfig` collision); 4 importers updated |
| `a4305d8` | docs | Mark G4c.1–G4c.5 + G4d.1–G4d.4 complete in `refactor-naming-conventions.md` |

### Collision rationale (suffix-form retained)

- `ActiveEffectSourceDnd35e` — Foundry exports `foundry.documents.ActiveEffectSource`
- `ActiveEffectSystemSourceDnd35e` — Foundry exports `ActiveEffectSystemSource`
- `ActiveEffectConfigDnd35e` — Foundry exports `foundry.applications.sheets.ActiveEffectConfig`

### Verification

| Gate | Result |
|---|---|
| `npm run build` (per commit) | ✓ clean, 642.27 kB |
| `npx tsc --noEmit` (per commit) | ✓ EXIT=0 |
| `npx vitest run` | ✓ 181 passed, 8 todo (20 files), 6.73s |
| `npx playwright test` | ✓ 20/20 passed, 7.0m (20:53:17 → 21:00:22) |

### Next up

PR 6 → Group 5+ (PhysicalItem rename and beyond — consult `docs/migration-plan/poc/refactor-naming-conventions.md`).
