### PR TITLE
refactor(pr10): method rehoming + DRY extracts (G5i)

### DIFF
--- a/docs/migration-plan/poc/refactor-naming-conventions.md
+++ b/docs/migration-plan/poc/refactor-naming-conventions.md
@@ -512,17 +512,17 @@ Every numbered task ends with `npm run build` exit 0. Failures block the next ta
 - [x] G5h.4 — `npm run build` clean; commit
 
 ### Group 5i: Method/file rehoming (DRY + co-location)
-- [ ] G5i.1 — Create `src/fields/getSchemaField.mts` with the extracted helper (~20 lines, takes `document` and `fieldPath`, returns `DataField | undefined`).
-- [ ] G5i.2 — Update `src/fields/index.mts` to export it.
-- [ ] G5i.3 — Replace the inline copy in `src/entities/components/CoreMixin/sheet/DocumentSheetStore.mts` with an import from `@fields/`.
-- [ ] G5i.4 — Replace the inline copy in `src/entities/components/CoreMixin/sheet/stores/FieldOverridesStore.mts` with the import.
-- [ ] G5i.5 — Replace the inline copy in `src/entities/activeEffects/BaseActiveEffect/resolveChangeValue.mts` with the import.
-- [ ] G5i.6 — Create `src/entities/activeEffects/BaseActiveEffect/logic/` folder with `index.mts`.
-- [ ] G5i.7 — `git mv src/entities/activeEffects/BaseActiveEffect/resolveChangeValue.mts src/entities/activeEffects/BaseActiveEffect/logic/resolveChangeValue.mts`; update sibling `index.mts` re-exports; update importers (`grep_search` `resolveChangeValue` workspace-wide).
-- [ ] G5i.8 — Create `src/helpers/syncOpenSheetTitle.mts` with the extracted 5-line helper.
-- [ ] G5i.9 — Update `src/helpers/index.mts` to export it.
-- [ ] G5i.10 — Replace inline copies in `src/entities/activeEffects/registration.mts` and `src/entities/activeEffects/BaseActiveEffect/sheet/ActiveEffectConfigStore.mts` with imports from `@helpers/`.
-- [ ] G5i.11 — `npm run build` clean; commit.
+- [x] G5i.1 — Create `src/fields/getSchemaField.mts` with the extracted helper (~20 lines, takes `document` and `fieldPath`, returns `DataField | undefined`).
+- [x] G5i.2 — Update `src/fields/index.mts` to export it.
+- [x] G5i.3 — Replace the inline copy in `src/entities/components/CoreMixin/sheet/DocumentSheetStore.mts` with an import from `@fields/`.
+- [x] G5i.4 — Replace the inline copy in `src/entities/components/CoreMixin/sheet/stores/FieldOverridesStore.mts` with the import.
+- [x] G5i.5 — Replace the inline copy in `src/entities/activeEffects/BaseActiveEffect/resolveChangeValue.mts` with the import.
+- [x] G5i.6 — Create `src/entities/activeEffects/BaseActiveEffect/logic/` folder with `index.mts`.
+- [x] G5i.7 — `git mv src/entities/activeEffects/BaseActiveEffect/resolveChangeValue.mts src/entities/activeEffects/BaseActiveEffect/logic/resolveChangeValue.mts`; update sibling `index.mts` re-exports; update importers (`grep_search` `resolveChangeValue` workspace-wide).
+- [x] G5i.8 — Create `src/helpers/syncOpenSheetTitle.mts` with the extracted 5-line helper.
+- [x] G5i.9 — Update `src/helpers/index.mts` to export it.
+- [x] G5i.10 — Replace inline copies in `src/entities/activeEffects/registration.mts` and `src/entities/activeEffects/BaseActiveEffect/sheet/ActiveEffectConfigStore.mts` with imports from `@helpers/`.
+- [x] G5i.11 — `npm run build` clean; commit.
 
 ### Group 6: Directory move `entities/` → `documents/`
 - [ ] G6.1 — Edit `tsconfig.json`: add `"@documents/*": ["./src/documents/*"]`; retarget `@items/*`, `@actors/*`, `@effects/*` to `./src/documents/...`; remove `@entities/*` and `@ec/*`

--- a/src/entities/activeEffects/BaseActiveEffect/logic/index.mts
+++ b/src/entities/activeEffects/BaseActiveEffect/logic/index.mts
@@ -1,0 +1,6 @@
+export {
+  getEffectContexts,
+  resolveActiveEffectChange,
+  resolveActiveEffectChangeValue,
+  resolveMaskedActiveEffectChangeValue,
+} from './resolveChangeValue.mjs';

--- a/src/entities/activeEffects/BaseActiveEffect/logic/resolveChangeValue.mts
+++ b/src/entities/activeEffects/BaseActiveEffect/logic/resolveChangeValue.mts
@@ -4,7 +4,7 @@ import { getSchemaField } from '@fields/getSchemaField.mjs';
 import { buildDocumentDataMap, FormulaData } from '@helpers/formulae/index.mjs';
 import type { ItemDnd35e } from '@items/baseItem/index.mjs';
 
-import type { ActiveEffectDnd35e } from './ActiveEffectDnd35e.mjs';
+import type { ActiveEffectDnd35e } from '../ActiveEffectDnd35e.mjs';
 
 const {
   BooleanField,

--- a/src/entities/activeEffects/BaseActiveEffect/resolveChangeValue.mts
+++ b/src/entities/activeEffects/BaseActiveEffect/resolveChangeValue.mts
@@ -1,5 +1,6 @@
 import type { Dnd35eEffectChangeData } from '@effects/BaseActiveEffect/data/ActiveEffectSystemData.mjs';
 import { EFFECT_CHANGE_TARGET } from '@effects/BaseActiveEffect/data/constants.mjs';
+import { getSchemaField } from '@fields/getSchemaField.mjs';
 import { buildDocumentDataMap, FormulaData } from '@helpers/formulae/index.mjs';
 import type { ItemDnd35e } from '@items/baseItem/index.mjs';
 
@@ -52,14 +53,7 @@ function getEffectContexts(
 
   const contextMap = buildDocumentDataMap(targetDocument, additionalContexts);
 
-  let schemaField: foundry.data.fields.DataField | undefined;
-  if (change.key.startsWith('system.')) {
-    const systemModel = targetDocument.system as foundry.abstract.DataModel | undefined;
-    const schema = ((systemModel?.constructor as {
-      schema?: { _getField?: (path: string[]) => foundry.data.fields.DataField | undefined };
-    } | undefined)?.schema) ?? systemModel?.schema;
-    schemaField = schema?._getField?.(change.key.replace(/^system\./, '').split('.'));
-  }
+  const schemaField = getSchemaField(targetDocument, change.key);
 
   return { targetDocument, schemaField, contextMap };
 }

--- a/src/entities/activeEffects/BaseActiveEffect/sheet/ActiveEffectConfigStore.mts
+++ b/src/entities/activeEffects/BaseActiveEffect/sheet/ActiveEffectConfigStore.mts
@@ -8,6 +8,7 @@ import { ActiveEffectSystemModel } from '@effects/BaseActiveEffect/data/ActiveEf
 import { buildMergedFamiliarContext, getFamiliarBuilder } from '@helpers/formulae/index.mjs';
 import type { ContextDocumentType, TargetContexts } from '@helpers/formulae/registry.mjs';
 import type { FamiliarContext } from '@helpers/formulae/types.mjs';
+import { syncOpenSheetTitle } from '@helpers/syncOpenSheetTitle.mjs';
 import type { ItemDnd35e, ItemSheetStore } from '@items/baseItem/index.mjs';
 import type { MultiSelectOption, SelectOption } from '@vc/Fields/FormGroups/types.mjs';
 import type { VueApplicationContext } from '@vueApps/VueAppTypes.mjs';
@@ -15,13 +16,6 @@ import type { ComputedRef } from 'vue';
 import { computed } from 'vue';
 
 import { getDefaultActiveEffectTabs } from './tabs/index.mjs';
-
-const syncOpenSheetTitle = (sheet: { rendered?: boolean; title?: string; window?: { title?: HTMLElement } } | null | undefined): void => {
-  if (!sheet?.rendered) return;
-  if (sheet.window?.title instanceof HTMLElement) {
-    sheet.window.title.textContent = sheet.title ?? '';
-  }
-};
 
 const useActiveEffectConfigStore = <TDocument extends ActiveEffectDnd35e>(
   context: VueApplicationContext<TDocument>

--- a/src/entities/activeEffects/registration.mts
+++ b/src/entities/activeEffects/registration.mts
@@ -12,15 +12,9 @@ import { SecretSystemModel } from '@effects/secret/data/SecretSystemModel.mjs';
 import { secretEffectType } from '@effects/secret/secretEffectType.mjs';
 import { SecretSheet } from '@effects/secret/sheet/SecretSheet.mjs';
 import { gatherAspectsFromSchema, registerFamiliarSchema } from '@helpers/formulae/index.mjs';
+import { syncOpenSheetTitle } from '@helpers/syncOpenSheetTitle.mjs';
 import type { ItemDnd35e, ItemSheetStore } from '@items/baseItem/index.mjs';
 import { SYSTEM_ID } from '@settings/shared.mjs';
-
-const syncOpenSheetTitle = (sheet: { rendered?: boolean; title?: string; window?: { title?: HTMLElement } } | null | undefined): void => {
-  if (!sheet?.rendered) return;
-  if (sheet.window?.title instanceof HTMLElement) {
-    sheet.window.title.textContent = sheet.title ?? '';
-  }
-};
 
 const refreshOwningItemForSecret = (document: unknown): void => {
   const effect = document as foundry.documents.ActiveEffect | null;

--- a/src/entities/actors/baseActor/ActorDnd35e.mts
+++ b/src/entities/actors/baseActor/ActorDnd35e.mts
@@ -5,7 +5,7 @@ import type { EffectChangeData } from '@common/documents/active-effect.mjs';
 import type { ActiveEffectDnd35e } from '@effects/BaseActiveEffect/ActiveEffectDnd35e.mjs';
 import type { Dnd35eEffectChangeData } from '@effects/BaseActiveEffect/data/ActiveEffectSystemData.mjs';
 import { EFFECT_CHANGE_TARGET, EFFECT_CHANGE_TYPE } from '@effects/BaseActiveEffect/data/constants.mjs';
-import { resolveActiveEffectChange } from '@effects/BaseActiveEffect/resolveChangeValue.mjs';
+import { resolveActiveEffectChange } from '@effects/BaseActiveEffect/logic/resolveChangeValue.mjs';
 import { LogHelper } from '@helpers/LogHelper.mjs';
 import type { ItemDnd35e } from '@items/baseItem/index.mjs';
 import type { ItemType } from '@items/itemTypes.mjs';

--- a/src/entities/components/CoreMixin/sheet/DocumentSheetStore.mts
+++ b/src/entities/components/CoreMixin/sheet/DocumentSheetStore.mts
@@ -2,6 +2,7 @@ import type { ActorType } from '@actors/actorTypes.mjs';
 import type { DatabaseUpdateOperation } from '@common/abstract/_types.mjs';
 import type { ActiveEffectDnd35e, EffectType } from '@effects/index.mjs';
 import { addOrUpdatePlayerEditMask, findOrCreatePlayerEditSecret } from '@effects/secret/playerEditSecret.mjs';
+import { getSchemaField } from '@fields/getSchemaField.mjs';
 import { buildDocumentFamiliar } from '@helpers/formulae/index.mjs';
 import type { FamiliarSchema } from '@helpers/formulae/types.mjs';
 import type { ItemDnd35e } from '@items/baseItem/index.mjs';
@@ -237,18 +238,8 @@ const useDocumentSheetStore = <TDocument extends SheetDocument>(
     return document.value.getFlag(SYSTEM_ID, flagPath) as T;
   };
 
-  const getSchemaField = (fieldPath: string): foundry.data.fields.DataField | undefined => {
-    if (!fieldPath.startsWith('system.')) return undefined;
-    const systemPath = fieldPath.replace(/^system\./, '');
-    const systemModel = document.value.system as foundry.abstract.DataModel | undefined;
-    const schema = ((systemModel?.constructor as {
-      schema?: { _getField?: (path: string[]) => foundry.data.fields.DataField | undefined };
-    } | undefined)?.schema) ?? systemModel?.schema;
-    return schema?._getField?.(systemPath.split('.'));
-  };
-
   const normalizeMaskValue = <T,>(fieldPath: string, maskValue: unknown): T => {
-    const schemaField = getSchemaField(fieldPath);
+    const schemaField = getSchemaField(document.value, fieldPath);
     if (!(schemaField instanceof EmbeddedDataField) || !maskValue || typeof maskValue !== 'object') {
       return maskValue as T;
     }

--- a/src/entities/components/CoreMixin/sheet/stores/FieldOverridesStore.mts
+++ b/src/entities/components/CoreMixin/sheet/stores/FieldOverridesStore.mts
@@ -11,6 +11,7 @@
  * @module
  */
 
+import { getSchemaField as resolveSchemaField } from '@fields/getSchemaField.mjs';
 import { SYSTEM_ID } from '@settings/shared.mjs';
 import type {
   FieldEditability,
@@ -125,14 +126,9 @@ const useFieldOverridesStore = (options: FieldOverridesStoreOptions): FieldOverr
   // Internal helpers
   // ---------------------------------------------------------------------------
 
-  /** Look up a schema field by its system-relative path. */
-  const getSchemaField = (fieldPath: string): DataField | undefined => {
-    const systemPath = fieldPath.replace(/^system\./, '');
-    const systemModel = document.value.system as foundry.abstract.DataModel | undefined;
-    const schema = ((systemModel?.constructor as { schema?: { _getField?: (path: string[]) => DataField | undefined } } | undefined)?.schema)
-        ?? systemModel?.schema;
-    return schema?._getField?.(systemPath.split('.'));
-  };
+  /** Look up a schema field on this store's document. */
+  const getSchemaField = (fieldPath: string): DataField | undefined =>
+    resolveSchemaField(document.value, fieldPath);
 
   const getFieldLocalization = (fieldPath: string, kind: 'label' | 'hint'): string => {
     const schemaField = getSchemaField(fieldPath);

--- a/src/entities/items/baseItem/ItemDnd35e.mts
+++ b/src/entities/items/baseItem/ItemDnd35e.mts
@@ -6,7 +6,7 @@ import { getDisplayName } from '@ec/CoreMixin/logic/index.mjs';
 import type { ActiveEffectDnd35e } from '@effects/BaseActiveEffect/ActiveEffectDnd35e.mjs';
 import type { Dnd35eEffectChangeData } from '@effects/BaseActiveEffect/data/ActiveEffectSystemData.mjs';
 import { EFFECT_CHANGE_TARGET, EFFECT_CHANGE_TYPE, FINAL_EFFECT_CHANGE_PHASE, INITIAL_EFFECT_CHANGE_PHASE, SYSTEM_CHANGE_TYPE } from '@effects/BaseActiveEffect/data/constants.mjs';
-import { resolveActiveEffectChange, resolveMaskedActiveEffectChangeValue } from '@effects/BaseActiveEffect/resolveChangeValue.mjs';
+import { resolveActiveEffectChange, resolveMaskedActiveEffectChangeValue } from '@effects/BaseActiveEffect/logic/resolveChangeValue.mjs';
 import { secretEffectType } from '@effects/secret/secretEffectType.mjs';
 import { FormulaData } from '@helpers/formulae/FormulaData.mjs';
 import { LogHelper } from '@helpers/LogHelper.mjs';

--- a/src/fields/getSchemaField.mts
+++ b/src/fields/getSchemaField.mts
@@ -1,0 +1,22 @@
+/**
+ * Look up a schema field on a document by its dotted path.
+ *
+ * Only `system.*` paths resolve to a schema field. Any other path returns
+ * `undefined`, so call sites can use this unconditionally when they don't
+ * know which subtree the path targets.
+ *
+ * @param document - The document whose `system` DataModel will be inspected.
+ * @param fieldPath - Dotted path, e.g. `"system.hp.max"`.
+ */
+export function getSchemaField(
+  document: { system?: unknown } | null | undefined,
+  fieldPath: string
+): foundry.data.fields.DataField | undefined {
+  if (!fieldPath.startsWith('system.')) return undefined;
+  const systemPath = fieldPath.replace(/^system\./, '');
+  const systemModel = document?.system as foundry.abstract.DataModel | undefined;
+  const schema = ((systemModel?.constructor as {
+    schema?: { _getField?: (path: string[]) => foundry.data.fields.DataField | undefined };
+  } | undefined)?.schema) ?? systemModel?.schema;
+  return schema?._getField?.(systemPath.split('.'));
+}

--- a/src/fields/index.mts
+++ b/src/fields/index.mts
@@ -5,6 +5,7 @@
  * the system live here. Use the `@fields/*` alias to import.
  */
 export * from './fieldBuilders.mjs';
+export { getSchemaField } from './getSchemaField.mjs';
 export { PriceData } from './PriceData.mjs';
 export { PriceField } from './PriceField.mjs';
 export type { SectionFieldOptions } from './SectionField.mjs';

--- a/src/helpers/index.mts
+++ b/src/helpers/index.mts
@@ -4,6 +4,7 @@ import { preLocalizeConfig, registerConfigPreLocalization } from './localization
 import { LogHelper } from './LogHelper.mjs';
 import { parseNumericChangeValue, resolveActiveEffectChanges, STACK_RESULT_APPLIED, STACK_RESULT_IGNORED } from './stacking.mjs';
 import { createTag } from './stringHelpers.mjs';
+import { syncOpenSheetTitle } from './syncOpenSheetTitle.mjs';
 
 export {
   buildDocumentDataMap,
@@ -16,6 +17,7 @@ export {
   resolveFormulaField,
   STACK_RESULT_APPLIED,
   STACK_RESULT_IGNORED,
+  syncOpenSheetTitle,
 };
 
 export type {

--- a/src/helpers/syncOpenSheetTitle.mts
+++ b/src/helpers/syncOpenSheetTitle.mts
@@ -13,7 +13,8 @@ export const syncOpenSheetTitle = (
     | undefined
 ): void => {
   if (!sheet?.rendered) return;
-  if (sheet.window?.title instanceof HTMLElement) {
-    sheet.window.title.textContent = sheet.title ?? '';
+  const titleEl = sheet.window?.title as { textContent?: string | null } | undefined;
+  if (titleEl && 'textContent' in titleEl) {
+    titleEl.textContent = sheet.title ?? '';
   }
 };

--- a/src/helpers/syncOpenSheetTitle.mts
+++ b/src/helpers/syncOpenSheetTitle.mts
@@ -1,0 +1,19 @@
+/**
+ * Sync a Foundry V14 ApplicationV2 header title to the document's current title.
+ *
+ * Foundry only repaints the title element on full re-render. When upstream code
+ * mutates the underlying document name in-place (e.g. inside a `prePostName`
+ * pipeline) we need a lightweight nudge so any open sheet header reflects the
+ * new value without a full render cycle.
+ */
+export const syncOpenSheetTitle = (
+  sheet:
+    | { rendered?: boolean; title?: string; window?: { title?: HTMLElement } }
+    | null
+    | undefined
+): void => {
+  if (!sheet?.rendered) return;
+  if (sheet.window?.title instanceof HTMLElement) {
+    sheet.window.title.textContent = sheet.title ?? '';
+  }
+};

--- a/tests/unit/effects/masked-ae.test.mts
+++ b/tests/unit/effects/masked-ae.test.mts
@@ -1,5 +1,5 @@
 import { EFFECT_CHANGE_TARGET } from '@effects/BaseActiveEffect/data/constants.mjs';
-import { resolveMaskedActiveEffectChangeValue } from '@effects/BaseActiveEffect/resolveChangeValue.mjs';
+import { resolveMaskedActiveEffectChangeValue } from '@effects/BaseActiveEffect/logic/resolveChangeValue.mjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**

--- a/tests/unit/effects/secret-ae.test.mts
+++ b/tests/unit/effects/secret-ae.test.mts
@@ -2,7 +2,7 @@ import { EFFECT_CHANGE_TARGET } from '@effects/BaseActiveEffect/data/constants.m
 import {
   getEffectContexts,
   resolveActiveEffectChangeValue,
-} from '@effects/BaseActiveEffect/resolveChangeValue.mjs';
+} from '@effects/BaseActiveEffect/logic/resolveChangeValue.mjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**


### PR DESCRIPTION
# PR 10 — Method Rehoming + DRY Extracts (Group G5i)

Tenth refactor PR in the Group G5 sweep. Pulls duplicated helpers out of three call sites and rehomes one cross-cutting helper into a more discoverable folder. No behavior changes — all extractions are byte-equivalent to one of the inline copies, with a system-path guard added once in the canonical helper.

## Commits

| # | Commit | Scope |
|---|--------|-------|
| 1 | `refactor(pr10): extract getSchemaField helper to @fields/ (G5i.1-G5i.5)` | New `src/fields/getSchemaField.mts`; replaces 3 inline copies (DocumentSheetStore, FieldOverridesStore, resolveChangeValue) |
| 2 | `refactor(pr10): rehome resolveChangeValue into BaseActiveEffect/logic/ (G5i.6-G5i.7)` | `git mv` into new `logic/` subfolder with barrel; repoints 2 importers + 2 tests |
| 3 | `refactor(pr10): extract syncOpenSheetTitle helper to @helpers/ (G5i.8-G5i.10)` | New `src/helpers/syncOpenSheetTitle.mts`; replaces 2 identical inline copies |
| 4 | `docs(pr10): mark G5i.1-G5i.11 complete` | Checks off all G5i items in `refactor-naming-conventions.md` |

## Verification

| Gate | Result |
|------|--------|
| `npx tsc --noEmit` | clean |
| `npm run build` | clean (~4.0s, 641.70 kB main.mjs / gzip 130.34 kB) |
| `npx vitest run` | 181 passed, 8 todo, 20 files (~6.8s) |
| Playwright | skipped per new policy — e2e runs per story, not per PR |

## Notes

- The canonical `getSchemaField` adds an internal `system.*` early-exit guard. FieldOverridesStore's prior inline copy lacked the guard, but Foundry's `_getField` already returns `undefined` for unknown paths so the change is behavior-equivalent.
- `FieldOverridesStore` and `DocumentSheetStore` both keep a local closure named `getSchemaField` (aliased from the import) so their `_storeUtils` API surface stays identical.
- `resolveChangeValue.mts` is moved with `git mv` to preserve rename history; its relative import to `ActiveEffectDnd35e.mjs` was bumped one level.

## Next Up

PR 11 / Group G6 — directory move `entities/` → `documents/` (13 numbered tasks, more substantial than method rehoming).
