### PR TITLE
docs(pr16): final validation (FV) — refactor phase complete

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,7 +49,7 @@ Document sheets use a unified 3-state mode model rendered via a header mode bar:
 - `useDocumentSheetStore.isEditable`: true only when user can edit and mode is `edit`
 - `getViewAwareFieldValue()` applies mask/effective logic for `play`; true-value behavior is available only in `true`
 
-## FormGroup Components (`src/vue/components/Fields/FormGroups/`)
+## FormGroup Components (`src/vue/components/fields/formGroups/`)
 All form input components share a common `editValue` pattern that must respect `ViewMode` (`edit`/`play`/`true`).
 
 ### Complete list

--- a/.github/instructions/dnd35e-patterns.instructions.md
+++ b/.github/instructions/dnd35e-patterns.instructions.md
@@ -115,19 +115,19 @@ Resolution: when multiple AEs apply same field, only highest value in each `bonu
 Sheet components belong in their entity-type folder:
 
 ```
-src/entities/items/
-  components/
-    Physical/
+src/documents/items/
+  physical/
+    physicalItem/
       sheet/components/
         PhysicalItemHeaderStatus.vue       ← Physical item badges
         ...                                ← Other physical-item-only sheet components
-    Equippable/
+    equippableItem/
       sheet/components/
         EquippableHeaderStatus.vue         ← Equippable-specific (equipped/carried state)
         ...                                ← Other equippable-item-only sheet components
-  Weapon/
-    sheet/components/
-      WeaponDamage.vue                     ← Weapon damage form group
+    weapon/
+      sheet/components/
+        WeaponDamage.vue                   ← Weapon damage form group
 ```
 
 **Why**: When Physical and Equippable item sheets need different behavior (e.g. badges show different state), having separate component homes makes changes safer. Updates to one entity type don't accidentally affect unrelated types. Search for "PhysicalItemHeaderStatus" finds exactly what you need, not 5 false positives in generic folders.
@@ -137,8 +137,8 @@ Generic components stay in `src/vue/components/` **only when** they are truly cr
 
 ```
 src/vue/components/
-  Fields/
-    FormGroups/
+  fields/
+    formGroups/
       FormGroup.vue                     ← Used by all entity types, all sheets
       NumberFormGroup.vue               ← Generic number input
       SelectFormGroup.vue               ← Generic select dropdown
@@ -146,7 +146,7 @@ src/vue/components/
     TabView.vue                         ← Generic tab container
 ```
 
-Test: "Is this used by Physical items AND Weapons AND Actors AND Effects?" If yes, generic folder. If "just items," put it in `src/entities/items/components/`.
+Test: "Is this used by Physical items AND Weapons AND Actors AND Effects?" If yes, generic folder. If "just items," put it in `src/documents/items/<bucket>/<type>/components/`.
 
 ### Anti-Pattern: Catch-All Folders
 Don't create folders like `HeaderComponents/`, `StatusBadges/`, `EditControls/`. These catch-alls:
@@ -155,6 +155,18 @@ Don't create folders like `HeaderComponents/`, `StatusBadges/`, `EditControls/`.
 - Violate single-responsibility (folder should have a *reason* to exist)
 
 **Learned**: Phase 1 initially placed HeaderStatus in generic `src/vue/components/HeaderStatus/`, then moved to entity domains when two different types needed two different components. Established domain-first placement avoids rework.
+
+## Naming Conventions
+
+Codified in `docs/migration-plan/poc/refactor-naming-conventions.md`. Key rules:
+
+- **Top-level layout**: documents live under `src/documents/` (`actors/`, `items/`, `activeEffects/`, `scene/`, `document/`). Item subtypes nest under buckets: `items/physical/` and `items/metaphysical/`.
+- **Suffix over prefix for system-named classes**: when a class name would collide with a Foundry type, use the `*Dnd35e` suffix form (e.g. `ItemDnd35e`, `ActorDnd35e`, `ActiveEffectDnd35e`, `RegionDocumentDnd35e`, `EffectChangeDataDnd35e`). Internal helper types that don't collide use bare names (e.g. `ParentDoc`, `OverrideOptions`, `SchemaFieldMeta`, `BaseFlags`, `ChangeType`).
+- **Drop `Base` markers** on system-data classes: `*SystemModel` and `*SystemData`, not `Base*SystemData` or `*SystemModelBase`.
+- **File casing**: `camelCase` directory names; `PascalCase` filenames for class-containing modules (e.g. `Buff.mts`, `ItemDnd35e.mts`). Single-component packaging folders may stay PascalCase (R.2.9).
+- **`types.mts` convention** (R.2.10): per-folder type-aggregation files use the bare `types.mts` name (not `_types.mts`).
+- **Grouped-helpers exception**: when a file aggregates many small helpers, the filename describes the group (e.g. `fieldBuilders.mts`) rather than any one symbol. Single-symbol files match the symbol's PascalCase name.
+- **Path aliases**: `@documents/*`, `@items/*`, `@actors/*`, `@effects/*`, `@scene/*`, `@fields/*`, `@vc/*` (vue components), `@helpers/*`, `@constants/*`, `@settings/*`, plus Foundry `@client/*`, `@common/*`, `@source/*`.
 
 ## Vue Sheet Patterns
 

--- a/.github/instructions/dnd35e-patterns.instructions.md
+++ b/.github/instructions/dnd35e-patterns.instructions.md
@@ -166,7 +166,7 @@ Codified in `docs/migration-plan/poc/refactor-naming-conventions.md`. Key rules:
 - **File casing**: `camelCase` directory names; `PascalCase` filenames for class-containing modules (e.g. `Buff.mts`, `ItemDnd35e.mts`). Single-component packaging folders may stay PascalCase (R.2.9).
 - **`types.mts` convention** (R.2.10): per-folder type-aggregation files use the bare `types.mts` name (not `_types.mts`).
 - **Grouped-helpers exception**: when a file aggregates many small helpers, the filename describes the group (e.g. `fieldBuilders.mts`) rather than any one symbol. Single-symbol files match the symbol's PascalCase name.
-- **Path aliases**: `@documents/*`, `@items/*`, `@actors/*`, `@effects/*`, `@scene/*`, `@fields/*`, `@vc/*` (vue components), `@helpers/*`, `@constants/*`, `@settings/*`, plus Foundry `@client/*`, `@common/*`, `@source/*`.
+- **Path aliases**: `@documents/*`, `@items/*`, `@actors/*`, `@effects/*`, `@scene/*`, `@fields/*`, `@vc/*` (vue components), `@vueApps/*`, `@vueStores/*`, `@canvas/*`, `@helpers/*`, `@constants/*`, `@settings/*`, plus Foundry `@client/*`, `@common/*`, `@source/*`.
 
 ## Vue Sheet Patterns
 

--- a/.github/instructions/e2e-testing.instructions.md
+++ b/.github/instructions/e2e-testing.instructions.md
@@ -122,7 +122,7 @@ The currently selected button carries `.active`. Clicking another button moves `
 ### Secret AE removal — reactivity contract
 Two facts to remember when mutating Secret AEs in a test:
 
-1. **The True button updates automatically.** Creating, updating, or deleting a Secret AE on an Item fires the `createActiveEffect` / `updateActiveEffect` / `deleteActiveEffect` hook chain, which calls `item.sheet.render()` via `refreshOwningItemForSecret` (`src/entities/activeEffects/registration.mts`). `_onRender` re-samples `hasSecrets` and pushes it to the store, so the bar refreshes without any explicit `rerenderSheet` call. If you ever find yourself needing a manual rerender to surface a Secret-AE change, **that's a bug in the hook, not the test**.
+1. **The True button updates automatically.** Creating, updating, or deleting a Secret AE on an Item fires the `createActiveEffect` / `updateActiveEffect` / `deleteActiveEffect` hook chain, which calls `item.sheet.render()` via `refreshOwningItemForSecret` (`src/documents/activeEffects/registration.mts`). `_onRender` re-samples `hasSecrets` and pushes it to the store, so the bar refreshes without any explicit `rerenderSheet` call. If you ever find yourself needing a manual rerender to surface a Secret-AE change, **that's a bug in the hook, not the test**.
 2. **Disabled Secret AEs still count as secrets.** The "does this doc have secrets?" check filters by `effect.type === 'secret'` only — it does not inspect `disabled`. To make the True button go away you must `.delete()` the AE (or change its type). Toggling `disabled` keeps it.
 
 ```ts

--- a/.github/repo-memory/README.md
+++ b/.github/repo-memory/README.md
@@ -22,7 +22,7 @@ If a note grows past ~50 lines or sprouts diagrams, promote it to `docs/architec
 - [config-prelocalization-pattern.md](config-prelocalization-pattern.md) — Two-step CONFIG enum localization + live-merge
 
 ### Conventions
-- [dnd35e-naming-convention.md](dnd35e-naming-convention.md) — `Dnd35e` prefix for our system, `System` reserved for Foundry
+- [dnd35e-naming-convention.md](dnd35e-naming-convention.md) — `Dnd35e` is a **suffix on Foundry collisions only**; bare names everywhere else
 - [type-safe-constants.md](type-safe-constants.md) — Individual `const` exports + combined array
 - [foundry-type-augmentation.md](foundry-type-augmentation.md) — Extending Foundry's closed unions via `declare module`
 - [vue-boolean-prop-defaults.md](vue-boolean-prop-defaults.md) — `withDefaults` for boolean props that default true
@@ -34,6 +34,8 @@ If a note grows past ~50 lines or sprouts diagrams, promote it to `docs/architec
 
 ### Process & workflow
 - [branching-convention.md](branching-convention.md) — Branch = phase, commit = story
+- [cross-cutting-refactor-strategy.md](cross-cutting-refactor-strategy.md) — Wave/group PR sequencing for repo-wide refactors
+- [identifier-rename-sweep.md](identifier-rename-sweep.md) — PowerShell `-creplace \b...\b` recipe + collision pre-check
 - [planning-doc-commit-pairing.md](planning-doc-commit-pairing.md) — Planning doc updates ship in the motivating commit
 - [phase-status-drift.md](phase-status-drift.md) — Verify checklist state against code, don't trust checkboxes
 - [phase-renumbering.md](phase-renumbering.md) — Renumber phase files highest-first with `git mv`

--- a/.github/repo-memory/branching-convention.md
+++ b/.github/repo-memory/branching-convention.md
@@ -4,3 +4,4 @@
 - **Commit = one story** within that phase branch. Multiple story commits accumulate on the phase branch before merge.
 - Phase 4 Story 1 created branch at story level (`poc/phase-04-story-01-test-infrastructure`) — this was a one-off; treat as ephemeral. Don't repeat the pattern.
 - Planning doc updates ship in the same commit as the work that motivated them (see `planning-doc-commit-pairing.md`).
+- **Cross-cutting refactor exception**: when a single phase doc drives many small mechanical PRs (e.g. the 16-PR naming/layout sweep), use `refactor/pr{NN}-{kebab-summary}` branches — one branch per PR, one PR per group from the doc's checklist. See `cross-cutting-refactor-strategy.md`.

--- a/.github/repo-memory/config-prelocalization-pattern.md
+++ b/.github/repo-memory/config-prelocalization-pattern.md
@@ -49,7 +49,7 @@ CONFIG.dnd35e.item = { ...CONFIG.dnd35e.item, ...ItemConfig };
 CONFIG.dnd35e.item = ItemConfig;
 ```
 
-Both `src/entities/items/registration.mts` and `src/entities/activeEffects/registration.mts` use spread merge.
+Both `src/documents/items/registration.mts` and `src/documents/activeEffects/registration.mts` use spread merge.
 
 ## i18n Key Naming Convention
 

--- a/.github/repo-memory/cross-cutting-refactor-strategy.md
+++ b/.github/repo-memory/cross-cutting-refactor-strategy.md
@@ -1,0 +1,47 @@
+# Cross-Cutting Refactor — Wave/Group PR Sequencing
+
+**Verified**: refactor/naming-conventions sweep, PRs 1–16 (merged #51–#66, May 2026)
+**Pattern**: A single phase document drives **many small PRs**, one per coherent group; each PR independently leaves build clean and unit suite green; full E2E runs once at the end.
+**Applies to**: Future cross-cutting refactors (folder moves, repo-wide renames, layout overhauls)
+**Why it matters**: A "mega-PR" for repo-wide layout/naming work is unreviewable. The group-PR pattern keeps each diff in human-readable territory, surfaces collisions early, and lets work pause at any group boundary without leaving the tree in a broken state.
+
+## The shape
+
+1. **One planning doc** lists every rule and every group as numbered checklist items (e.g. `G5g.1`, `G6.4`, `G9.2`). The doc is the source of truth; status updates land in the same commit as the work.
+2. **One phase branch per PR**: `refactor/pr{NN}-{kebab-summary}`. PRs target `dev`, not `main`.
+3. **Mechanical groups go first, semantic groups last**. The 16-PR sweep ordered as: file moves → folder casing → file renames → helper-type renames → final validation. Keeping all renames-of-the-same-symbol inside one PR avoids cross-PR import churn.
+4. **Per-PR gates** (the user's standing policy): `tsc --noEmit` + `npm run build` + `vitest` must pass. **E2E is NOT run per PR** — it runs once on the Final Validation PR ("every story not every PR"). Doc-only PRs may skip the build gate.
+5. **Final Validation PR** (FV) is doc-only: grep audit for residual old names, full E2E, status badge flip to ✅ Complete, instruction-file docs caught up.
+
+## Why per-group, not per-rule
+
+A group is "all renames that affect the same import surface" — e.g. G9 swept eight helper-type symbols in one PR because they all flow through the same `import { ... } from '@helpers/...'` lines. Splitting that into eight PRs would create eight import-line-rewrite collisions on the next rebase.
+
+## Things that surface inside a sweep (treat as scope, not bugs)
+
+- **Target-name collisions**. PR 15's G9.2 renamed `Dnd35eFieldMeta → FieldMeta` mechanically, then discovered the sheet store's `FieldMeta` already claimed that name. Resolved with a fixup amendment: `SchemaFieldMeta` for the schema-definition meta, bare `FieldMeta` stays on the sheet store. **Lesson**: grep the *target* names before sweeping (see `identifier-rename-sweep.md`).
+- **Type-export-split rule**. `export type { X };` and `export { Y };` must be separate statements when `X` is a type-only alias of a name re-exported as a value elsewhere. Came up in the PR 15 fixup.
+- **Stale repo-memory / instruction-file paths**. Repo-wide path renames invalidate every `src/entities/...` reference in `.github/` docs. The FV PR is the natural place to sweep these — but if the refactor is long, do a mid-sweep KB pass to prevent compounding drift.
+
+## Untracked files during the sweep
+
+`.github/workflows/restrict-main-pr-source.yml` (and similar) may be deliberately untracked. Use **named-file commits** or `git add -A -- src/ tests/` to avoid sweeping them in by accident. Do **not** `git add -A` at repo root during a long-running sweep.
+
+## When to invoke this pattern
+
+- Cross-cutting rename or move that touches 20+ files
+- Foundry-vocabulary alignment work (folder renames, document hierarchy)
+- Repo-wide convention shifts (file casing, type-export styles)
+
+## When NOT to use this pattern
+
+- Single-feature work — use a normal phase branch with story commits.
+- Anything with runtime behavior change — those go through the phase pipeline, not a "mechanical" refactor sweep.
+
+## Related
+
+- `identifier-rename-sweep.md` — The PowerShell mechanics for safe renames
+- `branching-convention.md` — Branch = phase, commit = story (this pattern is a refinement: branch = PR, group = commit-cluster)
+- `planning-doc-commit-pairing.md` — Phase doc updates ship with the motivating commit
+- `phase-status-drift.md` — Verify checklist state against code before flipping the status badge
+- `docs/migration-plan/poc/refactor-naming-conventions.md` — Worked example

--- a/.github/repo-memory/dnd35e-naming-convention.md
+++ b/.github/repo-memory/dnd35e-naming-convention.md
@@ -1,47 +1,52 @@
-# Dnd35e Naming Convention — System vs Dnd35e Prefix
+# Dnd35e Naming Convention — Suffix-Only on Foundry Collision
 
-**Verified**: Phase 2, Track 10 (renamed SYSTEM_CHANGE_TYPE → DND35E_CHANGE_TYPE)
-**Pattern**: Use `Dnd35e` prefix for our system's custom types/constants, reserve `System` for Foundry's generic concept
-**Applies to**: All constants, types, and interfaces specific to the dnd35e game system
+**Verified**: PR sweep 1–16 (refactor/naming-conventions, May 2026 — closed by PR #66)
+**Pattern**: `Dnd35e` is a **suffix**, applied **only** when the bare name collides with a Foundry class or type. No prefix anywhere in `src/`.
+**Applies to**: All exported classes, types, interfaces, constants in `src/` (and `tests/` references)
+
+> **Supersedes the old "use `Dnd35e` prefix" rule.** Phase 2 introduced
+> `Dnd35eChangeType`/`DND35E_CHANGE_TYPE`-style prefixes; the refactor sweep
+> reversed this. The canonical rule below is the post-refactor target state.
 
 ## The Rule
 
-| Prefix | Meaning | Example |
-|--------|---------|---------|
-| `System` | Foundry's generic "system data" concept | `system.hardness`, `ActiveEffectSystemModelBase`, `SystemActiveEffectChangeTypes` (Foundry stub) |
-| `Dnd35e` / `DND35E` | Our game system's custom additions | `DND35E_CHANGE_TYPE`, `Dnd35eChangeType`, `Dnd35eEffectChangeData`, `Dnd35eField` |
+1. **Default**: use the bare, descriptive name. `ChangeType`, `OverrideOptions`, `ParentDoc`, `SystemConfig`, `BaseFlags`, `EffectChangeData`-style names — no decoration.
+2. **On collision with a Foundry export**: append `Dnd35e` as a **suffix**. The suffix marks "this is our version of the otherwise-Foundry-named thing."
+3. **`System` is reserved for Foundry's `system` data concept** (the `Document.system` DataModel slot). Never use `System` for arbitrary "this is the game system" decoration.
+4. **Constant naming**: bare `SCREAMING_SNAKE` for our consts when there's no collision (`CHANGE_TYPE`, not `DND35E_CHANGE_TYPE`). Only suffix on collision.
 
-## Why It Matters
+| Bare name collides? | Form to use | Example |
+|---------------------|-------------|---------|
+| No | bare | `ChangeType`, `OverrideOptions`, `ParentDoc`, `SystemConfig`, `BaseFlags`, `CHANGE_TYPE` |
+| Yes (Foundry has same name) | `<Name>Dnd35e` | `ItemDnd35e`, `ActiveEffectConfigDnd35e`, `TokenDnd35e`, `EffectChangeDataDnd35e` |
 
-`system` in FoundryVTT has a specific meaning — it's the `system` property on Documents that holds the DataModel data. Using `System` prefix for our custom constants creates ambiguity:
+Verified collisions (require suffix): `Item`, `Actor`, `ActiveEffect`, `ActiveEffectConfig`, `Token`, `Scene`, `RegionDocument`, `EffectChangeData`.
 
-- `SystemChangeType` — is this about changes to `document.system`? Or our system's custom change types?
-- `SYSTEM_CHANGE_TYPE` — Foundry system data change type? Or dnd35e-registered change type?
+## Schema Meta vs Sheet Meta — the FieldMeta example
 
-Using `Dnd35e` makes ownership unambiguous:
+A single bare name can be claimed by two different layers. When the second layer arrives, **the more descriptive name moves** — both keep `Dnd35e` off.
 
-- `Dnd35eChangeType` — clearly our game system's custom change types
-- `DND35E_CHANGE_TYPE` — clearly dnd35e-registered, not a Foundry concept
+- `FieldMeta` (in `src/documents/document/sheet/stores/FieldOverridesStore.mts`) — runtime-resolved meta on the document-sheet store, claimed first.
+- `SchemaFieldMeta` (in `src/fields/fieldBuilders.mts`) — meta attached at schema-definition time, renamed during PR 15 fixup to avoid collision with the sheet-store `FieldMeta`.
 
-## Export Aliases
+**Rule**: prefer a more-descriptive bare name over a `Dnd35e` suffix when both options are available within our codebase. Reserve the suffix for genuine Foundry collisions.
 
-The const may still be exported under a convenience alias if the full name is unwieldy:
-```typescript
-// In constants.mts
-const DND35E_CHANGE_TYPE = { FAMILIAR: 'familiar', MASK: 'mask' } as const;
+## Naming Sub-Rules from the Refactor
 
-// In barrel — alias for ergonomic imports
-export { DND35E_CHANGE_TYPE as SYSTEM_CHANGE_TYPE };
-```
+- **`Base` marker**: drop it where it only restates `abstract class`; keep it where it's the most accurate descriptor *and* avoids a `Dnd35e` suffix (e.g. `BaseActiveEffect`, `BaseItem`).
+- **`types.mts`** (no leading underscore) is the file-aggregation convention; `_types.mts` is non-standard JS/TS.
+- **`fieldBuilders.mts`** is the canonical exception for grouped-helper filenames: camelCase plural when the file groups related factory helpers, not a single exported class.
+- **`documents/`**, not `entities/`. Foundry calls them documents; we follow.
+- **File casing**: PascalCase filename matches the primary exported class (`ItemDnd35e.mts` exports `class ItemDnd35e`). camelCase for grouped-helper files. R.2.9 single-component-folder exception allows `TabDivider/TabDivider.vue` PascalCase folder when the folder is dedicated to a single same-named export.
 
-This is acceptable when the alias is well-understood within the codebase. The source-of-truth name uses the `DND35E` prefix.
+## Migration Aliases
 
-## Exceptions
-
-- **Foundry extension points**: Interfaces in Foundry type stubs (e.g., `SystemActiveEffectChangeTypes`) use `System` because they're Foundry-level concepts that any system could augment.
-- **Generic base classes**: `ActiveEffectSystemModelBase` uses `System` because it mirrors Foundry's `system` DataModel pattern.
+When renaming a public-ish symbol, prefer a clean cut. Do **not** add `export { NewName as OldName }` aliases unless an external consumer demands it — the refactor sweep deleted these as it went.
 
 ## Related
 
-- `foundry-type-augmentation.md` — Where `SystemActiveEffectChangeTypes` (Foundry stub) vs `Dnd35eChangeType` (our type) distinction is most visible
+- `cross-cutting-refactor-strategy.md` — How the 16-PR sweep was sequenced
+- `identifier-rename-sweep.md` — Mechanical-rename recipe with collision pre-check
+- `foundry-type-augmentation.md` — Where `SystemActiveEffectChangeTypes` (Foundry stub) vs `ChangeType` (our type) distinction is visible
 - `type-safe-constants.md` — Naming pattern for const + type pairs
+- `docs/migration-plan/poc/refactor-naming-conventions.md` — Full rule set with rationale

--- a/.github/repo-memory/effect-change-optional-normalization.md
+++ b/.github/repo-memory/effect-change-optional-normalization.md
@@ -10,7 +10,7 @@
 
 ## Related
 
-- `src/entities/activeEffects/BaseActiveEffect/data/ActiveEffectSystemData.mts`
-- `src/entities/activeEffects/BaseActiveEffect/resolveChangeValue.mts`
-- `src/entities/items/baseItem/ItemDnd35e.mts`
+- `src/documents/activeEffects/baseActiveEffect/data/ActiveEffectSystemData.mts`
+- `src/documents/activeEffects/baseActiveEffect/logic/resolveChangeValue.mts`
+- `src/documents/items/baseItem/ItemDnd35e.mts`
 - `familiar-field-patterns.md`

--- a/.github/repo-memory/has-secrets-disabled-counts.md
+++ b/.github/repo-memory/has-secrets-disabled-counts.md
@@ -13,7 +13,7 @@
 
 **Locations**:
 - `VueDocumentSheetMixin#_onRender` — recomputes `hasSecrets` on render
-- The `secretEffectType` import in `src/entities/effects/` drives the type check
+- The `secretEffectType` import in `src/documents/activeEffects/` drives the type check
 
 **Pinned by**: `tests/e2e/view-mode-bar.spec.ts` test 2. The initial test
 draft used `disabled: true` and failed correctly — the bar did not hide

--- a/.github/repo-memory/identifier-rename-sweep.md
+++ b/.github/repo-memory/identifier-rename-sweep.md
@@ -1,0 +1,81 @@
+# Identifier Rename Sweep — PowerShell Recipe
+
+**Verified**: refactor PRs 9, 11, 13, 14, 15 (May 2026)
+**Pattern**: Use `-creplace` (case-sensitive) with `\b` word boundaries across `src,tests` for symbol renames; pre-check the target name for collisions before sweeping.
+**Applies to**: Any cross-file symbol rename (class, type, interface, const, function name) — NOT file or folder renames (use `git mv`).
+**Why it matters**: A naïve `replace` will mangle substrings (e.g. renaming `Item` matches `ItemDnd35e`); a case-insensitive replace will mangle comments and string literals; renaming to a name that already exists creates silent collisions.
+
+## Pre-flight: collision check
+
+**Always grep the target name first.** If anything outside the symbols being renamed already uses the target name, you have a collision.
+
+```powershell
+# Before renaming X → Y, check what currently claims Y
+Get-ChildItem -Path src,tests -Recurse -Include *.mts,*.mjs,*.ts,*.js,*.vue `
+  | Select-String -Pattern '\bY\b' -CaseSensitive `
+  | Group-Object Path | Select-Object Name, Count
+```
+
+If hits exist, decide:
+- Rename the *new* symbol to a more descriptive name (e.g. `SchemaFieldMeta` not `FieldMeta`).
+- Rename the *existing* symbol first in its own commit.
+- Abort the sweep.
+
+## The sweep
+
+```powershell
+$old = 'Dnd35eFieldMeta'
+$new = 'SchemaFieldMeta'
+Get-ChildItem -Path src,tests -Recurse -Include *.mts,*.mjs,*.ts,*.js,*.vue `
+  | ForEach-Object {
+    $content = Get-Content -Raw -LiteralPath $_.FullName
+    $updated = $content -creplace "\b$old\b", $new
+    if ($content -ne $updated) {
+      [System.IO.File]::WriteAllText($_.FullName, $updated, (New-Object System.Text.UTF8Encoding $false))
+    }
+  }
+```
+
+Key details:
+- **`-creplace`** is case-sensitive. `-replace` is not — never use it for code.
+- **`\b...\b`** word boundaries prevent substring corruption.
+- **UTF-8 no-BOM** preserves existing file encoding; `Set-Content` adds a BOM on some PowerShell versions.
+- **Scope to `src,tests`** — never include `.github/`, `docs/`, `_old_lang/` (those have their own concerns; sweep them separately if needed).
+
+## Per-PR gate after sweep
+
+```powershell
+npx tsc --noEmit 2>&1 | Select-Object -Last 5
+Write-Host "---"
+npm run build 2>&1 | Select-Object -Last 5
+```
+
+Then `npm test` for vitest. E2E only on the FV PR.
+
+## Common pitfalls
+
+- **`-replace` instead of `-creplace`**: mangles comments, doc-strings, and case-different identifiers in the same file.
+- **Missing `\b`**: renaming `Item` matches `ItemDnd35e`, `FormItem`, `ItemPriceFormGroup`, etc. Devastating.
+- **Renaming into a collision**: see pre-flight above. The PR 15 `FieldMeta` collision was missed at planning time and caught only after the sweep; fixup commit + amended push + force-with-lease was needed.
+- **Trusting `git push --force-with-lease` exit code**: it can return 1 on a successful push (verified the push succeeded by reading the remote refs in stdout). Read the output, not the exit code.
+
+## Type-export split
+
+If the renamed symbol is exported as both a value and a type from the same barrel, the post-rename re-export may need splitting:
+
+```ts
+// Before
+export { SchemaFieldMeta, requiredNumberField, optionalStringField };
+
+// After (when SchemaFieldMeta is type-only)
+export type { SchemaFieldMeta };
+export { requiredNumberField, optionalStringField };
+```
+
+`tsc` will flag this with `TS1205` / `TS1448` (re-exporting a type when `isolatedModules` is on).
+
+## Related
+
+- `cross-cutting-refactor-strategy.md` — The PR-sequencing pattern this lives inside
+- `powershell-pitfalls.md` — `&` separator, `&&` not allowed, Unix-utility avoidance
+- `untracked-workflow-files.md` — Don't sweep these in with `git add -A`

--- a/.github/repo-memory/masks-system-architecture.md
+++ b/.github/repo-memory/masks-system-architecture.md
@@ -63,8 +63,8 @@ if (masks && fieldPath in masks) {
 
 ## Related
 
-- `src/entities/items/baseItem/ItemDnd35e.mts` — `_buildMasks()`, `_masks` property
-- `src/entities/components/CoreMixin/sheet/DocumentSheetStore.mts` — `getViewAwareFieldValue()` masks check
-- `src/entities/activeEffects/secret/` — Secret AE type that carries MASK changes
+- `src/documents/items/baseItem/ItemDnd35e.mts` — `_buildMasks()`, `_masks` property
+- `src/documents/document/sheet/DocumentSheetStore.mts` — `getViewAwareFieldValue()` masks check
+- `src/documents/activeEffects/secret/` — Secret AE type that carries MASK changes
 - `foundry-type-augmentation.md` — How MASK type is registered in the type system
 - `dnd35e-naming-convention.md` — Why const is `DND35E_CHANGE_TYPE.MASK` not `SYSTEM_CHANGE_TYPE.MASK`

--- a/.github/repo-memory/system-json-registration.md
+++ b/.github/repo-memory/system-json-registration.md
@@ -12,8 +12,8 @@ Foundry uses `system.json` → `documentTypes` to:
 
 ## Registration Locations
 1. `system.json.template` → `documentTypes.[DocumentClass].[typeName]: {}`
-2. `src/entities/.../registration.mts` → `Object.assign(CONFIG.Item.dataModels, ...)` etc.
-3. `src/entities/.../effectTypes.mts` (or equivalent) → creation dialog config (can exclude types from picker)
+2. `src/documents/.../registration.mts` → `Object.assign(CONFIG.Item.dataModels, ...)` etc.
+3. `src/documents/.../effectTypes.mts` (or equivalent) → creation dialog config (can exclude types from picker)
 
 ## Checklist (Every New Subtype)
 - [ ] Add to `system.json.template` → `documentTypes`
@@ -23,5 +23,5 @@ Foundry uses `system.json` → `documentTypes` to:
 
 ## Related
 - `scripts/build-system-json.mjs` — template expansion script
-- `src/entities/activeEffects/effectTypes.mts` — AE type picker config
-- `src/entities/activeEffects/registration.mts` — AE DataModel registration
+- `src/documents/activeEffects/effectTypes.mts` — AE type picker config
+- `src/documents/activeEffects/registration.mts` — AE DataModel registration

--- a/.github/repo-memory/view-mode-bar-refresh.md
+++ b/.github/repo-memory/view-mode-bar-refresh.md
@@ -9,7 +9,7 @@
 - **Reactivity is provided by the AE hook chain**: `createActiveEffect`,
   `updateActiveEffect`, and `deleteActiveEffect` all route through
   `refreshOwningItemForSecret` in
-  `src/entities/activeEffects/registration.mts`, which calls
+  `src/documents/activeEffects/registration.mts`, which calls
   `item.sheet.render()` when the open item sheet is rendered. That
   re-render fires `_onRender`, which resamples `hasSecrets`.
 - **Consequence**: structural bar changes (True button appearing or

--- a/docs/migration-plan/poc/refactor-naming-conventions.md
+++ b/docs/migration-plan/poc/refactor-naming-conventions.md
@@ -588,7 +588,6 @@ Every numbered task ends with `npm run build` exit 0. Failures block the next ta
 - [x] FV.4 — **Full Playwright E2E suite** (`npx playwright test`) green on the final merged `dev` tree (one last sanity pass; each PR already ran E2E pre-merge).
 - [x] FV.5 — `.github/copilot-instructions.md` and `.github/instructions/dnd35e-patterns.instructions.md` updated to reflect the new `documents/` vocabulary, the suffix rule (with verified-collision exceptions), the `Base`-over-`Dnd35e` preference, the file-name-vs-grouped-helpers exception, the R.2.9 file-casing rule, and the R.2.10 `types.mts` convention.
 - [x] FV.6 — Mark this phase doc Complete (no roadmap row needed — see R.7).
-- [ ] FV.6 — Mark this phase doc Complete (no roadmap row needed — see R.7).
 
 ---
 

--- a/docs/migration-plan/poc/refactor-naming-conventions.md
+++ b/docs/migration-plan/poc/refactor-naming-conventions.md
@@ -1,6 +1,6 @@
 # Refactor: Naming & Layout Conventions (src-wide)
 
-**Status**: 📋 Planned
+**Status**: ✅ Complete
 **Type**: Cross-cutting refactor (mini-phase)
 **Branch**: `poc/refactor-naming-conventions` (off `origin/dev`)
 **Dependencies**: None (pure rename / relocation / re-export work, no runtime behavior change)
@@ -311,7 +311,7 @@ One row per rename unit. "Symbols" lists all in-file symbol renames; "—" means
 | Old | New | Note |
 | --- | --- | ---- |
 | `Dnd35eParentDoc` | `ParentDoc` | no collision |
-| `Dnd35eFieldMeta` | `FieldMeta` | no collision |
+| `Dnd35eFieldMeta` | `SchemaFieldMeta` | collision with `FieldOverridesStore.FieldMeta` discovered during PR 15; suffix-form `FieldMeta` already exists as the sheet-store runtime-resolved meta, so the schema-definition meta took the descriptive `SchemaFieldMeta` name |
 | `Dnd35eOverrideOptions` | `OverrideOptions` | no collision |
 | `Dnd35eSystemConfig` | `SystemConfig` | verify; escalate to `SystemConfigDnd35e` if needed |
 | `Dnd35eBaseFlags` | `BaseFlags` | `Base` prefix is the accurate descriptor |
@@ -575,18 +575,19 @@ Every numbered task ends with `npm run build` exit 0. Failures block the next ta
 
 ### Group 9: Helper-type prefix sweep
 - [x] G9.1 — Verified-collision rename first: `Dnd35eEffectChangeData` → `EffectChangeDataDnd35e` (file + symbol + imports).
-- [x] G9.2 — Bare renames: `Dnd35eParentDoc` → `ParentDoc`, `Dnd35eFieldMeta` → `FieldMeta`, `Dnd35eOverrideOptions` → `OverrideOptions`, `Dnd35eSectionField` → `SectionField`, `Dnd35eBaseFlags` → `BaseFlags`, `Dnd35eChangeType` → `ChangeType`, `DND35E_CHANGE_TYPE` → `CHANGE_TYPE`.
+- [x] G9.2 — Bare renames: `Dnd35eParentDoc` → `ParentDoc`, `Dnd35eFieldMeta` → `SchemaFieldMeta` (collision with `FieldOverridesStore.FieldMeta` — see R.3.3), `Dnd35eOverrideOptions` → `OverrideOptions`, `Dnd35eSectionField` → `SectionField`, `Dnd35eBaseFlags` → `BaseFlags`, `Dnd35eChangeType` → `ChangeType`, `DND35E_CHANGE_TYPE` → `CHANGE_TYPE`.
 - [x] G9.3 — Verify-during-execution: confirm `Dnd35eSystemConfig` → `SystemConfig` does not collide with Foundry; if it does, use `SystemConfigDnd35e`.
 - [x] G9.4 — Update all imports / barrels; eslint --fix.
 - [x] G9.5 — `grep_search` workspace-wide for `Dnd35e` — remaining matches should be only the verified colliding names (`*Dnd35e` suffix form) plus planning docs.
 - [x] G9.6 — `npm run build` clean; commit.
 
 ### Final validation
-- [ ] FV.1 — Workspace `grep_search` for old prefix forms (`DnD35e`, `BaseDnd35eSystemData`, `BaseDnd35eSystemSource`, `ItemSystemModelBase`, `ActorSystemModelBase`, `ActiveEffectSystemModelBase`, `PhysicalSystemData.mjs`, `PhysicalItemDnd35e`, `BaseItemSheet`, `applyIdentifiableSchema.mjs`, `Dnd35eDocument` class, `Dnd35eDocumentMixin`, `Dnd35eDocumentSystemModel`, `Dnd35eDocumentFlags`, `Dnd35eDocumentProperties`, `Dnd35eDocumentConstructor`, `Dnd35eActiveEffect` class, `Dnd35eActiveEffectFlags`, `Dnd35eActiveEffectConfig`, `Dnd35eActiveEffectSystemSource`, `Dnd35eActiveEffectSource`, `Dnd35eParentDoc`, `Dnd35eFieldMeta`, `Dnd35eOverrideOptions`, `Dnd35eSectionField`, `Dnd35eSystemConfig`, `Dnd35eBaseFlags`, `Dnd35eEffectChangeData`, `Dnd35eChangeType`, `DND35E_CHANGE_TYPE`, `tokenDnd35e` (lowercase class form), `logHelper.mjs`, `src/scene/`, `region-document`, `token-document`, `region-behaviour`, `@settings/_types`, `@settings/constants`, `_types.mjs`, `_types.mts`, `@ec/`, `@entities/`, `src/entities/`, inline `getSchemaField` definitions, inline `syncOpenSheetTitle` definitions, top-level `BaseActiveEffect/resolveChangeValue.mjs`). Production code must show zero matches; planning docs / changelog allowed.
-- [ ] FV.2 — `npm run build` clean
-- [ ] FV.3 — `npx vitest run` green
-- [ ] FV.4 — **Full Playwright E2E suite** (`npx playwright test`) green on the final merged `dev` tree (one last sanity pass; each PR already ran E2E pre-merge).
-- [ ] FV.5 — `.github/copilot-instructions.md` and `.github/instructions/dnd35e-patterns.instructions.md` updated to reflect the new `documents/` vocabulary, the suffix rule (with verified-collision exceptions), the `Base`-over-`Dnd35e` preference, the file-name-vs-grouped-helpers exception, the R.2.9 file-casing rule, and the R.2.10 `types.mts` convention.
+- [x] FV.1 — Workspace `grep_search` for old prefix forms (`DnD35e`, `BaseDnd35eSystemData`, `BaseDnd35eSystemSource`, `ItemSystemModelBase`, `ActorSystemModelBase`, `ActiveEffectSystemModelBase`, `PhysicalSystemData.mjs`, `PhysicalItemDnd35e`, `BaseItemSheet`, `applyIdentifiableSchema.mjs`, `Dnd35eDocument` class, `Dnd35eDocumentMixin`, `Dnd35eDocumentSystemModel`, `Dnd35eDocumentFlags`, `Dnd35eDocumentProperties`, `Dnd35eDocumentConstructor`, `Dnd35eActiveEffect` class, `Dnd35eActiveEffectFlags`, `Dnd35eActiveEffectConfig`, `Dnd35eActiveEffectSystemSource`, `Dnd35eActiveEffectSource`, `Dnd35eParentDoc`, `Dnd35eFieldMeta`, `Dnd35eOverrideOptions`, `Dnd35eSectionField`, `Dnd35eSystemConfig`, `Dnd35eBaseFlags`, `Dnd35eEffectChangeData`, `Dnd35eChangeType`, `DND35E_CHANGE_TYPE`, `tokenDnd35e` (lowercase class form), `logHelper.mjs`, `src/scene/`, `region-document`, `token-document`, `region-behaviour`, `@settings/_types`, `@settings/constants`, `_types.mjs`, `_types.mts`, `@ec/`, `@entities/`, `src/entities/`, inline `getSchemaField` definitions, inline `syncOpenSheetTitle` definitions, top-level `BaseActiveEffect/resolveChangeValue.mjs`). Production code must show zero matches; planning docs / changelog allowed.
+- [x] FV.2 — `npm run build` clean
+- [x] FV.3 — `npx vitest run` green
+- [x] FV.4 — **Full Playwright E2E suite** (`npx playwright test`) green on the final merged `dev` tree (one last sanity pass; each PR already ran E2E pre-merge).
+- [x] FV.5 — `.github/copilot-instructions.md` and `.github/instructions/dnd35e-patterns.instructions.md` updated to reflect the new `documents/` vocabulary, the suffix rule (with verified-collision exceptions), the `Base`-over-`Dnd35e` preference, the file-name-vs-grouped-helpers exception, the R.2.9 file-casing rule, and the R.2.10 `types.mts` convention.
+- [x] FV.6 — Mark this phase doc Complete (no roadmap row needed — see R.7).
 - [ ] FV.6 — Mark this phase doc Complete (no roadmap row needed — see R.7).
 
 ---


### PR DESCRIPTION
## Summary

PR 16 / **FV** — Final validation closing out the naming/layout refactor. Documentation + audit only; **no production code changes**.

## Gates

- **FV.1 grep audit**: zero matches in production code (`src/`, `tests/`, `types/`) for the old prefix forms listed in the phase doc. The 299 `_types.mjs` hits found during the sweep were all Foundry-internal import paths (`@common/abstract/_types.mjs`, `@client/.../_types.mjs`), not our codebase's `_types.mts → types.mts` rename (G5h verified zero own-code refs).
- **FV.2 build**: `npm run build` clean — 641.66 kB / 130.32 kB gzip, ~4s.
- **FV.3 vitest**: 181 passed / 8 todo / 20 files.
- **FV.4 Playwright E2E**: 20/20 passed (6.8m).

## Doc updates (FV.5)

`.github/instructions/dnd35e-patterns.instructions.md`:
- Fixed stale `src/entities/items/` paths in Component Placement Strategy → now `src/documents/items/physical/{physicalItem,equippableItem}/` etc.
- Fixed stale `src/vue/components/Fields/FormGroups/` → `src/vue/components/fields/formGroups/`.
- Added **Naming Conventions** section codifying the refactor's rules: `documents/` layout, suffix-over-prefix for system-named classes, drop-`Base`-marker on system data, camelCase dirs + PascalCase filenames, `types.mts` (R.2.10), grouped-helpers exception, current path aliases.

`.github/copilot-instructions.md`:
- Fixed stale `src/vue/components/Fields/FormGroups/` header → lowercase form.

## G9.2 doc correction

The phase doc's G9.2 entry and R.3.3 table claimed `Dnd35eFieldMeta → FieldMeta`. The actual implementation in PR 15 renamed it to `SchemaFieldMeta` to avoid collision with `FieldOverridesStore.FieldMeta` (the runtime-resolved sheet-store meta that already used the bare `FieldMeta` name). Phase doc updated to reflect reality.

## FV.6 — Phase complete

`docs/migration-plan/poc/refactor-naming-conventions.md` status now `✅ Complete`. All G9.1–G9.6 and FV.1–FV.6 items checked off.

## Refactor recap

This closes the multi-PR refactor sweep spanning **PRs 1–16**: 15 code PRs + this final validation PR. The system tree now uses `src/documents/`, the suffix-over-prefix naming rule for system-named classes, camelCase directory casing, `types.mts` aggregation files, and a clean separation between sheet-store runtime meta (`FieldMeta`) and schema-definition meta (`SchemaFieldMeta`).
