### PR TITLE
fix(weapon-store): route weaponType/weaponSubtype through *_LOCALIZED maps

### DIFF
--- a/src/documents/items/physical/weapon/sheet/WeaponStore.mts
+++ b/src/documents/items/physical/weapon/sheet/WeaponStore.mts
@@ -4,6 +4,7 @@ import type { EquippableItemGetters, EquippableItemLike, EquippableItemStore, Eq
 import { useEquippableItemStore } from '@items/physical/equippableItem/index.mjs';
 import type { EquippableItemActions } from '@items/physical/equippableItem/sheet/EquippableItemStore.mjs';
 import { physicalItemEffectsTab } from '@items/physical/physicalItem/index.mjs';
+import { WEAPON_SUBTYPE_LOCALIZED, WEAPON_TYPE_LOCALIZED } from '@items/physical/weapon/data/constants.mjs';
 import type { Weapon } from '@items/physical/weapon/index.mjs';
 import { weaponDetailsTab } from '@items/physical/weapon/index.mjs';
 import type { VueApplicationContext } from '@vueApps/VueAppTypes.mjs';
@@ -28,8 +29,8 @@ const useWeaponStore = (context: VueApplicationContext<Weapon>) => {
   const documentGetters: WeaponGetters = {
     ...baseStore.documentGetters,
     ...equippableStore.documentGetters,
-    weaponType: computed(() => game.i18n.localize(document.value.system.weaponType)),
-    weaponSubtype: computed(() => game.i18n.localize(document.value.system.weaponSubtype)),
+    weaponType: computed(() => game.i18n.localize(WEAPON_TYPE_LOCALIZED[document.value.system.weaponType])),
+    weaponSubtype: computed(() => game.i18n.localize(WEAPON_SUBTYPE_LOCALIZED[document.value.system.weaponSubtype])),
   };
 
   const _storeUtils: weaponStoreUtils = {


### PR DESCRIPTION
Cherry-picked from `feature/armor-catch_up` commit 0d977d6 — WeaponStore portion only. The ArmorStore half stays on the armor branch.

## The bug
`WeaponStore.mts` was calling `game.i18n.localize(document.value.system.weaponType)` on raw choice values like `'simple'` / `'light'` instead of i18n keys. With choices passed as arrays, Foundry does not auto-localize choice values, so `weaponType` / `weaponSubtype` rendered as the raw enum value in play/true view.

## The fix
Route through the existing `WEAPON_TYPE_LOCALIZED` / `WEAPON_SUBTYPE_LOCALIZED` value->key maps from `weapon/data/constants.mts`, which is the canonical pattern (same maps already feed `weaponTypeSelectOptions`).

## Scope
- 1 file, +3/-2
- No schema or store-shape changes
- Build clean (`npm run build`)