### PR TITLE
plan: Phase 6 Approved + poc.9 & poc.10 Stub to Planned + KB updates

### DIFF
--- a/.github/instructions/dnd35e-patterns.instructions.md
+++ b/.github/instructions/dnd35e-patterns.instructions.md
@@ -236,6 +236,140 @@ CONFIG.dnd35e.item = ItemConfig;
 
 Registration order is not guaranteed. Multiple files populate the same CONFIG object.
 
+## DocumentEventEmitter — Per-Instance Lifecycle Event Bus
+
+Every system document carries a `readonly events: DocumentEventEmitter` instance. It is an **instance-scoped** pub/sub bus — each document has its own subscriber list, contrasting with global `Hooks.*` which fan out to all listeners for that event type.
+
+### API
+
+```ts
+// Subscribe — returns an unsubscribe function
+const off = item.events.on(PhysicalItem.LifeCycle.broken, ({ item, hp }) => {
+  console.log(`${item.name} became broken (hp: ${hp.current}/${hp.max})`);
+});
+off(); // unsubscribe
+
+// Subscribe once — auto-unsubscribes after first firing
+item.events.once(PhysicalItem.LifeCycle.repaired, (payload) => { ... });
+
+// Emit (from within the document class)
+void this.events.emit(PhysicalItem.LifeCycle.broken, { item: this, hp: { current, max } });
+```
+
+### LifeCycle Static Constants — Spread Inheritance
+
+Each class in the composition chain declares a `static readonly LifeCycle` object, extending parents via spread:
+
+```ts
+// Base (DocumentDnd35e):
+const DocumentLifeCycle = { created: 'created', destroyed: 'destroyed' } as const;
+
+// PhysicalItem extends base:
+static readonly LifeCycle = {
+  ...DocumentLifeCycle,
+  broken: 'broken',
+  repaired: 'repaired',
+} as const;
+
+// Weapon extends PhysicalItem:
+static override readonly LifeCycle = {
+  ...PhysicalItem.LifeCycle,
+  beforeAction: 'beforeAction',
+  afterAction: 'afterAction',
+  onHit: 'onHit',
+  onCrit: 'onCrit',
+} as const;
+```
+
+**Always use the constant** (`PhysicalItem.LifeCycle.broken`) not the raw string (`'broken'`) — TypeScript narrows the type and refactoring stays safe.
+
+### Timing Contracts
+
+| Event | When emitted | Why |
+|-------|-------------|-----|
+| `created` | Via `queueMicrotask` after `_onCreate` | Defers until the full `_onCreate` call stack (all super calls) has unwound — subscribers see a fully initialized document |
+| `destroyed` | **Before** `super._onDelete` | Subscribers can still access the document's collections while it's in-memory |
+
+After `destroyed` emits, `events.clear()` is called immediately — async handlers running from the snapshot still complete, but no new subscriptions can receive the event.
+
+### Memory Leak Prevention
+
+`events.clear()` is called automatically in `_onDelete`. If your subscriber holds a reference to the emitting document (common), you must either:
+1. Rely on `_onDelete` clearing (sufficient for most cases)
+2. Call `off()` explicitly in component teardown (for Vue stores / UI subscribers)
+
+### Scope: When to use `events` vs. global `Hooks`
+
+| Scenario | Use |
+|----------|-----|
+| "Any weapon became broken" | `Hooks.on('updateItem', ...)` |
+| "**This specific** weapon became broken" | `weapon.events.on(Weapon.LifeCycle.broken, ...)` |
+| Cross-document side effects (actor ← item) | `item.events.on(...)` subscribed by the owning actor |
+| System-wide tracking / analytics | `Hooks` |
+
+See `src/helpers/DocumentEventEmitter.mts` and `src/documents/document/DocumentDnd35e.mts`.
+
+---
+
+## System-Managed AE Flag + Toggle Semantics
+
+AEs created programmatically by system code are marked with `flags.dnd35e.systemManaged: true`. This flag governs **toggle-off behavior** — user-authored custom AEs must never be silently deleted.
+
+### The Convention
+
+```ts
+// Marking an AE as system-managed (at creation time):
+await item.createEmbeddedDocuments('ActiveEffect', [{
+  name: 'Masterwork Weapon Enhancement',
+  type: materialEffectType,
+  flags: { dnd35e: { materialSubtype: 'masterwork', systemManaged: true } },
+}]);
+
+// Detecting system-managed vs. custom:
+const isSystemManaged = effect.getFlag('dnd35e', 'systemManaged') === true;
+```
+
+### Toggle-Off Semantic: Delete System / Disable Custom
+
+When a toggle (e.g. `isMasterwork = false`) turns off a category of AEs:
+
+| AE type | Toggle OFF action | Rationale |
+|---------|------------------|-----------|
+| System-managed | **Delete** | System owns it; it will be re-created from compendium on next toggle-on |
+| Custom (user-created) | **Disable** | User data must not be destroyed; disabling stops the effect while preserving edits |
+
+```ts
+const systemManaged = masterworkAes.filter((ae) => isSystemManagedMasterworkAe(ae));
+const custom        = masterworkAes.filter((ae) => !isSystemManagedMasterworkAe(ae));
+
+// Delete system-managed
+if (systemManaged.length) {
+  await item.deleteEmbeddedDocuments('ActiveEffect', systemManaged.map((ae) => ae.id!));
+}
+// Disable custom
+const toDisable = custom.filter((ae) => !ae.disabled).map((ae) => ({ _id: ae.id, disabled: true }));
+if (toDisable.length) {
+  await item.updateEmbeddedDocuments('ActiveEffect', toDisable);
+}
+```
+
+### Toggle-On Semantic: Re-enable Existing / Create from Compendium
+
+```ts
+if (masterworkAes.length > 0) {
+  // Re-enable any disabled ones (system-managed or custom)
+  const toEnable = masterworkAes.filter((ae) => ae.disabled).map((ae) => ({ _id: ae.id, disabled: false }));
+  if (toEnable.length) await item.updateEmbeddedDocuments('ActiveEffect', toEnable);
+} else {
+  // No AEs of this type exist yet — create from compendium
+  await attachDefaultMasterworkAe(item, { enabled: true });
+}
+```
+
+This pattern applies to every system-managed AE category: Masterwork, Broken, and any future system AEs.
+
+---
+
 ## Field Permissions & Overrides
 
 See `dnd35e-field.instructions.md` for field override cascade, view-aware getters, and permission defaults.

--- a/.github/instructions/e2e-testing.instructions.md
+++ b/.github/instructions/e2e-testing.instructions.md
@@ -215,8 +215,8 @@ Run unit tests fast: `npx vitest run --project unit`. Run a single file: `npx vi
 2. **Check view mode** — is the surface you're asserting on actually rendered in the current mode?
 3. **Check overlays** — did a notification appear and block your click?
 4. **Check commit timing** — did you wait for the document update to round-trip, or only for the DOM to redraw?
-5. **Compendium returns null** — check for stale LevelDB LOCK files (`packs/materials/LOCK`, `packs/documentation/LOCK`). Foundry leaves these behind if it was running during a build. Remove them and rebuild. See `/memories/repo/e2e-leveldb-lock-files.md`.
-6. **`_onUpdate` hook not firing** — check that you're using **nested** object paths (`{ system: { hp: { current: 0 } } }`), not flat dot-notation (`{ 'system.hp.current': 0 }`). Foundry's diff object only populates `changed.system` when the update is nested. See `/memories/repo/foundry-onupdate-nested-path.md`.
+5. **Compendium returns null** — check for stale LevelDB LOCK files (`packs/materials/LOCK`, `packs/documentation/LOCK`). Foundry leaves these behind if it was running during a build. Remove them and rebuild. See `../repo-memory/e2e-leveldb-lock-files.md`.
+6. **`_onUpdate` hook not firing** — check that you're using **nested** object paths (`{ system: { hp: { current: 0 } } }`), not flat dot-notation (`{ 'system.hp.current': 0 }`). Foundry's diff object only populates `changed.system` when the update is nested. See `../repo-memory/foundry-onupdate-nested-path.md`.
 
 ### Identifying Pre-Existing Flaky Failures (Dual-Browser Tests)
 

--- a/.github/instructions/e2e-testing.instructions.md
+++ b/.github/instructions/e2e-testing.instructions.md
@@ -168,6 +168,37 @@ await setFieldOverride(page, weaponUuid, 'system.hp.value', 'visibility', 'gmOnl
 
 Field overrides write to `flags.dnd35e.fieldOverrides.{encodedPath}.{key}` — same flag the in-app override UI uses. `encodeFieldPath` from `fieldPermissions.mts` handles path escaping for keys that contain dots.
 
+## Pre-Seeding Documents for Sync Tests
+
+When testing "enable / create-from-compendium" toggle logic (e.g. `syncMasterworkAeState`, `syncBrokenAeState`), prefer **pre-seeding the item with a disabled AE** rather than letting the code create one from compendium on the first toggle-on.
+
+Why:
+- Avoids compendium availability as a dependency (LOCK file failures, missing pack)
+- Exercises the "existing disabled AE gets re-enabled" code path explicitly, not the create-from-scratch fallback
+- Deterministic: the test controls exactly what AEs exist
+
+```ts
+// Pre-seed: create the item with the AE already embedded and disabled
+const itemUuid = await createItem(page, 'weapon', { name: 'Test Blade' });
+await page.evaluate(async (uuid) => {
+  const item = await (globalThis as any).fromUuid(uuid);
+  await item.createEmbeddedDocuments('ActiveEffect', [{
+    name: 'Masterwork Weapon Enhancement',
+    type: 'base',
+    disabled: true,
+    flags: { dnd35e: { materialSubtype: 'masterwork', systemManaged: true } },
+  }]);
+}, itemUuid);
+
+// Now toggle on — should re-enable the existing AE, not create from compendium
+await toggleMasterwork(page, itemUuid, true);
+const aes = await listMaterialAes(page, itemUuid);
+expect(aes.filter(a => a.materialSubtype === 'masterwork')).toHaveLength(1);
+expect(aes[0].disabled).toBe(false);
+```
+
+See `tests/e2e/broken-masterwork-sync.spec.ts` test 4 for the canonical example.
+
 ## Unit Test Companions (`tests/unit/`)
 
 E2E specs are slow; pair them with unit tests for the extracted pieces:
@@ -184,6 +215,18 @@ Run unit tests fast: `npx vitest run --project unit`. Run a single file: `npx vi
 2. **Check view mode** — is the surface you're asserting on actually rendered in the current mode?
 3. **Check overlays** — did a notification appear and block your click?
 4. **Check commit timing** — did you wait for the document update to round-trip, or only for the DOM to redraw?
+5. **Compendium returns null** — check for stale LevelDB LOCK files (`packs/materials/LOCK`, `packs/documentation/LOCK`). Foundry leaves these behind if it was running during a build. Remove them and rebuild. See `/memories/repo/e2e-leveldb-lock-files.md`.
+6. **`_onUpdate` hook not firing** — check that you're using **nested** object paths (`{ system: { hp: { current: 0 } } }`), not flat dot-notation (`{ 'system.hp.current': 0 }`). Foundry's diff object only populates `changed.system` when the update is nested. See `/memories/repo/foundry-onupdate-nested-path.md`.
+
+### Identifying Pre-Existing Flaky Failures (Dual-Browser Tests)
+
+Dual-browser tests (`field-permissions.spec.ts`, `secret-ae.spec.ts`, `view-mode-bar.spec.ts`) fail intermittently due to Foundry/Playwright timing instability in the second browser context. **These are not regressions.** The telltale sign is repeated log lines:
+
+```
+[WebServer] FoundryVTT | ... | [warn] Failed to parse URL from undefined
+```
+
+If you see this pattern clustered around a failure, it is the dual-browser test flaking — not a code regression. Note them as pre-existing in the PR.
 
 ## Related
 - [vue-sheet-patterns.instructions.md](vue-sheet-patterns.instructions.md) — view modes and FormGroup behavior under test

--- a/.github/skills/e2e-testing/SKILL.md
+++ b/.github/skills/e2e-testing/SKILL.md
@@ -130,6 +130,7 @@ If the spec exposed a complex pure function inside a class, **extract the functi
 | `material-single-per-type.spec.ts` | System setting toggling, validation surfaces |
 | `material-details-changes-tab.spec.ts` | Tab navigation, AE-changes assertions |
 | `secret-ae.spec.ts` | Active Effect lifecycle on items |
+| `broken-masterwork-sync.spec.ts` | Pre-seeding disabled AEs, `listMaterialAes` helper, sync-state assertions, `expect.poll` on `readWeaponSystem` |
 
 ## When You Get Stuck
 

--- a/.github/skills/phase-planning/SKILL.md
+++ b/.github/skills/phase-planning/SKILL.md
@@ -42,6 +42,26 @@ Helps maintain and improve phase planning documentation throughout the system li
 - **Traceability**: Cross-reference related sections
 - **Testability**: Completion checklists use verifiable criteria
 - **Terminology fidelity**: Verify runtime terms against constants/types before final wording
+- **Open question protocol**: Never mark open questions as resolved unilaterally. Present each proposed answer, get user sign-off, then apply. See "Open Question Protocol" below.
+- **WISHLIST scope rule**: WISHLIST = "no phase assigned yet." If the target phase is known, reference that phase directly instead. Sending known-phase work to WISHLIST creates false backlog.
+
+## Open Question Protocol
+
+Phase docs contain `[ ]` open questions in a dedicated section. These are unresolved design decisions — **never resolve them without user sign-off**, even when the answer seems obvious.
+
+**Correct workflow:**
+1. Read each unchecked question aloud to the user
+2. Propose an answer with brief rationale (especially for POC-scope questions where "simplest thing" is usually right)
+3. Wait for confirmation or correction
+4. Apply the resolution verbatim to the doc
+5. Mark the item `[x]`
+
+**Example — good approach:**
+> C2 UI — original question: "expandable tree or flat list with parent indicator?"
+> My proposal: flat list, contained items grouped under container row with indentation. Tree UI → deferred to beta.1.
+> *(wait for user response before editing)*
+
+**Why it matters:** Design decisions in planning docs have downstream cost. A wrong answer left unchallenged gets built. An answer the user disagrees with costs a corrective conversation mid-implementation.
 
 ## Anti-Regression Checks (After Major Implementation)
 

--- a/docs/architecture/architecture-overview.md
+++ b/docs/architecture/architecture-overview.md
@@ -38,7 +38,7 @@ Masking (showing players different values than stored) is handled entirely by th
 ```ts
 // Plain field — always the pattern
 schema.hardness = requiredNumberField(0);
-schema.price = new PriceField();          // special composite type
+schema.price = new CurrencyField();       // special composite type
 schema.nameFormula = new FormulaField();  // formula-specific type
 ```
 
@@ -63,7 +63,7 @@ Runtime GM overrides are stored in `flags.dnd35e.fieldOverrides` on the document
 The schema walker uses static markers on field constructors to control recursion:
 
 - `isFamiliarField = true` — compound leaf; schema walker exposes `.value` access path
-- `isFamiliarLeaf = true` — opaque leaf; no recursion (used by `PriceField`, `FormulaField`)
+- `isFamiliarLeaf = true` — opaque leaf; no recursion (used by `CurrencyField`, `FormulaField`)
 - No marker on a `SchemaField` → walker recurses into children
 - No marker on other field types → simple scalar leaf
 
@@ -380,11 +380,11 @@ src/settings/{domain}/
 
 Most settings are ported from the legacy system. Health, Roll, and Skills are scaffolded with types, constants, and UI but their registrations are commented out pending wiring to actual game mechanics.
 
-### Currency & PriceField — The Deep Dive
+### Currency & CurrencyField — The Deep Dive
 
-The currency system is the most architecturally significant settings domain because it introduces `PriceField` and `PriceData` — a new composite data type that flows through the entire AE pipeline.
+The currency system is the most architecturally significant settings domain because it introduces `CurrencyField` and `CurrencyData` — a new composite data type that flows through the entire AE pipeline.
 
-**PriceData** is a DataModel representing a price as a collection of coin stacks:
+**CurrencyData** is a DataModel representing a currency value as a collection of coin stacks:
 
 ```ts
 {
@@ -398,20 +398,20 @@ The currency system is the most architecturally significant settings domain beca
 
 `srdEquivalent` is recomputed from stacks on every `_initializeSource` using the world's current currency settings. If stacks reference coins that have been disabled in settings, the system reconsolidates using the stored `srdEquivalent` and the currently-enabled denominations. This means worlds can change their currency configuration without losing price data.
 
-**PriceField** extends `EmbeddedDataField<PriceData>` and adds full Active Effect change support:
+**CurrencyField** extends `EmbeddedDataField<CurrencyData>` and adds full Active Effect change support:
 
 | AE Mode | Behavior |
 |---------|----------|
 | **add** | Merge coin counts (add matching coins, append new) |
 | **subtract** | Reduce counts (remove stacks at zero) |
 | **multiply** | Multiply all counts by scalar |
-| **override** | Replace entire price |
+| **override** | Replace entire value |
 | **upgrade** | Per-coin, take the higher count |
 | **downgrade** | Per-coin, take the lower count |
 
-Delta casting accepts multiple formats: JSON arrays, `PriceData` instances, shorthand strings (`"5 srd_gp, 3 srd_sp"`), or raw numbers (treated as GP).
+Delta casting accepts multiple formats: JSON arrays, `CurrencyData` instances, shorthand strings (`"5 srd_gp, 3 srd_sp"`), or raw numbers (treated as GP).
 
-**Why this matters**: Material effects generate price modifier changes. A Mithral material might add `[{ coinId: 'srd_gp', count: 1000 }]` to a weapon's price. Because `PriceField` handles its own AE change modes, this works through the standard Foundry AE pipeline — no special-case code needed.
+**Why this matters**: Material effects generate price modifier changes. A Mithral material might add `[{ coinId: 'srd_gp', count: 1000 }]` to a weapon's price. Because `CurrencyField` handles its own AE change modes, this works through the standard Foundry AE pipeline — no special-case code needed.
 
 The **ItemPriceFormGroup** Vue component renders a multi-denomination coin editor in item sheets, reading from the world's currency settings to know which coins to display. It respects ViewMode semantics so play mode can display masked/effective values while true mode shows unmasked values for GMs.
 

--- a/docs/architecture/property-maps/PropertyMap-Actors.md
+++ b/docs/architecture/property-maps/PropertyMap-Actors.md
@@ -1,4 +1,4 @@
-# 📘 Actor Architecture Reference (Work in Progress)
+﻿# 📘 Actor Architecture Reference (Work in Progress)
 
 A unified reference for all actor type compositions, inheritance chains, and field assignments.
 
@@ -117,19 +117,19 @@ All actors inherit these fields.
 
 | Field | Type | Phase | Stored/Derived | D35E Source | Notes |
 |-------|------|-------|----------------|-------------|-------|
-| `speed.land.base` | number | 5 🔲 | Stored | `attributes.speed.land.base` | Default 30 (human). Race modifies via AE |
-| `speed.land.total` | number | 5 🔲 | Derived | `attributes.speed.land.total` | base + modifiers (armor, encumbrance, effects) |
-| `speed.climb.base` | number | 5 🔲 | Stored | `attributes.speed.climb.base` | Default 0 |
-| `speed.climb.total` | number | 5 🔲 | Derived | `attributes.speed.climb.total` | |
-| `speed.swim.base` | number | 5 🔲 | Stored | `attributes.speed.swim.base` | Default 0 |
-| `speed.swim.total` | number | 5 🔲 | Derived | `attributes.speed.swim.total` | |
-| `speed.burrow.base` | number | 5 🔲 | Stored | `attributes.speed.burrow.base` | Default 0 |
-| `speed.burrow.total` | number | 5 🔲 | Derived | `attributes.speed.burrow.total` | |
-| `speed.fly.base` | number | 5 🔲 | Stored | `attributes.speed.fly.base` | Default 0 |
-| `speed.fly.total` | number | 5 🔲 | Derived | `attributes.speed.fly.total` | |
-| `speed.fly.maneuverability` | string | 5 🔲 | Stored | `attributes.speed.fly.maneuverability` | "clumsy"\|"poor"\|"average"\|"good"\|"perfect" |
-| `biography` | string | 5 🔲 | Stored | `details.biography.value` | Rich text |
-| `notes` | string | 5 🔲 | Stored | `details.notes.value` | Rich text |
+| `speed.land.base` | number | 6 🔲 | Stored | `attributes.speed.land.base` | Default 30 (human). Race modifies via AE |
+| `speed.land.total` | number | 6 🔲 | Derived | `attributes.speed.land.total` | base + modifiers (armor, encumbrance, effects) |
+| `speed.climb.base` | number | 6 🔲 | Stored | `attributes.speed.climb.base` | Default 0 |
+| `speed.climb.total` | number | 6 🔲 | Derived | `attributes.speed.climb.total` | |
+| `speed.swim.base` | number | 6 🔲 | Stored | `attributes.speed.swim.base` | Default 0 |
+| `speed.swim.total` | number | 6 🔲 | Derived | `attributes.speed.swim.total` | |
+| `speed.burrow.base` | number | 6 🔲 | Stored | `attributes.speed.burrow.base` | Default 0 |
+| `speed.burrow.total` | number | 6 🔲 | Derived | `attributes.speed.burrow.total` | |
+| `speed.fly.base` | number | 6 🔲 | Stored | `attributes.speed.fly.base` | Default 0 |
+| `speed.fly.total` | number | 6 🔲 | Derived | `attributes.speed.fly.total` | |
+| `speed.fly.maneuverability` | string | 6 🔲 | Stored | `attributes.speed.fly.maneuverability` | "clumsy"\|"poor"\|"average"\|"good"\|"perfect" |
+| `biography` | string | 6 🔲 | Stored | `details.biography.value` | Rich text |
+| `notes` | string | 6 🔲 | Stored | `details.notes.value` | Rich text |
 | `bond` | — | ⛔ | — | `master` | Replaced by Bond Pattern AE on the bonded creature. Not a stored field. |
 | `bond.actorId` | — | ⛔ | — | `master.id` | Bond AE carries `bondedTo` UUID in its changes |
 | `bond.bondType` | — | ⛔ | — | — | Bond AE carries `bondType` in its changes |
@@ -162,18 +162,18 @@ Shared by Character and NPC.
 
 | Field | Type | Phase | Stored/Derived | D35E Source | Notes |
 |-------|------|-------|----------------|-------------|-------|
-| `abilities.str.base` | number | 5 🔲 | Stored | `abilities.str.value` | Raw score |
-| `abilities.str.mod` | number | 5 🔲 | Derived | `abilities.str.mod` | `floor((base - 10) / 2)` |
-| `abilities.dex.base` | number | 5 🔲 | Stored | `abilities.dex.value` | |
-| `abilities.dex.mod` | number | 5 🔲 | Derived | `abilities.dex.mod` | |
-| `abilities.con.base` | number | 5 🔲 | Stored | `abilities.con.value` | |
-| `abilities.con.mod` | number | 5 🔲 | Derived | `abilities.con.mod` | |
-| `abilities.int.base` | number | 5 🔲 | Stored | `abilities.int.value` | |
-| `abilities.int.mod` | number | 5 🔲 | Derived | `abilities.int.mod` | |
-| `abilities.wis.base` | number | 5 🔲 | Stored | `abilities.wis.value` | |
-| `abilities.wis.mod` | number | 5 🔲 | Derived | `abilities.wis.mod` | |
-| `abilities.cha.base` | number | 5 🔲 | Stored | `abilities.cha.value` | |
-| `abilities.cha.mod` | number | 5 🔲 | Derived | `abilities.cha.mod` | |
+| `abilities.str.base` | number | 6 🔲 | Stored | `abilities.str.value` | Raw score |
+| `abilities.str.mod` | number | 6 🔲 | Derived | `abilities.str.mod` | `floor((base - 10) / 2)` |
+| `abilities.dex.base` | number | 6 🔲 | Stored | `abilities.dex.value` | |
+| `abilities.dex.mod` | number | 6 🔲 | Derived | `abilities.dex.mod` | |
+| `abilities.con.base` | number | 6 🔲 | Stored | `abilities.con.value` | |
+| `abilities.con.mod` | number | 6 🔲 | Derived | `abilities.con.mod` | |
+| `abilities.int.base` | number | 6 🔲 | Stored | `abilities.int.value` | |
+| `abilities.int.mod` | number | 6 🔲 | Derived | `abilities.int.mod` | |
+| `abilities.wis.base` | number | 6 🔲 | Stored | `abilities.wis.value` | |
+| `abilities.wis.mod` | number | 6 🔲 | Derived | `abilities.wis.mod` | |
+| `abilities.cha.base` | number | 6 🔲 | Stored | `abilities.cha.value` | |
+| `abilities.cha.mod` | number | 6 🔲 | Derived | `abilities.cha.mod` | |
 
 ##### Ability fields deferred to later phases
 
@@ -184,18 +184,18 @@ Shared by Character and NPC.
 | `abilities.*.penalty` | 20 | `abilities.*.penalty` | Ability penalty (stacks) |
 | `abilities.*.userPenalty` | 20 | `abilities.*.userPenalty` | Manual penalty override |
 | `abilities.*.checkMod` | Skills | `abilities.*.checkMod` | Ability check modifier |
-| `abilities.str.carryBonus` | 5 🔲 | `abilities.str.carryBonus` | Extra carrying capacity |
-| `abilities.str.carryMultiplier` | 5 🔲 | `abilities.str.carryMultiplier` | Size/quadruped multiplier |
+| ~~`abilities.str.carryBonus`~~ | — | — | Moved to `encumbrance.carryBonus` |
+| ~~`abilities.str.carryMultiplier`~~ | — | — | Moved to `encumbrance.carryMultiplier` |
 
 #### Hit Points (Creature)
 
 | Field | Type | Phase | Stored/Derived | D35E Source | Notes |
 |-------|------|-------|----------------|-------------|-------|
-| `hp.value` | number | 5 🔲 | Stored | `attributes.hp.value` | Current HP |
-| `hp.max` | number | 5 🔲 | Derived | `attributes.hp.max` | Placeholder: `1 × HD + CON mod`. Classes replace |
-| `hp.temp` | number | 5 🔲 | Stored | `attributes.hp.temp` | Temporary HP |
-| `hp.nonlethal` | number | 5 🔲 | Stored | `attributes.hp.nonlethal` | Nonlethal damage taken |
-| `hp.min` | number | 5 🔲 | Stored | `attributes.hp.min` | Death threshold (default -10) |
+| `hp.value` | number | 6 🔲 | Stored | `attributes.hp.value` | Current HP |
+| `hp.max` | number | 6 🔲 | Derived | `attributes.hp.max` | Placeholder: `1 × HD + CON mod`. Classes replace |
+| `hp.temp` | number | 6 🔲 | Stored | `attributes.hp.temp` | Temporary HP |
+| `hp.nonlethal` | number | 6 🔲 | Stored | `attributes.hp.nonlethal` | Nonlethal damage taken |
+| `hp.min` | number | 6 🔲 | Stored | `attributes.hp.min` | Death threshold (default -10) |
 
 ##### HP fields deferred
 
@@ -209,9 +209,9 @@ Shared by Character and NPC.
 
 | Field | Type | Phase | Stored/Derived | D35E Source | Notes |
 |-------|------|-------|----------------|-------------|-------|
-| `ac.normal` | number | 5 🔲 | Derived | `attributes.ac.normal.total` | `10 + DEX mod`. +armor/shield (Ph15), +size (Ph11), +deflect/dodge etc. |
-| `ac.touch` | number | 5 🔲 | Derived | `attributes.ac.touch.total` | `10 + DEX mod`. No armor/shield |
-| `ac.flatFooted` | number | 5 🔲 | Derived | `attributes.ac.flatFooted.total` | `10`. No DEX bonus |
+| `ac.normal` | number | 6 🔲 | Derived | `attributes.ac.normal.total` | `10 + DEX mod`. +armor/shield (Ph15), +size (Ph11), +deflect/dodge etc. |
+| `ac.touch` | number | 6 🔲 | Derived | `attributes.ac.touch.total` | `10 + DEX mod`. No armor/shield |
+| `ac.flatFooted` | number | 6 🔲 | Derived | `attributes.ac.flatFooted.total` | `10`. No DEX bonus |
 | `ac.naturalArmor` | number | 11 (Races) 🔲 | Stored | `attributes.naturalAC` | Race/monster natural armor |
 
 ##### AC fields deferred
@@ -228,23 +228,23 @@ Shared by Character and NPC.
 
 | Field | Type | Phase | Stored/Derived | D35E Source | Notes |
 |-------|------|-------|----------------|-------------|-------|
-| `saves.fort.base` | number | 5 🔲 | Stored | `attributes.savingThrows.fort.base` | 0 until Classes provides progression |
-| `saves.fort.total` | number | 5 🔲 | Derived | `attributes.savingThrows.fort.total` | `base + CON mod` |
-| `saves.fort.ability` | string | 5 🔲 | Stored | — | Default "con". Configurable for edge cases |
-| `saves.ref.base` | number | 5 🔲 | Stored | `attributes.savingThrows.ref.base` | |
-| `saves.ref.total` | number | 5 🔲 | Derived | `attributes.savingThrows.ref.total` | `base + DEX mod` |
-| `saves.ref.ability` | string | 5 🔲 | Stored | — | Default "dex" |
-| `saves.will.base` | number | 5 🔲 | Stored | `attributes.savingThrows.will.base` | |
-| `saves.will.total` | number | 5 🔲 | Derived | `attributes.savingThrows.will.total` | `base + WIS mod` |
-| `saves.will.ability` | string | 5 🔲 | Stored | — | Default "wis" |
+| `saves.fort.base` | number | 6 🔲 | Stored | `attributes.savingThrows.fort.base` | 0 until Classes provides progression |
+| `saves.fort.total` | number | 6 🔲 | Derived | `attributes.savingThrows.fort.total` | `base + CON mod` |
+| `saves.fort.ability` | string | 6 🔲 | Stored | — | Default "con". Configurable for edge cases |
+| `saves.ref.base` | number | 6 🔲 | Stored | `attributes.savingThrows.ref.base` | |
+| `saves.ref.total` | number | 6 🔲 | Derived | `attributes.savingThrows.ref.total` | `base + DEX mod` |
+| `saves.ref.ability` | string | 6 🔲 | Stored | — | Default "dex" |
+| `saves.will.base` | number | 6 🔲 | Stored | `attributes.savingThrows.will.base` | |
+| `saves.will.total` | number | 6 🔲 | Derived | `attributes.savingThrows.will.total` | `base + WIS mod` |
+| `saves.will.ability` | string | 6 🔲 | Stored | — | Default "wis" |
 
 #### Combat Stats
 
 | Field | Type | Phase | Stored/Derived | D35E Source | Notes |
 |-------|------|-------|----------------|-------------|-------|
-| `bab` | number | 5 🔲 | Derived | `attributes.bab.total` | 0 until Classes provides progression |
-| `init.bonus` | number | 5 🔲 | Stored | `attributes.init.bonus` | Misc initiative bonus (feats, items) |
-| `init.total` | number | 5 🔲 | Derived | `attributes.init.total` | `DEX mod + bonus` |
+| `bab` | number | 6 🔲 | Derived | `attributes.bab.total` | 0 until Classes provides progression |
+| `init.bonus` | number | 6 🔲 | Stored | `attributes.init.bonus` | Misc initiative bonus (feats, items) |
+| `init.total` | number | 6 🔲 | Derived | `attributes.init.total` | `DEX mod + bonus` |
 | `cmb` | number | 8 (Actions) 🔲 | Derived | `attributes.cmb.total` | `BAB + STR mod + size mod` |
 | `cmd` | number | 8 🔲 | Derived | `attributes.cmd.total` | `10 + BAB + STR mod + DEX mod + size mod` |
 
@@ -261,8 +261,8 @@ Shared by Character and NPC.
 
 | Field | Type | Phase | Stored/Derived | D35E Source | Notes |
 |-------|------|-------|----------------|-------------|-------|
-| `sr` | number | 5 🔲 | Stored | `attributes.sr.total` | Spell resistance. 0 default |
-| `dr` | array | 5 🔲 | Stored | `attributes.damageReduction` | DR entries (value, types) |
+| `sr` | number | 6 🔲 | Stored | `attributes.sr.total` | Spell resistance. 0 default |
+| `dr` | array | 6 🔲 | Stored | `attributes.damageReduction` | DR entries (value, types) |
 | `energyResistance` | array | 📋 | Stored | `attributes.energyResistance` | Defer — no consumer yet |
 
 #### Senses
@@ -279,29 +279,33 @@ Shared by Character and NPC.
 
 | Field | Type | Phase | Stored/Derived | D35E Source | Notes |
 |-------|------|-------|----------------|-------------|-------|
-| `encumbrance.carriedWeight` | number | 5 🔲 | Derived | `attributes.encumbrance.carriedWeight` | Sum of inventory weight |
-| `encumbrance.light` | number | 5 🔲 | Derived | `attributes.encumbrance.levels.light` | STR-based threshold |
-| `encumbrance.medium` | number | 5 🔲 | Derived | `attributes.encumbrance.levels.medium` | |
-| `encumbrance.heavy` | number | 5 🔲 | Derived | `attributes.encumbrance.levels.heavy` | |
-| `encumbrance.carry` | number | 5 🔲 | Derived | `attributes.encumbrance.levels.carry` | Max lift overhead |
-| `encumbrance.drag` | number | 5 🔲 | Derived | `attributes.encumbrance.levels.drag` | Max push/drag |
-| `encumbrance.level` | number | 5 🔲 | Derived | `attributes.encumbrance.level` | 0=light, 1=medium, 2=heavy, 3=over |
+| `encumbrance.carriedWeight` | number | 6 🔲 | Derived | `attributes.encumbrance.carriedWeight` | Sum of inventory weight |
+| `encumbrance.light` | number | 6 🔲 | Derived | `attributes.encumbrance.levels.light` | STR-based threshold |
+| `encumbrance.medium` | number | 6 🔲 | Derived | `attributes.encumbrance.levels.medium` | |
+| `encumbrance.heavy` | number | 6 🔲 | Derived | `attributes.encumbrance.levels.heavy` | |
+| `encumbrance.carry` | number | 6 🔲 | Derived | `attributes.encumbrance.levels.carry` | Max lift overhead |
+| `encumbrance.drag` | number | 6 🔲 | Derived | `attributes.encumbrance.levels.drag` | Max push/drag |
+| `encumbrance.level` | number | 6 🔲 | Derived | `attributes.encumbrance.level` | 0=light, 1=medium, 2=heavy, 3=over |
+| `encumbrance.carryBonus` | number | 6 🔲 | Stored | `abilities.str.carryBonus` | Flat bonus to base carrying capacity. Default 0. AE-targetable (e.g., Carrying feats). |
+| `encumbrance.carryMultiplier` | number | 6 🔲 | Stored | `abilities.str.carryMultiplier` | Capacity multiplier. Default 1.0 (medium, bipedal). AEs set to 2.0 (Large), 1.5 (quadruped). |
 
-#### Currency
+#### Currency & Vault
 
 | Field | Type | Phase | Stored/Derived | D35E Source | Notes |
 |-------|------|-------|----------------|-------------|-------|
-| `currency.pp` | number | 5 🔲 | Stored | `currency.pp` | Planned with Group C decisions |
-| `currency.gp` | number | 5 🔲 | Stored | `currency.gp` | |
-| `currency.sp` | number | 5 🔲 | Stored | `currency.sp` | |
-| `currency.cp` | number | 5 🔲 | Stored | `currency.cp` | |
+| `currency` | CurrencyField | 6 🔲 | Stored | `currency.*` | Currency carried on person. Uses world-settings coins (same infrastructure as item prices via `CurrencyData.getCurrencyConfig()`). Contributes to encumbrance unless the "ignore currency weight" world setting is on. |
 
-##### Currency fields deferred / removed
+> **One built-in currency field per actor.** Future vaults are named container items (Beta Phase 1+) each carrying their own `CurrencyField`. Debt tracking is on the post-release wishlist.
+>
+> `CurrencyField` (renamed from `PriceField` in Phase 6 pre-story) supports all world-configured currencies, AE add/subtract/multiply change modes, consolidation, and GP-equivalent snapshot.
+
+##### Currency fields removed
 
 | D35E Field | Disposition | Notes |
 |-----------|-------------|-------|
-| `altCurrency` | ⛔ Removed | Replaced by currency in containers |
-| `customCurrency` | 📋 Deferred | Custom currency types — revisit in Beta |
+| `currency.pp/gp/sp/cp` | ⛔ Removed | Replaced by `currency: CurrencyField` (world-settings currencies) |
+| `altCurrency` | ⛔ Removed | Replaced by named vault container items (Beta Phase 1+) |
+| `customCurrency` | ⛔ Removed | Replaced by world-settings currency configuration (`CurrencyData.getCurrencyConfig()`) |
 
 #### Equipment Slots
 
@@ -316,9 +320,9 @@ Shared by Character and NPC.
 
 | Field | Type | Phase | Stored/Derived | D35E Source | Notes |
 |-------|------|-------|----------------|-------------|-------|
-| `alignment` | [LawAxis, MoralAxis] | 5 🔲 | Stored | `details.alignment` | Strongly-typed tuple: [`"lawful"\|"neutral"\|"chaotic"`, `"good"\|"neutral"\|"evil"`]. Concrete strings, no nulls. Maps to the 3x3 alignment grid. |
-| `size` | string | 5 🔲 | Stored | `traits.size` | Default "medium". Race modifies. Uses `SIZES` constant |
-| `level` | number | 5 🔲 | Derived | `details.level.value` | Placeholder = 1. Classes replace with sum of class levels |
+| `alignment` | [MoralAxis\|null, ChaosAxis\|null] | 6 🔲 | Stored | `details.alignment` | Strongly-typed tuple. `MoralAxis = 'good'\|'neutral'\|'evil'`. `ChaosAxis = 'lawful'\|'neutral'\|'chaotic'`. Null for unaligned/any-alignment creatures (some monster stat blocks). Maps to the 3×3 grid; null renders as "—". Agreed with D35E creator. |
+| `size` | string | 6 🔲 | Stored | `traits.size` | Default "medium". Race modifies. Uses `SIZES` constant |
+| `level` | number | 6 🔲 | Derived | `details.level.value` | Placeholder = 1. Classes replace with sum of class levels |
 
 ##### Creature fields deferred
 
@@ -359,14 +363,14 @@ Extends Creature. Character-specific fields.
 
 | Field | Type | Phase | Stored/Derived | D35E Source | Notes |
 |-------|------|-------|----------------|-------------|-------|
-| `xp.value` | number | 5 🔲 | Stored | `details.xp.value` | Current XP. Cosmetic in milestone mode. |
+| `xp.value` | number | 6 🔲 | Stored | `details.xp.value` | Current XP. Cosmetic in milestone mode. |
 | `xp.max` | number | 12 🔲 | Derived | `details.xp.max` | XP to next level. Derived from GM's XP table in XP mode; 0 in milestone mode. |
-| `height` | string | 5 🔲 | Stored | `details.height` | Description field |
-| `weight` | string | 5 🔲 | Stored | `details.weight` | Description field (character weight, not inventory) |
-| `gender` | string | 5 🔲 | Stored | `details.gender` | |
-| `deity` | string | 5 🔲 | Stored | `details.deity` | |
-| `age` | string | 5 🔲 | Stored | `details.age` | |
-| `isPartyMember` | boolean | 5 🔲 | Stored | `isPartyMember` | Show in party tracker |
+| `height` | string | 6 🔲 | Stored | `details.height` | Description field |
+| `weight` | string | 6 🔲 | Stored | `details.weight` | Description field (character weight, not inventory) |
+| `gender` | string | 6 🔲 | Stored | `details.gender` | |
+| `deity` | string | 6 🔲 | Stored | `details.deity` | |
+| `age` | string | 6 🔲 | Stored | `details.age` | |
+| `isPartyMember` | boolean | 6 🔲 | Stored | `isPartyMember` | Show in party tracker |
 
 #### Level History (Character)
 
@@ -426,7 +430,11 @@ The registry is rebuilt every `prepareDerivedData()` cycle — never persisted. 
 
 ### NpcSystemModel
 
-Extends Creature. Covers all non-player creatures: goblins, dragons, NPCs with class levels, mindless undead.
+Extends Creature. Covers **all** non-player creatures: goblins, dragons, NPCs with class levels, mindless undead — including named villain NPCs and anonymous merchants.
+
+> **SRD analysis confirms**: No mechanical distinction between "NPC" and "monster" in D&D 3.5e. Both use identical ability scores, saves, BAB, feats, and skills. CR, Environment, Treasure, and Advancement are informational extras that monsters happen to have, not a schema boundary. A merchant NPC is just a human with Commoner/Expert class levels. A dragon is a creature with racial HD progression. Both advance through the same `Progression` component. **One type, two sheet presentations.**
+>
+> Lair/legendary actions do not exist in D&D 3.5e (5e only). No schema reason to split.
 
 | Field | Type | Phase | Stored/Derived | D35E Source | Notes |
 |-------|------|-------|----------------|-------------|-------|
@@ -453,15 +461,13 @@ Extends Creature. Covers all non-player creatures: goblins, dragons, NPCs with c
 
 ---
 
-### Companion Mixin (on ActorSystemModelBase)
+### Companion Relationship (Bond AE Pattern)
 
-Companion is NOT a separate actor type — it is an optional `bond` field on ActorSystemModelBase. **Any actor** can be bonded to a controller: an NPC familiar, a Character cohort, or even an animated Object. The `bond` field is null by default and populated when the actor is wrapped in its companion shell.
+Companion is **not a separate actor type**. Any actor (Character, NPC, Object) can be bonded to a controller via a **Bond AE** — a non-transfer active effect applied to the bonded creature carrying `bondType`, `bondedTo` (UUID), and `sharedInitiative` in its changes. No schema field on any model. Reverse lookup (what is bonded TO me) uses AE queries.
 
-> Bond fields are listed in the **ActorSystemModelBase** field table above — they are not duplicated here.
+> Bond fields shown as `⛔` in the `ActorSystemModelBase` field table are confirmed **not stored** — they exist as a D35E migration note only.
 
-> **Key insight**: Bond is a mixin/wrapper, not a type. This eliminates the need for type conversion workflows. Applying a bond = setting one field. Removing a bond = clearing it. The actor's actual type (NPC, Character, Object) never changes.
->
-> **Stat derivation by bondType**: Handled in `prepareDerivedData()` when `bond !== null`. Familiars derive HP/BAB/saves from controller. Animal companions gain bonus HD/natural armor/STR/DEX from druid level. Others: no stat changes, bond is informational.
+> **No schema stub needed**: Bond design is deferred entirely. When the Bond/Companion feature is implemented, it reads/writes Bond AEs, not schema fields. The actor's actual type never changes.
 
 ---
 

--- a/docs/architecture/property-maps/PropertyMap-Actors.md
+++ b/docs/architecture/property-maps/PropertyMap-Actors.md
@@ -1,4 +1,4 @@
-﻿# 📘 Actor Architecture Reference (Work in Progress)
+# 📘 Actor Architecture Reference (Work in Progress)
 
 A unified reference for all actor type compositions, inheritance chains, and field assignments.
 

--- a/docs/migration-plan/beta/phase-01-equipment-loot.md
+++ b/docs/migration-plan/beta/phase-01-equipment-loot.md
@@ -137,6 +137,16 @@ AmmoSystemModel extends PhysicalItemSystemModel
 └── isDefaultAmmo: boolean
 ```
 
+### Named Vault Containers
+
+A **vault** is a `ContainerSystemModel` item with `capacity: 0` (unlimited) and a `isWeightless: boolean` flag that, when true, removes the container's own weight and all contents weight from the actor's encumbrance. Examples: "Town Bank", "Hideout Stash", "Merchant Account".
+
+The vault carries its own `currency: CurrencyField` for tracking stored coin separately from the character's on-person currency. This reuses the same `CurrencyField` the actor schema uses — no new field type.
+
+Vault items appear in a dedicated **Vaults** section in the Inventory tab (below the main item groups) showing each vault's name and currency total. Depends on the Container infrastructure implemented in this phase.
+
+---
+
 ## 10.5 Double-Sided Weapons (Deferred)
 
 **Challenge**: In the current system (D35E), each side of a double weapon is created as a separate weapon item. In dnd35e, a weapon can have only one set of attack actions. Supporting double weapons would require either:

--- a/docs/migration-plan/poc/phase-02-task-decomposition.md
+++ b/docs/migration-plan/poc/phase-02-task-decomposition.md
@@ -1091,12 +1091,12 @@ PARALLEL WORK ZONES
 - `schemaWalker.mts`: `walkFields()` treats non-opted-out, non-SchemaField fields as simple leaves
 - Two static markers recognized on field constructors:
   - `isFamiliarField = true` → compound leaf with `.value` access path
-  - `isFamiliarLeaf = true` → opaque leaf, not recursed into (PriceField, FormulaField)
+  - `isFamiliarLeaf = true` → opaque leaf, not recursed into (CurrencyField, FormulaField)
 - Opt-out: `slug` field in `Dnd35eDocumentSystemModel` uses `familiar: { formulaVisible: false }`
 - Fields that already opt out: `nameFormula`, `description` (via `withFamiliar(..., { formulaVisible: false })`)
 
 **Opaque leaf fields** (handle their own inner structure):
-- **PriceField** — renders via `PriceData.toString()`; inner stacks/srdEquivalent hidden from walker
+- **CurrencyField** — renders via `CurrencyData.toString()`; inner stacks/srdEquivalent hidden from walker
 - **FormulaField** — the formula string is an implementation detail; future phases surface `resolvedValue`
 
 ---

--- a/docs/migration-plan/poc/phase-06-actor-foundation.md
+++ b/docs/migration-plan/poc/phase-06-actor-foundation.md
@@ -1,4 +1,4 @@
-﻿# POC Phase 6: Actor Foundation
+# POC Phase 6: Actor Foundation
 
 **Status**: ✅ Approved (Actor schema, multiclass stacking, ability scores)
 
@@ -451,7 +451,7 @@ class DocumentEventEmitter {
 | `death` | `{ previousHp: number, currentHp: number, cause?: string, attackerId?: string, damage?: number }` | Actor HP drops to ≤ world death threshold | Draconian death throes, Rage ends, Contingency fires |
 | `revealSecret` | `{ secretAeId: string, field: string, previousValue: unknown, revealedValue: unknown }` | Secret AE is disabled (revealed) | Chat notification, journal updates, identification macro triggers |
 
-> `preUseAction`, `postUseAction`, `dealDamage`, and `UseActionContext` → **poc.9** (Basic Combat).
+> `preUseAction`, `postUseAction`, `dealDamage`, and `UseActionContext` → **poc.10** (Basic Combat).
 
 #### Item Events
 

--- a/docs/migration-plan/poc/phase-06-actor-foundation.md
+++ b/docs/migration-plan/poc/phase-06-actor-foundation.md
@@ -498,7 +498,7 @@ A separate **"Monsters die at 0"** world toggle makes NPC actors without class l
 
 **Phase 6 — Remaining:**
 - [ ] Add static `wellKnownEvents` registry + `registerEventType()` to `DocumentEventEmitter`
-- [ ] Register well-known domain events at system init: `takeDamage`, `dying`, `death`, `destroyed`, `revealSecret` (`preUseAction`/`postUseAction`/`dealDamage` registered in poc.9)
+- [ ] Register well-known domain events at system init: `takeDamage`, `dying`, `death`, `destroyed`, `revealSecret` (`preUseAction`/`postUseAction`/`dealDamage` registered in poc.10)
 - [ ] Define typed payload interfaces: `TakeDamagePayload`, `DeathPayload`, `DyingPayload`, `DestroyedPayload`, `RevealSecretPayload`
 - [ ] Implement `takeDamage → dying → death` cascade in actor damage application method
 - [ ] Implement world setting: death threshold mode (`−10` flat / `−CON score`)

--- a/docs/migration-plan/poc/phase-06-actor-foundation.md
+++ b/docs/migration-plan/poc/phase-06-actor-foundation.md
@@ -1,6 +1,6 @@
 # POC Phase 6: Actor Foundation
 
-**Status**: 📋 Outlined (Actor schema, multiclass stacking, ability scores)
+**Status**: � Planned (Actor schema, multiclass stacking, ability scores)
 
 > **Milestone**: POC  
 > **Dependencies**: Phase 1, Phase 3  
@@ -36,7 +36,7 @@ Questions organized into groups for serial resolution. As each group is resolved
 - [x] **Alignment, description fields**: In Phase 5. biography, notes, height, weight, gender, deity, age, XP — these are character sheet display properties with no external consumer dependency.
 - [x] **DR / SR**: Fields exist on model but empty/0. Populated by race/class/item effects when those arrive.
 - [x] **Encumbrance**: Derived from STR + inventory weight, assumes Medium size multiplier. Races adjust multiplier.
-- [x] **Skills**: **Not on model at all** until the Skills phase. No stub, no empty record.
+- [x] **Skills**: **Not on model** until the dedicated Skills phase (after Classes). Skill totals derive from `ranks + ability mod + misc - ACP`; ranks are awarded from class levels and can't be meaningfully stored without the Classes system. No stub, no empty record. Phase 8 handles "roll a skill check" as a simple `d20 + ability mod` actor action without needing schema fields.
 - [x] **Conditions**: **Not on model** until Conditions phase. The Effects tab shows Active Effects (which already work). Condition toggle UI added when Conditions phase arrives.
 - [x] **Formula familiar**: Each phase registers its own `#self.*` fields when it adds properties. Phase 5 registers abilities, HP, AC, saves, init, BAB, speed. Later phases add their fields.
 
@@ -46,15 +46,14 @@ Questions organized into groups for serial resolution. As each group is resolved
 
 - [x] **Location**: `docs/architecture/property-maps/PropertyMap-Actors.md`
 - [x] **Format**: Hybrid — mermaid ER for inheritance hierarchy, grouped field tables per model with Phase/Stored-Derived/D35E-Source columns
-- [x] **Scope**: All 6 types mapped: Character, NPC (covers monsters), Companion, Object, Trap + future Vehicle/IntelligentItem notes
+- [x] **Scope**: All 5 types mapped: Character, NPC (covers monsters), Object, Trap + future Vehicle/IntelligentItem notes. Companions are **not a separate type** — Bond AE on any actor (Character or NPC) handles the relationship.
 - [x] **Composition**: Inheritance-first architecture:
   - `ActorSystemModelBase` → speed, biography/notes (truly universal)
-  - `CreatureSystemModel` → abilities, HP(creature), AC, saves, BAB, init, combat, senses, encumbrance, currency, equipment
-  - `CharacterSystemModel` → xp, description fields, isPartyMember
-  - `NpcSystemModel` → cr, creature type/subtype, environment, treasure, advancement (covers all monsters)
-  - `CompanionSystemModel` → bond { actorId, bondType, sharedInitiative }
-  - `ObjectSystemModel` → HP(object), hardness, breakDC
-  - `TrapSystemModel` → init, findDC, disarmDC, cr, saves
+  - `CreatureSystemModel extends ActorSystemModelBase` → abilities, HP(creature), AC, saves, BAB, init, combat, senses, encumbrance, currency, equipment
+  - `CharacterSystemModel extends CreatureSystemModel` → xp, description fields, isPartyMember
+  - `NpcSystemModel extends CreatureSystemModel` → cr, creature type/subtype, environment, treasure, advancement (covers all monsters)
+  - `ObjectSystemModel extends ActorSystemModelBase` → HP(object), hardness, breakDC
+  - `TrapSystemModel extends ObjectSystemModel` → adds action/trigger capability (design deferred)
 
 **Key decisions documented in PropertyMap**:
 - NPC = Monster (same type, different sheet presentation)
@@ -66,9 +65,9 @@ Questions organized into groups for serial resolution. As each group is resolved
 ### Group C: Inventory System ❓
 
 #### C1: Item States
-- [ ] **Three-state model**: Stored (not on person) → Carried (on person) → Equipped (subset of carried). Items in containers inherit their container's state.
-- [ ] **Existing flags**: `isCarried` exists on `PhysicalItemSystemModel`, `isEquipped` exists on `EquippableItemSystemModel`. Confirm these are the right home — no new flags needed on the actor.
-- [ ] **"Stored" semantics**: `isCarried = false` means stored. Is "stored" always on the actor but just not contributing to weight? Or does stored mean "in a chest somewhere, not on this actor at all"?
+- [x] **Three-state model**: Stored (not on person) → Carried (on person) → Equipped (subset of carried). Items in containers inherit their container's state.
+- [x] **Existing flags**: `isCarried` exists on `PhysicalItemSystemModel`, `isEquipped` exists on `EquippableItemSystemModel`. These are the right home — no new flags needed on the actor.
+- [x] **"Stored" semantics resolved**: `isCarried = false` means stored. Stored items remain **owned by the actor** (tracked in their inventory) but do **not** contribute to encumbrance weight. They appear in the inventory tab in a visually distinct "Stored" section below carried items. Use case: "I left my camping gear at the inn." A stored item can be un-stored (toggle `isCarried = true`) at any time.
 
 #### C2: Containers
 - [x] **Container model**: Uses `containerId` reference pattern (dnd5e canonical). All items are flat siblings in `actor.items`. Contained items store `containerId` pointing to parent container's ID. Container items compute `contents` by filtering siblings.
@@ -76,43 +75,62 @@ Questions organized into groups for serial resolution. As each group is resolved
 - [ ] **Nesting**: Can containers contain containers? (Bag inside a backpack?) — needs rules decision
 - [ ] **UI**: How do containers display in the inventory tab? Expandable tree? Flat list with parent indicator?
 
-#### C3: Weapon Slots
-- [ ] **Slot definitions**: Need mainhand / offhand at minimum. Natural attack slots?
-- [ ] **Two-handing**: A weapon in mainhand that is two-handed occupies both hand slots. How is this tracked?
-- [ ] **Dual wield**: Two weapons, one per hand. Interaction with the existing `equipmentSlots.mts` body slots.
-- [ ] **Where do weapon slots live**: Extend `equipmentSlots.mts` or separate `weaponSlots.mts`?
+#### C3: Weapon Slots ✅
 
-#### C4: Currency
-- [ ] **Storage model**: User has detailed plans. Need in-depth dialog.
-- [ ] **Weight rule**: 50 coins = 1 lb. Is this always-on or setting-dependent?
-- [ ] **Currency on actor vs in containers**: Can coins be in a bag of holding?
-- [ ] **Multiple currency pools**: D35E has `currency` + `altCurrency` + `customCurrency`. What do we need?
+**Resolved decisions:**
+
+- [x] **Slot definitions**: `mainhand` and `offhand` as sentinel slot IDs in `equipmentSlots.mts`. Natural attack slots deferred to Natural Attacks phase.
+- [x] **Two-handing**: Deferred to **end of Phase 6** with a community feedback round mid-phase once screenshots of the mainhand/offhand UI exist. We want players to react to what they see before locking in the three-slot design (mainhand / offhand / two-hand).
+  - For Phase 6: no two-hand slot. A two-handed weapon equips to mainhand. The offhand is not locked. Action System (Phase 8) reads `isTwoHanded` flag at roll time and handles the penalty/off-hand-disable logic there.
+  - Community feedback question: "Is a distinct two-hand slot better UX than the mainhand+offhand model? Does a third slot that disables both others feel right?"
+- [x] **Dual wield**: Two weapons, one per hand — works naturally with mainhand + offhand. Two-weapon fighting penalties live in the Action System (Phase 8).
+- [x] **Where weapon slots live**: Extend `equipmentSlots.mts` with `mainhand` and `offhand` sentinel constants.
+
+#### C4: Currency & Vaults ✅
+
+**Resolved decisions:**
+
+- [x] **Vault concept**: Every container can hold currency. A vault is any container with a `containedValue: CurrencyField` — same field type as an item's `price`, just representing currency *held inside* rather than the item's sale value.
+- [x] **CurrencyField for all currency**: Uses `CurrencyField` directly — same as item prices. No bespoke `Record<currencyId, number>` structure. World-settings currencies supported from day one. Renamed from `PriceField` in the Phase 6 pre-story refactor.
+- [x] **One built-in currency field**: Characters have exactly ONE schema currency field:
+  - `currency: CurrencyField` — currency on person (pockets, coin purse). At root of schema — no nesting. Contributes to encumbrance via coin weights from world settings. Future vault container items (Beta Phase 1+) will each carry their own `CurrencyField` but are separate items, not schema fields.
+- [x] **Global "ignore currency weight" world setting**: A single setting that removes all currency from encumbrance calculations system-wide. No per-vault toggles. Default: off (currency weighs something).
+- [x] **Future vaults (Beta Phase 1+)**: Named currency-only container items on the character sheet. No item weight-capacity limit. Each can be toggled weightless. Examples: "Town Bank", "Hideout Stash", "Merchant Account". These are container items (depend on poc.6 + poc.7 → beta.1) — deferred.
+- [x] **Debt tracking**: Post-release wishlist. Vaults with negative currency counts to represent debts owed.
+- [x] **D35E fields removed**:
+  - `currency.pp/gp/sp/cp` → `currency: CurrencyField` (flat root field, no nesting)
+  - `altCurrency` → Future named vault container items (Beta Phase 1)
+  - `customCurrency` → World-settings currency configuration (`CurrencyData.getCurrencyConfig()`)
 
 #### C5: Item Lifecycle
 - [ ] **Drag-and-drop from compendium**: Foundry creates owned item copy. Confirm this works out-of-the-box or needs custom handling.
 - [ ] **Item deletion**: Remove from actor. Any cleanup needed (unequip, remove from container)?
 
-### Group D: Character Sheet UX ❓
+### Group D: Character Sheet UX ✅
 
-- [ ] **Tab structure**: Review D35E's 12-tab layout and DnD5e's 8-tab sidebar layout. Decide our approach.
-  - D35E tabs: Details, Attributes, Combat, Inventory, Features, Skills, Buffs, Spells, Cards, Biography, Notes, Config
-  - DnD5e tabs: Details, Inventory, Features, Spells, Effects, Biography (+ conditional Bastion, Special Traits)
-- [ ] **Tab navigation style**: Horizontal top bar (D35E) vs vertical sidebar (DnD5e) vs something else?
-- [ ] **What's available in Phase 5**: Abilities display, Inventory tab, Effects tab (no conditions yet), Biography tab. Features tab as placeholder.
-- [ ] **Skills tab**: Blank/hidden until Skills phase. Confirm.
-- [ ] **Combat tab**: Deferred until Phase 8/9. Confirm.
-- [ ] **Conditions in Effects tab**: Show effects list now, add conditions toggles when Conditions phase arrives.
-- [ ] **Inventory tab detail level**: Grouped by type, equip toggles, weight/price. Slot selection is basic until Equipment phase refines it.
-- [ ] **Header bar content**: Name, portrait — what else in Phase 5? (Level, race, alignment all deferred per Group A?)
+**Resolved decisions:**
 
-### Group E: Active Effect & Store Integration ❓
+- [x] **Tab navigation style**: **Vertical sidebar** (like dnd5e's AppV2 side tab bar). Preferred over D35E horizontal top bar — better UX and visual hierarchy. Community feedback round planned mid-phase.
+- [x] **Phase 6 tabs**: `Abilities | Inventory | Features | Effects | Biography`
+  - D35E has 12 tabs — we scope-cut aggressively and add tabs only when their data lands.
+- [x] **Skills tab**: Hidden/absent until the full Skills phase (after Classes). No stub.
+- [x] **Combat tab**: Absent until Phase 8 (Action System). No stub.
+- [x] **Conditions in Effects tab**: Show AE list now; condition toggles added when Conditions phase arrives.
+- [x] **Inventory tab detail**: Grouped by type (Weapons, Equipment, Consumables, Loot). Equip toggles, weight/price columns, total weight display. `isCarried` grouping distinguishes stored vs. carried items visually. Slot selection is basic until Beta Phase 1 (Equipment) refines it.
+- [x] **Header bar**: Name, portrait. Level/race/alignment deferred per Group A decisions.
+- [x] **D35E reference**: Run `@Explore` subagent against the D35E system source to map their sheet layout and UX patterns. Use as visual reference during implementation. Do NOT copy directly — bring it up to modern standards with our styles.
 
-- [ ] **AE processing update**: Current `ActorDnd35e.applyActiveEffects()` uses Foundry's base `CHANGE_TYPES` handlers. Phase 2 introduced `resolveActiveEffectChanges()` with pre-filter stacking. The actor override should **fully replace** the base application loop with the same collect → resolve → apply winners pattern used by `ItemDnd35e`. Extract shared logic into `applyStackedChanges()` helper in `src/helpers/stacking.mts`.
-- [ ] **Stale references**: §5.8 and completion checklist reference `system._stackingHistory` which was redesigned in Phase 2 to use enriched `overrides`. Update to use `overrides` with `bonusType`, `stackResult`, `stackReason` metadata.
-- [ ] **VueDocumentSheetMixin**: Current type constraint is `ItemDnd35e | DnD35eActiveEffect`. Needs to accept actors. This is likely a small change (widen the generic), not a big task — confirm.
-- [ ] **Actor Pinia store**: No dedicated actor store exists. Need one for document sheet reactivity. Follow existing `DocumentSheetStore` pattern or create actor-specific store?
-- [ ] **Actor config registration**: `src/constants/config/actor.mts` has empty `documentClasses`. Register character class.
-- [ ] **Formula familiar expansion**: `registration.mts` currently registers only document-level aspects (name). Expand with ability scores, attributes, etc. for `#self.*` contexts.
+### Group E: Active Effect & Store Integration ✅
+
+**Resolved decisions:**
+
+- [x] **AE processing update**: Confirmed — fully replace the base application loop with collect → resolve → apply winners pattern (same as `ItemDnd35e`). Extract shared logic into `applyStackedChanges()` helper in `src/helpers/stacking.mts`.
+- [x] **Stale references**: Update §5.8 and checklist to use `overrides` with `bonusType`, `stackResult`, `stackReason` metadata (not `system._stackingHistory`).
+- [x] **VueDocumentSheetMixin**: Widen `TDocument` generic to accept `ActorDnd35e`. Small change — widen the union type constraint.
+- [x] **VueActorSheet**: Create `src/vue/apps/VueActorSheet.mts` mirroring `VueItemSheet.mts` but extending `useVueDocumentSheetMixin(ActorSheetBase)` where `ActorSheetBase = foundry.applications.sheets.ActorSheetV2<ActorDnd35e, ...>`.
+- [x] **Actor Pinia store**: Create actor-specific store following the exact same pattern as `DocumentSheetStore` (item/AE pattern). One store file per major store concern — mirrors item and AE implementation.
+- [x] **Actor config registration**: Register character class in `src/constants/config/actor.mts` `documentClasses`.
+- [x] **Formula familiar expansion**: Expand `registration.mts` with ability scores, attributes, etc. for `#self.*` contexts when schema is defined.
 
 ### Codebase TODO Notes (Landing Here)
 
@@ -122,6 +140,24 @@ The following TODO notes exist in the codebase and are tracked here for resoluti
 - [ ] **Equipment slot 'none' sentinel cleanup** (`equipmentSlots.mts:20`): The `'none'` option in `EQUIP_SLOT_SELECT_OPTIONS` is flagged as redundant for multiselect. When this phase implements equipment slot UI and validation, resolve whether `equippedSlotIds` should become a single-select nullable field (replace `'none'` with `value: null`) or remain multiselect (remove the `'none'` option entirely).
 - [ ] **Container dropdown in PhysicalItemStore** (`PhysicalItemStore.mts:64`): `possibleContainers` computed returns only `[None]` with a TODO to build out after implementing containers. Wire this to query the parent actor's items for container-type items once the container model (§C2) is implemented.
 
+### Group G: Actor Type Hierarchy ✅
+
+**Resolved decisions:**
+
+- [x] **Schema hierarchy confirmed — build all layers now**: Three DataModel base layers + stubs for unregistered types. Only `CharacterSystemModel` is registered in Phase 6.
+  - `ActorSystemModelBase` → speed, biography/notes (universal)
+  - `CreatureSystemModel extends ActorSystemModelBase` → abilities, HP, AC, saves, BAB, init, senses, encumbrance, currency, equipment (shared by Character + NPC)
+  - `CharacterSystemModel extends CreatureSystemModel` → xp, description fields (height/weight/gender/deity/age/alignment), isPartyMember
+  - `NpcSystemModel extends CreatureSystemModel` → cr, creature type/subtype, environment, treasure, advancement — **stub only**, Phase 23
+  - `ObjectSystemModel extends ActorSystemModelBase` → HP(object), hardness, breakDC — **stub only**, Phase 23
+  - `TrapSystemModel extends ObjectSystemModel` → action/trigger capability deferred to trap design phase — **stub only**, Phase 23
+- [x] **No CompanionSystemModel**: Companions (familiars, animal companions, mounts, summons, cohorts, commanded creatures) are regular Character or NPC actors linked to their master via the Bond AE. No dedicated actor type. No `bond` field on any schema in Phase 6. Bond relationship design deferred to the phase that implements it.
+- [x] **TrapSystemModel extends ObjectSystemModel**: Traps are objects with actions. They share HP, hardness, and breakDC with objects. The `findDC` and `disarmDC` trap-specific fields are added on top. Future: a trap actor may reference the physical item it represents (e.g., a pressure plate in the actor's inventory) to drive its stats — see WISHLIST.
+- [x] **NPC = Monster confirmed**: SRD analysis — no mechanical distinction. One `NpcSystemModel` covers all non-player creatures. Sheet presentation may differ; data model is shared. Phase 23 scope.
+- [x] **Actor sheets get full view-mode treatment**: `VueActorSheet` uses `VueDocumentSheetMixin`, so edit/play/true modes, field visibility overrides, editability overrides, and FieldControls all work identically to item sheets. GMs can mark any actor field as GM-only or hidden. Secret AEs on actors work. Nothing actor-specific needed — it's all in the mixin.
+
+---
+
 ### Group F: Phase Structure ✅
 
 **Resolved decisions:**
@@ -129,10 +165,99 @@ The following TODO notes exist in the codebase and are tracked here for resoluti
 - [x] **Skills split into two scopes**:
   - **Phase 8 (Action System)**: Basic skill check as an example of an *actor-owned action*. d20 + ability mod → chat card. No ranks, no class skills, just an ability check with skill flavor. Proves that actions can live on actors, not just items.
   - **New phase after Phase 12 (Classes)**: Full skill system — ranks, class skills, skill points per level, trained-only, ACP, synergies, custom skills. This phase depends heavily on class data.
-- [x] **No skills on the actor model in Phase 5**: No `skills` property at all. The basic skill check in Phase 8 reads ability mods directly. The full Skills phase adds the schema.
+- [x] **No skills on the actor model in Phase 6**: No `skills` property at all. The basic skill check in Phase 8 reads ability mods directly. The full Skills phase adds the schema.
 - [x] **INSERT, don't take over**: The full Skills phase is inserted after Classes. Does not replace Phase 14 (Testing & POC Validation). Exact numbering deferred until we do the README update.
 - [x] **POC exit criteria**: Will revisit — tentatively includes "a character can roll a skill check" via the Phase 8 actor-action example.
 - [x] **Current spec cleanup**: Remove "skills stub — expanded in Phase 14" references from §5.1 and completion checklist. (Phase 14 is Testing, not Skills.)
+
+---
+
+---
+
+## Phase Delivery Plan
+
+Phase 6 is delivered in **4 stories**. Each story ends with a working, user-testable slice — E2E tests are written at story completion. Unit tests accompany each commit within a story.
+### Pre-story: Rename `PriceField` / `PriceData` → `CurrencyField` / `CurrencyData`
+
+**Rationale**: `PriceField` is a generic currency-value field that happens to be used as an item's sale price. Naming it after its most common use case leaks item semantics into infrastructure. Phase 6 adds it to the actor schema as `currency: CurrencyField` — which reads wrong with the old name. Rename now so all Phase 6 code starts with the correct name.
+
+**Scope**:
+- `src/fields/PriceField.mts` → `src/fields/CurrencyField.mts` (class `CurrencyField`, type `CurrencyData`)
+- All usages: `new PriceField()` → `new CurrencyField()`, `PriceData` → `CurrencyData`
+- **Keep "Price" in item-specific components**: `ItemPriceFormGroup.vue`, `ItemPrice.vue`, `ItemResalePrice.vue` — these are contextually correct (they display an item's price).
+- **Keep "price" as the schema field name on items**: `price: new CurrencyField()` — field name is still `price`, only the class name changes.
+
+This is a single commit, pure rename, no behavior change.
+```
+Story 1
+  └─► Story 2  ──► Story 4
+  └─► Story 3  ──► Story 4
+```
+
+Stories 2 and 3 are independent of each other and can be worked in parallel after Story 1 merges.
+
+---
+
+### Story 1 — Character Actor with Ability Scores
+
+**User**: GM  
+**Delivers**: A character actor can be created, its sheet opens, and all 6 ability scores are visible and editable with live modifier display. Sheet tab bar present (stubs OK for non-Abilities tabs). DocumentEventEmitter wired on all system documents.  
+**Depends on**: nothing — first story.
+
+**Commits:**
+1. **Schema hierarchy + registration** — `ActorSystemModelBase`, `CreatureSystemModel`, `CharacterSystemModel` (full), `NpcSystemModel` / `ObjectSystemModel` / `TrapSystemModel` (stubs). Register `CharacterSystemModel` in `registration.mts`. *(Unit tests: schema instantiates with defaults, `persisted:false` fields reset on prep cycle)*
+2. **DocumentEventEmitter** — `DocumentEventEmitter` class, typed payload interfaces, well-known event registry wired into `DocumentDnd35e`. *(Unit tests: on/off/once/emit/clear; failing callback doesn't block others)*
+3. **VueActorSheet + sheet scaffolding** — `VueActorSheet.mts` base class, `CharacterSheet.mts` + `CharacterSheet.vue` with tab bar (Abilities | Inventory | Features | Effects | Biography), widen `VueDocumentSheetMixin` generic to accept `ActorDnd35e`. *(Unit tests: sheet mounts without errors)*
+4. **Abilities tab** — 6 `NumberFormGroup`s (editable base score), derived modifier display (read-only). All labels via i18n. `abilities.json` + `actors.json`. *(Unit tests: mod formula edge cases — score 1 → −5, score 20 → +5)*
+5. **Biography tab** — Rich-text editor or plain textarea for biography/notes fields.
+
+**E2E acceptance**: Create character actor → open sheet → Abilities tab visible → edit STR from 10 to 14 → modifier updates to `+2`.
+
+---
+
+### Story 2 — Combat Stats (HP, AC, Saves, Speed, Initiative, BAB)
+
+**User**: GM/Player  
+**Delivers**: Sheet displays HP (editable current/max), all 3 AC variants, fort/ref/will saves, initiative, BAB, and land speed — all deriving live from ability scores.  
+**Depends on**: Story 1.
+
+**Commits:**
+1. **Derived data pipeline** — `prepareBaseData()` + `prepareDerivedData()`: ability modifiers, AC (normal/touch/flat-footed), saves, initiative, BAB stub (0), speed, size modifier plumbing. All `persisted:false` fields reset and recomputed each prep cycle. *(Unit tests: ability mod calc; AC at DEX 14 = 12; fort = CON mod; init = DEX mod + bonus)*
+2. **HP system + damage event cascade** — `hp.max = hp.base + CON mod`; `hp.value` editable; wire `takeDamage → dying → death` event cascade in damage-application method. *(Unit tests: `dying` fires at HP ≤ 0, `death` fires at HP ≤ −10; threshold configurable; events fire once per transition)*
+3. **Combat stats panel on sheet** — HP (editable `value` / derived `max`), AC variants, saves, initiative, BAB, speed displayed in sheet Abilities tab or a summary header section. *(Unit tests: component renders correct values)*
+
+**E2E acceptance**: Create character with DEX 16 → AC shows `13` (10 + 3); set CON 14 → HP max increases by 2; edit `hp.value` → value persists after sheet re-open.
+
+---
+
+### Story 3 — Inventory, Equipment Slots, Encumbrance, Currency
+
+**User**: GM/Player  
+**Delivers**: Inventory tab shows owned items grouped by type; items dragged from compendium appear in the list; weapons can be equipped to mainhand/offhand; encumbrance tier shown; currency field on sheet.  
+**Depends on**: Story 1. **Runs in parallel with Story 2.**
+
+**Commits:**
+1. **Inventory tab scaffold** — Inventory tab with grouped item list (Weapons / Equipment / Consumables / Loot); item rows: name, quantity, weight, price, carried/equipped state. *(Unit tests: grouping logic, stored-vs-carried display)*
+2. **Equipment slots + equip toggle** — mainhand/offhand sentinel constants in `equipmentSlots.mts`; equip/unequip toggle per item; slot collision validation. *(Unit tests: slot validation; equipping occupied slot blocked)*
+3. **Encumbrance + currency** — `carriedWeight` derived from `sum(item.weight × qty)` for `isCarried` items; thresholds from STR score; encumbrance tier display; `currency: CurrencyField` in inventory footer. *(Unit tests: carrying capacity at STR 10 = 100 lb; light/medium/heavy thresholds; stored items excluded from weight)*
+4. **Drag-drop from compendium** — item drop handler; `instantiate` event fires on item add. *(Integration tests: drop item → appears in correct group)*
+
+**E2E acceptance**: Drag longsword from compendium → appears in Weapons list → equip to mainhand → equipped state shown; add items exceeding STR light load → encumbrance tier shows Medium.
+
+---
+
+### Story 4 — Active Effects Modify Stats (Stacking Engine on Actor)
+
+**User**: GM  
+**Delivers**: Effects tab shows AEs on the actor; adding a stat-modifying AE changes derived stats immediately; same bonus-type bonuses don't stack (only best applies).  
+**Depends on**: Story 2 (stat fields must exist before AEs can modify them).
+
+**Commits:**
+1. **`applyStackedChanges()` helper** — extract/finalize shared stacking utility in `src/helpers/stacking.mts` for use by both `ItemDnd35e` and `ActorDnd35e`. *(Unit tests: stacking rules; same-type rejection; penalty tracking)*
+2. **`ActorDnd35e.applyActiveEffects()`** — integrate stacking engine: collect changes from all enabled AEs, separate penalties, resolve, write to `system`, enrich `this.overrides` with `bonusType` / `stackResult` / `stackReason` metadata. *(Unit tests: buff applies; penalty applies; duplicate enhancement bonus rejected; overrides populated correctly)*
+3. **Effects tab** — AE list display; enable/disable toggle; stacking debug info visible in expanded view (which bonuses won/were rejected). *(Integration tests: toggle AE enabled → stat updates live)*
+
+**E2E acceptance**: Add `+2 enhancement` STR AE → STR score increases by 2; add second `+2 enhancement` STR AE → STR does NOT increase to +4 (non-stacking); disable first AE from Effects tab → STR reverts.
 
 ---
 
@@ -157,12 +282,11 @@ ActorSystemModel (character)
 ├── details
 │   ├── level (persisted: false, derived from class items)
 │   ├── xp: { value, max }
-│   ├── alignment: string
+│   ├── alignment: [MoralAxis|null, ChaosAxis|null]
 │   ├── race: string (persisted: false, derived from race item)
 │   └── size: SizeCategory
-├── skills: Record<SkillKey, SkillData> (stub — expanded in Phase 14)
-├── currency: { pp, gp, sp, cp }
-├── encumbrance: { current (p:f), light (p:f), medium (p:f), heavy (p:f), carry (p:f), drag (p:f) }
+├── currency: CurrencyField             (coin weight → encumbrance; "ignore currency weight" setting disables)
+├── encumbrance: { carriedWeight (p:f), light (p:f), medium (p:f), heavy (p:f), carry (p:f), drag (p:f), level (p:f), carryBonus, carryMultiplier }
 └── conditions: Record<ConditionKey, boolean> (stub — expanded in Phase 20)
 ```
 
@@ -214,9 +338,9 @@ Start tracking `system.migration.version` on actors from this phase onward. Even
 ## Completion Checklist
 
 ### ✅ Complete
-- (None — Phase 5 has not started)
+- (None — Phase 6 has not started)
 
-### ❌ Not Started (All Tasks for Phase 5)
+### ❌ Not Started (All Tasks for Phase 6)
 
 **Foundry v14 Integration:**
 - [ ] Use `persisted: false` for ALL derived stat fields: ability mods, AC totals, save totals, init total, BAB total, HP max, speed totals, encumbrance thresholds, level, race string
@@ -230,22 +354,27 @@ Start tracking `system.migration.version` on actors from this phase onward. Even
 - [ ] Test: `isOfType("character")` correctly narrows TypeScript type
 - [ ] Test: Derived `persisted: false` fields reset every prep cycle and are NOT saved to DB
 
-**Actor Data Model & Schema Structure:**
-- [ ] Create `src/entities/actor/ActorSystemModel.mts` extending DataModel
-- [ ] Implement abilities section: str, dex, con, int, wis, cha each with base + derived mod
-- [ ] Implement attributes.hp: base, max (derived), value, temp, nonlethal fields
-- [ ] Implement attributes.bab: total field (derived, computed from BAB formula)
-- [ ] Implement attributes.ac: normal, touch, flatFooted (all derived from DEX + 10 + size)
-- [ ] Implement attributes.saves: fort, ref, will each with base + total (derived) + ability key
-- [ ] Implement attributes.speed: land, climb, swim, burrow, fly each with base + total (derived)
-- [ ] Implement attributes.init: bonus + total (derived from DEX mod + bonus)
-- [ ] Implement attributes.sr and attributes.dr[]  array
-- [ ] Implement details: level (derived from class items), xp (value/max), alignment, race, size (SizeCategory enum)
-- [ ] Implement skills as empty Record<string, SkillData> stub for Phase 14 expansion
-- [ ] Implement currency: pp, gp, sp, cp fields
-- [ ] Implement encumbrance: current (derived), light/medium/heavy (derived), carry/drag (derived)
-- [ ] Implement conditions as empty Record<string, boolean> stub for Phase 20 expansion
-- [ ] Add `system.migration.version` field with initial value matching current dnd35e version
+**Actor Data Model & Schema Structure (Group G hierarchy — build all layers now):**
+- [ ] Create `src/documents/actors/baseActor/data/ActorSystemModelBase.mts` — universal base (`ActorSystemModelBase`): speed fields (land/climb/swim/burrow/fly each with base + total `persisted:false`), biography, notes
+- [ ] Create `src/documents/actors/baseActor/data/CreatureSystemModel.mts` — `CreatureSystemModel extends ActorSystemModelBase`: all creature-shared stats
+  - [ ] Abilities: str, dex, con, int, wis, cha each with `base: number` + `mod: number (persisted:false)`
+  - [ ] Attributes.hp: `base, max (persisted:false), value, temp, nonlethal`
+  - [ ] Attributes.bab: `total (persisted:false, derived as 0; Classes phase fills progression)`
+  - [ ] Attributes.ac: `normal, touch, flatFooted` all `persisted:false` — start at `10 + DEX mod + size`
+  - [ ] Attributes.saves: fort, ref, will each with `base + total (persisted:false) + ability: AbilityKey`
+  - [ ] Attributes.init: `bonus + total (persisted:false)`
+  - [ ] Attributes.sr: number; attributes.dr: DamageReduction[] array
+  - [ ] `currency: CurrencyField` at schema root (world-settings currencies; coin weight → encumbrance)
+  - [ ] Encumbrance: `carriedWeight (pf), light/medium/heavy/carry/drag thresholds (pf), carryBonus, carryMultiplier`
+- [ ] Create `src/documents/actors/character/data/CharacterSystemModel.mts` — `CharacterSystemModel extends CreatureSystemModel`: character-only fields
+  - [ ] Details: `level (persisted:false)`, `xp: {value, max}`, `alignment`, `race (persisted:false)`, `size: SizeCategory`
+  - [ ] `isPartyMember: boolean`
+  - [ ] Conditions as empty `Record<string, boolean>` stub (Phase 20 expands)
+  - [ ] `system.migration.version` field with initial value matching current dnd35e version
+- [ ] Create `src/documents/actors/npc/data/NpcSystemModel.mts` — `NpcSystemModel extends CreatureSystemModel`: **stub only** (Phase 23 adds cr, type/subtype, environment, treasure, advancement)
+- [ ] Create `src/documents/actors/object/data/ObjectSystemModel.mts` — `ObjectSystemModel extends ActorSystemModelBase`: **stub only** (Phase 23 adds HP(object), hardness, breakDC)
+- [ ] Create `src/documents/actors/trap/data/TrapSystemModel.mts` — `TrapSystemModel extends ObjectSystemModel`: **stub only** (Phase 23 adds findDC, disarmDC)
+- _(Skills are deferred to the dedicated Skills phase after Classes — see Group A for rationale.)_
 - [ ] Ensure all NumberFields use proper Foundry validation (min: 0 where applicable)
 
 **Derived Data Preparation Pipeline:**
@@ -282,7 +411,7 @@ Start tracking `system.migration.version` on actors from this phase onward. Even
 - [ ] Separate all changes into two groups: `penalty` bonus type vs all others
 - [ ] Call `resolveActiveEffectChanges(bonuses, penalties)` to get resolved values + history
 - [ ] Store resolved values back into `this.system` using setProperty for each field
-- [ ] Enrich `this.overrides` with stacking metadata (`bonusType`, `stackResult`, `stackReason`) — same pattern as Phase 2 ItemDnd35e
+- [ ] Enrich `this.overrides` with stacking metadata (`bonusType`, `stackResult`, `stackReason`) per the `Override` interface in `src/helpers/stacking.mts` — same pattern as Phase 2 ItemDnd35e
 - [ ] Test: Buff AE with +2 bonus applies and shows in resolved value
 - [ ] Test: Penalty AE is tracked separately and rejected if higher bonus wins
 - [ ] Test: Stacking history in overrides contains all applied/ignored changes with reasons
@@ -328,7 +457,6 @@ Start tracking `system.migration.version` on actors from this phase onward. Even
 - [ ] Add i18n keys for all ability names: dnd35e.abilities.str, .dex, .con, .int, .wis, .cha
 - [ ] Add i18n keys for all attribute names: dnd35e.attributes.hp, .ac, .init, .bab
 - [ ] Add i18n keys for save names: dnd35e.saves.fort, .ref, .will
-- [ ] Add i18n keys for skill names (empty for now, Phase 14 fills in)
 - [ ] Add i18n keys for actor sheet tabs
 - [ ] Add i18n keys for inventory grouping labels
 - [ ] Update en.json in src/lang/ with all new keys
@@ -362,15 +490,15 @@ This phase integrates active effect changes into actor preparation, using the **
 Actors can have active effects that modify their stats (e.g., a buff that grants +2 to Strength checks). These effects generate `Dnd35eEffectChangeData` changes just like Material AEs on items do:
 
 ```typescript
-// src/entities/actor/ActorDnd35e.mts
+// src/documents/actors/baseActor/ActorDnd35e.mts
 override applyActiveEffects() {
-  // Import the generic stacking utility from Phase 2
-  const { resolveActiveEffectChanges } = await import('@helpers/stacking.mts');
+  // Import the generic stacking utility from helpers
+  const { resolveActiveEffectChanges } = await import('@helpers/stacking.mjs');
 
   // Collect all changes from enabled active effects
   const allChanges: Dnd35eEffectChangeData[] = [];
   for (const effect of this.effects) {
-    if (effect.data.disabled) continue;
+    if (effect.disabled) continue;
     if (effect.system.buildChanges) {
       allChanges.push(...effect.system.buildChanges());
     }
@@ -746,15 +874,22 @@ Modules extend: `DocumentEventEmitter.registerEventType('myModule.stunned', { la
 | Action | Path |
 |--------|------|
 | Create | `src/helpers/DocumentEventEmitter.mts` — `DocumentEventEmitter` class, `DocumentEvent<T>`, `DocumentEventCallback<T>` types |
-| Modify | `src/entities/components/CoreMixin/Dnd35eDocument.mts` — add `readonly events: DocumentEventEmitter` to mixin |
-| Expand | `src/entities/actors/baseActor/data/ActorSystemModelBase.mts` — add ability scores, HP, AC, saves, etc. |
-| Expand | `src/entities/actors/baseActor/data/ActorSystemData.mts` — interfaces for source + derived data |
-| Implement | `ActorDnd35e.applyActiveEffects()` — import `resolveActiveEffectChanges()` from Phase 2 stacking module; store history in `system._stackingHistory` |
-| Expand | `src/entities/actors/baseActor/ActorDnd35e.mts` — implement `prepareBaseData()`, `prepareDerivedData()`, `update()` refresh, `applyActiveEffects()` |
-| Create | `src/vue/apps/actor/CharacterSheet.vue` — main character sheet |
-| Create | `src/vue/apps/actor/CharacterSheetApp.mts` — Vue app wrapper |
-| Create | `src/vue/components/actor/` — AbilityScores, Inventory, EquipmentSlots components |
-| Modify | `src/entities/actors/registration.mts` — register character sheet |
-| Create | `src/constants/abilities.mts` — ability score constants |
+| Modify | `src/documents/document/DocumentDnd35e.mts` — add `readonly events: DocumentEventEmitter` to mixin |
+| Create | `src/documents/actors/baseActor/data/ActorSystemModelBase.mts` — `ActorSystemModelBase`: speed, biography/notes |
+| Create | `src/documents/actors/baseActor/data/CreatureSystemModel.mts` — `CreatureSystemModel extends ActorSystemModelBase`: abilities, HP, AC, saves, BAB, init, senses, encumbrance, currency |
+| Create | `src/documents/actors/character/data/CharacterSystemModel.mts` — `CharacterSystemModel extends CreatureSystemModel`: xp, description fields, isPartyMember |
+| Create | `src/documents/actors/npc/data/NpcSystemModel.mts` — `NpcSystemModel extends CreatureSystemModel`: stub only (Phase 23) |
+| Create | `src/documents/actors/object/data/ObjectSystemModel.mts` — `ObjectSystemModel extends ActorSystemModelBase`: stub only (Phase 23) |
+| Create | `src/documents/actors/trap/data/TrapSystemModel.mts` — `TrapSystemModel extends ObjectSystemModel`: stub only (Phase 23) |
+| Expand | `src/documents/actors/baseActor/data/ActorSystemData.mts` — interfaces for source + derived data |
+| Expand | `src/documents/actors/baseActor/ActorDnd35e.mts` — implement `prepareBaseData()`, `prepareDerivedData()`, `update()` refresh, `applyActiveEffects()` with stacking engine |
+| Modify | `src/helpers/stacking.mts` — extract `applyStackedChanges()` helper (if not already done in Phase 2) for shared use by items and actors |
+| Create | `src/vue/apps/VueActorSheet.mts` — abstract actor sheet base, mirrors `VueItemSheet.mts`; extends `useVueDocumentSheetMixin(ActorSheetBase)` |
+| Widen | `src/vue/apps/VueDocumentSheetMixin.mts` — widen `TDocument` generic to accept `ActorDnd35e` |
+| Create | `src/documents/actors/character/sheet/CharacterSheet.mts` — concrete character sheet class extending `VueActorSheet` |
+| Create | `src/documents/actors/character/sheet/CharacterSheet.vue` — main character sheet Vue component (tabs: Abilities, Inventory, Features, Effects, Biography) |
+| Create | `src/documents/actors/character/sheet/components/` — AbilityScores.vue, InventoryTab.vue, EquipmentSlots.vue and other tab/section components |
+| Modify | `src/documents/actors/registration.mts` — register character sheet and `CharacterSystemModel` |
+| Create | `src/constants/abilities.mts` — ability score constants (keys, labels, associated saves) |
 | Create | `src/lang/en/abilities.json`, `src/lang/en/actors.json` |
-| Test | Unit tests for actor-level stacking (buffs, penalties); validate history accuracy on combat-relevant fields |
+| Test | `tests/unit/documents/actors/` — unit tests for ability mod calculation, AC derivation, encumbrance, stacking |

--- a/docs/migration-plan/poc/phase-06-actor-foundation.md
+++ b/docs/migration-plan/poc/phase-06-actor-foundation.md
@@ -4,9 +4,9 @@
 
 > **Milestone**: POC  
 > **Dependencies**: Phase 1, Phase 3  
-> **Goal**: A character actor has ability scores, BAB, HP, flat AC, saves, speed, size, and an inventory with equipped weapon tracking. All stats are stored as formula-ready fields that Phase 8 (Action System) consumes via `#self.*` contexts.
+> **Goal**: A character actor has ability scores, BAB, HP, flat AC, saves, speed, size, and an inventory with equipped weapon tracking. All stats are stored as formula-ready fields that poc.10 (Basic Combat) and alpha.3 (Action System) consume via `#self.*` contexts.
 
-> **Action System note**: Phase 8 action formulas reference actor stats via `#self.*` contexts — e.g., `#self.abilities.str.mod`, `#self.bab`, `#self.ac.*`, `#self.saves.*`. These are **derived** fields (`persisted: false`): `str.mod` is calculated from base score, `bab` derives from class progressions (alpha.2; resolves to `0` until then), and `attributes.ac.*` is computed from DEX + size + bonuses. Base score fields are stored; derived stats are computed each prep cycle.
+> **Action System note**: poc.10 and alpha.3 action formulas reference actor stats via `#self.*` contexts — e.g., `#self.abilities.str.mod`, `#self.bab`, `#self.ac.*`, `#self.saves.*`. These are **derived** fields (`persisted: false`): `str.mod` is calculated from base score, `bab` derives from class progressions (alpha.2; resolves to `0` until then), and `attributes.ac.*` is computed from DEX + size + bonuses. Base score fields are stored; derived stats are computed each prep cycle.
 
 ---
 
@@ -33,7 +33,7 @@ The following TODO notes exist in the codebase and are tracked here for resoluti
 - [ ] **Update `actorTypes.mts` placeholder** (`actorTypes.mts:1`): Currently only defines `'character'` with a TODO to add actual actor types. Phase 6 adds the character shell; Phase 23 adds NPC/Trap/Object. At minimum, verify the placeholder is sufficient for Phase 6's character-only scope, and add a forward reference to Phase 23 for expansion.
 - [ ] **Equipment slot 'none' sentinel cleanup** (`equipmentSlots.mts:20`): The `'none'` option in `EQUIP_SLOT_SELECT_OPTIONS` is flagged as redundant for multiselect. When this phase implements equipment slot UI and validation, resolve whether `equippedSlotIds` should become a single-select nullable field (replace `'none'` with `value: null`) or remain multiselect (remove the `'none'` option entirely).
 - [ ] **Container dropdown in PhysicalItemStore** (`PhysicalItemStore.mts:64`): `possibleContainers` computed returns only `[None]` with a TODO to build out after implementing containers. Wire this to query the parent actor's items for container-type items once the container model (§C2) is implemented.
-- [ ] **FormulaFamiliar derived field support**: FormulaFamiliar's schema walker builds autocomplete from static `DataModel` schema definitions. Verify that `persisted: false` fields (ability mods, BAB, AC totals, save totals) are included in walker output — they are declared in `defineSchema()` but their runtime values only exist after `prepareDerivedData()` runs. If the walker skips them, either extend the walker to include runtime-derived fields or ensure `_buildFormulaContexts()` registers them separately as formula-visible properties. **Must be resolved before Phase 8 ships formula authoring UI.**
+- [ ] **FormulaFamiliar derived field support**: FormulaFamiliar's schema walker builds autocomplete from static `DataModel` schema definitions. Verify that `persisted: false` fields (ability mods, BAB, AC totals, save totals) are included in walker output — they are declared in `defineSchema()` but their runtime values only exist after `prepareDerivedData()` runs. If the walker skips them, either extend the walker to include runtime-derived fields or ensure `_buildFormulaContexts()` registers them separately as formula-visible properties. **Must be resolved before alpha.3 ships formula authoring UI** (poc.10 attack formulas also depend on this).
 
 ---
 
@@ -259,12 +259,12 @@ Override `update()` on `ActorDnd35e` to refresh the active Pinia store after Fou
 - [ ] Call `applyActiveEffects()` during `prepareDerivedData()` prep cycle
 - [ ] Test: Prep cycle completes without errors for fresh actor
 
-**Formula-Ready Field Preparation for Phase 8:**
+**Formula-Ready Field Preparation for poc.10 / alpha.3:**
 - [ ] Call `_buildFormulaContexts()` (from Dnd35eDocumentMixin) in `prepareDerivedData()` to populate `#self.*` contexts
 - [ ] Verify RollData includes: abilities, ability modifiers, bab, ac variants, saves, speed, size, initiative, hp
 - [ ] Ensure `getRollData()` returns POJO with all formula-ready paths (e.g., `abilities.str.mod`, `bab`, `ac.normal`)
 - [ ] Register formula contexts in Pinia store for IDE autocomplete hints
-- [ ] Document all formula paths available via `#self.*` that Phase 8 actions will consume
+- [ ] Document all formula paths available via `#self.*` that poc.10 and alpha.3 actions will consume
 - [ ] Test: `getRollData()` returns complete object with no undefined fields
 
 **Active Effect Integration (Stacking Engine):**

--- a/docs/migration-plan/poc/phase-06-actor-foundation.md
+++ b/docs/migration-plan/poc/phase-06-actor-foundation.md
@@ -1,12 +1,12 @@
-# POC Phase 6: Actor Foundation
+﻿# POC Phase 6: Actor Foundation
 
-**Status**: � Planned (Actor schema, multiclass stacking, ability scores)
+**Status**: ✅ Approved (Actor schema, multiclass stacking, ability scores)
 
 > **Milestone**: POC  
 > **Dependencies**: Phase 1, Phase 3  
 > **Goal**: A character actor has ability scores, BAB, HP, flat AC, saves, speed, size, and an inventory with equipped weapon tracking. All stats are stored as formula-ready fields that Phase 8 (Action System) consumes via `#self.*` contexts.
 
-> **Action System note**: BAB is stored on the actor even before classes compute it (Phase 12). The Actor schema defines the fields that become `#self.abilities.str.mod`, `#self.bab`, `#self.attributes.ac.*`, `#self.saves.*` — all referenced by action formulas.
+> **Action System note**: Phase 8 action formulas reference actor stats via `#self.*` contexts — e.g., `#self.abilities.str.mod`, `#self.bab`, `#self.ac.*`, `#self.saves.*`. These are **derived** fields (`persisted: false`): `str.mod` is calculated from base score, `bab` derives from class progressions (alpha.2; resolves to `0` until then), and `attributes.ac.*` is computed from DEX + size + bonuses. Base score fields are stored; derived stats are computed each prep cycle.
 
 ---
 
@@ -14,123 +14,17 @@
 
 Questions organized into groups for serial resolution. As each group is resolved, its items move to the relevant detail section and the group is marked ✅.
 
-### Group A: Deferred Property Philosophy ✅
-
-> **Architecture Decision: Shell-Now, Derive-Later**
->
-> The actor schema includes the *shell* for every field that has a reasonable default or a partial derivation available now. Properties get full derivation logic when the phase that provides the source data arrives. This differs from the strict "no property until consumer exists" rule used for items — actors benefit from having their stat block visible on the character sheet even before classes/races/etc. fill in the computed parts.
->
-> **Examples**: AC exists now as `10 + DEX mod`. When Equipment arrives, armor/shield bonuses layer in. When Races arrive, size modifiers layer in. The field was always there — only its derivation grows.
-
-**Resolved decisions:**
-
-- [x] **Level**: Placeholder derived property, hardcoded to `1`. Classes phase replaces with real derivation from class item HD. Needed because HP max formula uses level.
-- [x] **Size**: Default `medium` on model. Races modify it (likely through an active effect). Carrying capacity and AC size modifiers use this field and work correctly at medium defaults.
-- [x] **Race (string)**: Deferred until Races phase. Not on the model.
-- [x] **BAB**: Field exists, derived as `0`. Classes phase fills in progression. Phase 8 can reference `#self.bab` — it just reads 0 until classes exist.
-- [x] **Saves**: Shell fields exist: `fort = CON mod + base(0)`, `ref = DEX mod + base(0)`, `will = WIS mod + base(0)`. Class base progression added in Classes phase.
-- [x] **AC**: `normal = 10 + DEX mod`, `touch = 10 + DEX mod`, `flatFooted = 10`. Armor/shield (Equipment), size (Races), dodge/deflect etc. layer in later.
-- [x] **Init**: `total = DEX mod + bonus(0)`. Improved Initiative feat etc. add to bonus later.
-- [x] **Speed**: Default `land.base = 30, total = 30`. Races modify base (possibly via AE). Armor/encumbrance modify total later.
-- [x] **HP max**: Derived as `placeholder_level(1) × HD + CON mod`. Classes replace this with sum of actual class HD rolls.
-- [x] **Alignment, description fields**: In Phase 5. biography, notes, height, weight, gender, deity, age, XP — these are character sheet display properties with no external consumer dependency.
-- [x] **DR / SR**: Fields exist on model but empty/0. Populated by race/class/item effects when those arrive.
-- [x] **Encumbrance**: Derived from STR + inventory weight, assumes Medium size multiplier. Races adjust multiplier.
-- [x] **Skills**: **Not on model** until the dedicated Skills phase (after Classes). Skill totals derive from `ranks + ability mod + misc - ACP`; ranks are awarded from class levels and can't be meaningfully stored without the Classes system. No stub, no empty record. Phase 8 handles "roll a skill check" as a simple `d20 + ability mod` actor action without needing schema fields.
-- [x] **Conditions**: **Not on model** until Conditions phase. The Effects tab shows Active Effects (which already work). Condition toggle UI added when Conditions phase arrives.
-- [x] **Formula familiar**: Each phase registers its own `#self.*` fields when it adds properties. Phase 5 registers abilities, HP, AC, saves, init, BAB, speed. Later phases add their fields.
-
-### Group B: Actor PropertyMap ✅
-
-**Resolved**: Full PropertyMap created at `docs/architecture/property-maps/PropertyMap-Actors.md`.
-
-- [x] **Location**: `docs/architecture/property-maps/PropertyMap-Actors.md`
-- [x] **Format**: Hybrid — mermaid ER for inheritance hierarchy, grouped field tables per model with Phase/Stored-Derived/D35E-Source columns
-- [x] **Scope**: All 5 types mapped: Character, NPC (covers monsters), Object, Trap + future Vehicle/IntelligentItem notes. Companions are **not a separate type** — Bond AE on any actor (Character or NPC) handles the relationship.
-- [x] **Composition**: Inheritance-first architecture:
-  - `ActorSystemModelBase` → speed, biography/notes (truly universal)
-  - `CreatureSystemModel extends ActorSystemModelBase` → abilities, HP(creature), AC, saves, BAB, init, combat, senses, encumbrance, currency, equipment
-  - `CharacterSystemModel extends CreatureSystemModel` → xp, description fields, isPartyMember
-  - `NpcSystemModel extends CreatureSystemModel` → cr, creature type/subtype, environment, treasure, advancement (covers all monsters)
-  - `ObjectSystemModel extends ActorSystemModelBase` → HP(object), hardness, breakDC
-  - `TrapSystemModel extends ObjectSystemModel` → adds action/trigger capability (design deferred)
-
-**Key decisions documented in PropertyMap**:
-- NPC = Monster (same type, different sheet presentation)
-- `bond` replaces `master` (familiar, animalCompanion, mount, summon, cohort, commanded)
-- Racial HD handled as pseudo-class in Races/Classes phases
-- Spellbooks are NOT common — added per class by class items
-- Identifiable needs system-wide redesign → Secret AE phase (flagged, not solved here)
-
-### Group C: Inventory System ❓
-
-#### C1: Item States
-- [x] **Three-state model**: Stored (not on person) → Carried (on person) → Equipped (subset of carried). Items in containers inherit their container's state.
-- [x] **Existing flags**: `isCarried` exists on `PhysicalItemSystemModel`, `isEquipped` exists on `EquippableItemSystemModel`. These are the right home — no new flags needed on the actor.
-- [x] **"Stored" semantics resolved**: `isCarried = false` means stored. Stored items remain **owned by the actor** (tracked in their inventory) but do **not** contribute to encumbrance weight. They appear in the inventory tab in a visually distinct "Stored" section below carried items. Use case: "I left my camping gear at the inn." A stored item can be un-stored (toggle `isCarried = true`) at any time.
+### Group C: Inventory System ✅
 
 #### C2: Containers
 - [x] **Container model**: Uses `containerId` reference pattern (dnd5e canonical). All items are flat siblings in `actor.items`. Contained items store `containerId` pointing to parent container's ID. Container items compute `contents` by filtering siblings.
 - [x] **Weight interaction**: **Container AE Propagation** — containers emit a special AE to each contained item. Bag of holding AE sets weightlessness on contained items (no manual weight calc logic). Non-extradimensional containers: container weight + sum of contents weights.
-- [ ] **Nesting**: Can containers contain containers? (Bag inside a backpack?) — needs rules decision
-- [ ] **UI**: How do containers display in the inventory tab? Expandable tree? Flat list with parent indicator?
-
-#### C3: Weapon Slots ✅
-
-**Resolved decisions:**
-
-- [x] **Slot definitions**: `mainhand` and `offhand` as sentinel slot IDs in `equipmentSlots.mts`. Natural attack slots deferred to Natural Attacks phase.
-- [x] **Two-handing**: Deferred to **end of Phase 6** with a community feedback round mid-phase once screenshots of the mainhand/offhand UI exist. We want players to react to what they see before locking in the three-slot design (mainhand / offhand / two-hand).
-  - For Phase 6: no two-hand slot. A two-handed weapon equips to mainhand. The offhand is not locked. Action System (Phase 8) reads `isTwoHanded` flag at roll time and handles the penalty/off-hand-disable logic there.
-  - Community feedback question: "Is a distinct two-hand slot better UX than the mainhand+offhand model? Does a third slot that disables both others feel right?"
-- [x] **Dual wield**: Two weapons, one per hand — works naturally with mainhand + offhand. Two-weapon fighting penalties live in the Action System (Phase 8).
-- [x] **Where weapon slots live**: Extend `equipmentSlots.mts` with `mainhand` and `offhand` sentinel constants.
-
-#### C4: Currency & Vaults ✅
-
-**Resolved decisions:**
-
-- [x] **Vault concept**: Every container can hold currency. A vault is any container with a `containedValue: CurrencyField` — same field type as an item's `price`, just representing currency *held inside* rather than the item's sale value.
-- [x] **CurrencyField for all currency**: Uses `CurrencyField` directly — same as item prices. No bespoke `Record<currencyId, number>` structure. World-settings currencies supported from day one. Renamed from `PriceField` in the Phase 6 pre-story refactor.
-- [x] **One built-in currency field**: Characters have exactly ONE schema currency field:
-  - `currency: CurrencyField` — currency on person (pockets, coin purse). At root of schema — no nesting. Contributes to encumbrance via coin weights from world settings. Future vault container items (Beta Phase 1+) will each carry their own `CurrencyField` but are separate items, not schema fields.
-- [x] **Global "ignore currency weight" world setting**: A single setting that removes all currency from encumbrance calculations system-wide. No per-vault toggles. Default: off (currency weighs something).
-- [x] **Future vaults (Beta Phase 1+)**: Named currency-only container items on the character sheet. No item weight-capacity limit. Each can be toggled weightless. Examples: "Town Bank", "Hideout Stash", "Merchant Account". These are container items (depend on poc.6 + poc.7 → beta.1) — deferred.
-- [x] **Debt tracking**: Post-release wishlist. Vaults with negative currency counts to represent debts owed.
-- [x] **D35E fields removed**:
-  - `currency.pp/gp/sp/cp` → `currency: CurrencyField` (flat root field, no nesting)
-  - `altCurrency` → Future named vault container items (Beta Phase 1)
-  - `customCurrency` → World-settings currency configuration (`CurrencyData.getCurrencyConfig()`)
+- [x] **Nesting**: `containerId` supports nesting at schema level. Phase 6 does not implement recursive container weight or nested-container UI. Full nested container support (bag-in-backpack with recursive weight) deferred to **beta.1** (Equipment & Loot).
+- [x] **UI**: Inventory tab uses a flat list. Contained items are grouped under their container's row with visual indentation — the container item acts as a section header for its contents.
 
 #### C5: Item Lifecycle
-- [ ] **Drag-and-drop from compendium**: Foundry creates owned item copy. Confirm this works out-of-the-box or needs custom handling.
-- [ ] **Item deletion**: Remove from actor. Any cleanup needed (unequip, remove from container)?
-
-### Group D: Character Sheet UX ✅
-
-**Resolved decisions:**
-
-- [x] **Tab navigation style**: **Vertical sidebar** (like dnd5e's AppV2 side tab bar). Preferred over D35E horizontal top bar — better UX and visual hierarchy. Community feedback round planned mid-phase.
-- [x] **Phase 6 tabs**: `Abilities | Inventory | Features | Effects | Biography`
-  - D35E has 12 tabs — we scope-cut aggressively and add tabs only when their data lands.
-- [x] **Skills tab**: Hidden/absent until the full Skills phase (after Classes). No stub.
-- [x] **Combat tab**: Absent until Phase 8 (Action System). No stub.
-- [x] **Conditions in Effects tab**: Show AE list now; condition toggles added when Conditions phase arrives.
-- [x] **Inventory tab detail**: Grouped by type (Weapons, Equipment, Consumables, Loot). Equip toggles, weight/price columns, total weight display. `isCarried` grouping distinguishes stored vs. carried items visually. Slot selection is basic until Beta Phase 1 (Equipment) refines it.
-- [x] **Header bar**: Name, portrait. Level/race/alignment deferred per Group A decisions.
-- [x] **D35E reference**: Run `@Explore` subagent against the D35E system source to map their sheet layout and UX patterns. Use as visual reference during implementation. Do NOT copy directly — bring it up to modern standards with our styles.
-
-### Group E: Active Effect & Store Integration ✅
-
-**Resolved decisions:**
-
-- [x] **AE processing update**: Confirmed — fully replace the base application loop with collect → resolve → apply winners pattern (same as `ItemDnd35e`). Extract shared logic into `applyStackedChanges()` helper in `src/helpers/stacking.mts`.
-- [x] **Stale references**: Update §5.8 and checklist to use `overrides` with `bonusType`, `stackResult`, `stackReason` metadata (not `system._stackingHistory`).
-- [x] **VueDocumentSheetMixin**: Widen `TDocument` generic to accept `ActorDnd35e`. Small change — widen the union type constraint.
-- [x] **VueActorSheet**: Create `src/vue/apps/VueActorSheet.mts` mirroring `VueItemSheet.mts` but extending `useVueDocumentSheetMixin(ActorSheetBase)` where `ActorSheetBase = foundry.applications.sheets.ActorSheetV2<ActorDnd35e, ...>`.
-- [x] **Actor Pinia store**: Create actor-specific store following the exact same pattern as `DocumentSheetStore` (item/AE pattern). One store file per major store concern — mirrors item and AE implementation.
-- [x] **Actor config registration**: Register character class in `src/constants/config/actor.mts` `documentClasses`.
-- [x] **Formula familiar expansion**: Expand `registration.mts` with ability scores, attributes, etc. for `#self.*` contexts when schema is defined.
+- [x] **Drag-and-drop from compendium**: Foundry handles via `ActorSheet._onDropItem()` — creates an owned copy automatically. Override only to apply container assignment (if dropped onto a container item row) and fire the `created` lifecycle event (Phase 5 infrastructure).
+- [x] **Item deletion**: Call `item.delete()`. No manual cleanup needed — equipped state is derived from the item list, so deleting the item removes it from derivation automatically. Foundry's `_onDeleteEmbeddedDocuments` hook handles re-render.
 
 ### Codebase TODO Notes (Landing Here)
 
@@ -139,38 +33,7 @@ The following TODO notes exist in the codebase and are tracked here for resoluti
 - [ ] **Update `actorTypes.mts` placeholder** (`actorTypes.mts:1`): Currently only defines `'character'` with a TODO to add actual actor types. Phase 6 adds the character shell; Phase 23 adds NPC/Trap/Object. At minimum, verify the placeholder is sufficient for Phase 6's character-only scope, and add a forward reference to Phase 23 for expansion.
 - [ ] **Equipment slot 'none' sentinel cleanup** (`equipmentSlots.mts:20`): The `'none'` option in `EQUIP_SLOT_SELECT_OPTIONS` is flagged as redundant for multiselect. When this phase implements equipment slot UI and validation, resolve whether `equippedSlotIds` should become a single-select nullable field (replace `'none'` with `value: null`) or remain multiselect (remove the `'none'` option entirely).
 - [ ] **Container dropdown in PhysicalItemStore** (`PhysicalItemStore.mts:64`): `possibleContainers` computed returns only `[None]` with a TODO to build out after implementing containers. Wire this to query the parent actor's items for container-type items once the container model (§C2) is implemented.
-
-### Group G: Actor Type Hierarchy ✅
-
-**Resolved decisions:**
-
-- [x] **Schema hierarchy confirmed — build all layers now**: Three DataModel base layers + stubs for unregistered types. Only `CharacterSystemModel` is registered in Phase 6.
-  - `ActorSystemModelBase` → speed, biography/notes (universal)
-  - `CreatureSystemModel extends ActorSystemModelBase` → abilities, HP, AC, saves, BAB, init, senses, encumbrance, currency, equipment (shared by Character + NPC)
-  - `CharacterSystemModel extends CreatureSystemModel` → xp, description fields (height/weight/gender/deity/age/alignment), isPartyMember
-  - `NpcSystemModel extends CreatureSystemModel` → cr, creature type/subtype, environment, treasure, advancement — **stub only**, Phase 23
-  - `ObjectSystemModel extends ActorSystemModelBase` → HP(object), hardness, breakDC — **stub only**, Phase 23
-  - `TrapSystemModel extends ObjectSystemModel` → action/trigger capability deferred to trap design phase — **stub only**, Phase 23
-- [x] **No CompanionSystemModel**: Companions (familiars, animal companions, mounts, summons, cohorts, commanded creatures) are regular Character or NPC actors linked to their master via the Bond AE. No dedicated actor type. No `bond` field on any schema in Phase 6. Bond relationship design deferred to the phase that implements it.
-- [x] **TrapSystemModel extends ObjectSystemModel**: Traps are objects with actions. They share HP, hardness, and breakDC with objects. The `findDC` and `disarmDC` trap-specific fields are added on top. Future: a trap actor may reference the physical item it represents (e.g., a pressure plate in the actor's inventory) to drive its stats — see WISHLIST.
-- [x] **NPC = Monster confirmed**: SRD analysis — no mechanical distinction. One `NpcSystemModel` covers all non-player creatures. Sheet presentation may differ; data model is shared. Phase 23 scope.
-- [x] **Actor sheets get full view-mode treatment**: `VueActorSheet` uses `VueDocumentSheetMixin`, so edit/play/true modes, field visibility overrides, editability overrides, and FieldControls all work identically to item sheets. GMs can mark any actor field as GM-only or hidden. Secret AEs on actors work. Nothing actor-specific needed — it's all in the mixin.
-
----
-
-### Group F: Phase Structure ✅
-
-**Resolved decisions:**
-
-- [x] **Skills split into two scopes**:
-  - **Phase 8 (Action System)**: Basic skill check as an example of an *actor-owned action*. d20 + ability mod → chat card. No ranks, no class skills, just an ability check with skill flavor. Proves that actions can live on actors, not just items.
-  - **New phase after Phase 12 (Classes)**: Full skill system — ranks, class skills, skill points per level, trained-only, ACP, synergies, custom skills. This phase depends heavily on class data.
-- [x] **No skills on the actor model in Phase 6**: No `skills` property at all. The basic skill check in Phase 8 reads ability mods directly. The full Skills phase adds the schema.
-- [x] **INSERT, don't take over**: The full Skills phase is inserted after Classes. Does not replace Phase 14 (Testing & POC Validation). Exact numbering deferred until we do the README update.
-- [x] **POC exit criteria**: Will revisit — tentatively includes "a character can roll a skill check" via the Phase 8 actor-action example.
-- [x] **Current spec cleanup**: Remove "skills stub — expanded in Phase 14" references from §5.1 and completion checklist. (Phase 14 is Testing, not Skills.)
-
----
+- [ ] **FormulaFamiliar derived field support**: FormulaFamiliar's schema walker builds autocomplete from static `DataModel` schema definitions. Verify that `persisted: false` fields (ability mods, BAB, AC totals, save totals) are included in walker output — they are declared in `defineSchema()` but their runtime values only exist after `prepareDerivedData()` runs. If the walker skips them, either extend the walker to include runtime-derived fields or ensure `_buildFormulaContexts()` registers them separately as formula-visible properties. **Must be resolved before Phase 8 ships formula authoring UI.**
 
 ---
 
@@ -187,7 +50,13 @@ Phase 6 is delivered in **4 stories**. Each story ends with a working, user-test
 - **Keep "Price" in item-specific components**: `ItemPriceFormGroup.vue`, `ItemPrice.vue`, `ItemResalePrice.vue` — these are contextually correct (they display an item's price).
 - **Keep "price" as the schema field name on items**: `price: new CurrencyField()` — field name is still `price`, only the class name changes.
 
-This is a single commit, pure rename, no behavior change.
+This pre-story PR contains **3 commits**:
+
+1. **CurrencyField rename** — pure rename, no behavior change.
+2. **`persisted: false` audit** — audit all existing system models (poc.1–poc.2: `PhysicalItemSystemModel`, `EquippableItemSystemModel`, `WeaponSystemModel`, `GeneralSystemModel`, and any mixins with schema declarations) for fields that are derived/computed but currently declared as stored fields. Reclassify them as `{ persisted: false }` with an appropriate `initial` value. Actor-only derived fields (`str.mod`, `bab`, AC totals, etc.) are new and handled in Story 1 — this commit covers the existing item and AE side models only.
+3. **Pack source items** — identify and author items needed for Phase 6 testing, commit the resulting `packs/_source` JSON. Since item creation is a manual process done in the Foundry UI (export → JSON), decide what's needed here so the items exist before Stories 3+ need them.
+
+**Pack content identification** (for commit 3): Before authoring anything, list required items and which pack they belong to. Examples: a longsword for inventory/equip testing, a suit of leather armor for AC testing, a basic consumable for the Consumables group. Add that list here before beginning commit 3.
 ```
 Story 1
   └─► Story 2  ──► Story 4
@@ -206,7 +75,7 @@ Stories 2 and 3 are independent of each other and can be worked in parallel afte
 
 **Commits:**
 1. **Schema hierarchy + registration** — `ActorSystemModelBase`, `CreatureSystemModel`, `CharacterSystemModel` (full), `NpcSystemModel` / `ObjectSystemModel` / `TrapSystemModel` (stubs). Register `CharacterSystemModel` in `registration.mts`. *(Unit tests: schema instantiates with defaults, `persisted:false` fields reset on prep cycle)*
-2. **DocumentEventEmitter** — `DocumentEventEmitter` class, typed payload interfaces, well-known event registry wired into `DocumentDnd35e`. *(Unit tests: on/off/once/emit/clear; failing callback doesn't block others)*
+2. **Domain event wiring** — `DocumentEventEmitter` and `events` on all documents are already implemented (Phase 5). This commit: add `wellKnownEvents` static registry + `registerEventType()`; define typed payload interfaces for all domain events (`TakeDamagePayload`, `DeathPayload`, `DyingPayload`, etc.). *(Unit tests: on/off/once/emit/clear; failing callback doesn't block others)*
 3. **VueActorSheet + sheet scaffolding** — `VueActorSheet.mts` base class, `CharacterSheet.mts` + `CharacterSheet.vue` with tab bar (Abilities | Inventory | Features | Effects | Biography), widen `VueDocumentSheetMixin` generic to accept `ActorDnd35e`. *(Unit tests: sheet mounts without errors)*
 4. **Abilities tab** — 6 `NumberFormGroup`s (editable base score), derived modifier display (read-only). All labels via i18n. `abilities.json` + `actors.json`. *(Unit tests: mod formula edge cases — score 1 → −5, score 20 → +5)*
 5. **Biography tab** — Rich-text editor or plain textarea for biography/notes fields.
@@ -223,10 +92,10 @@ Stories 2 and 3 are independent of each other and can be worked in parallel afte
 
 **Commits:**
 1. **Derived data pipeline** — `prepareBaseData()` + `prepareDerivedData()`: ability modifiers, AC (normal/touch/flat-footed), saves, initiative, BAB stub (0), speed, size modifier plumbing. All `persisted:false` fields reset and recomputed each prep cycle. *(Unit tests: ability mod calc; AC at DEX 14 = 12; fort = CON mod; init = DEX mod + bonus)*
-2. **HP system + damage event cascade** — `hp.max = hp.base + CON mod`; `hp.value` editable; wire `takeDamage → dying → death` event cascade in damage-application method. *(Unit tests: `dying` fires at HP ≤ 0, `death` fires at HP ≤ −10; threshold configurable; events fire once per transition)*
-3. **Combat stats panel on sheet** — HP (editable `value` / derived `max`), AC variants, saves, initiative, BAB, speed displayed in sheet Abilities tab or a summary header section. *(Unit tests: component renders correct values)*
+2. **HP system + damage event cascade** — `hp.max` hardcoded to `100` (TODO: derive from class HD × level + CON mod in alpha.2); `hp.current` editable; wire `takeDamage → dying → death` event cascade in damage-application method. *(Unit tests: `dying` fires at HP ≤ 0, `death` fires at HP ≤ −10; threshold configurable; events fire once per transition)*
+3. **Combat stats panel on sheet** — HP (editable `current` / derived `max`), AC variants, saves, initiative, BAB, speed displayed in sheet Abilities tab or a summary header section. *(Unit tests: component renders correct values)*
 
-**E2E acceptance**: Create character with DEX 16 → AC shows `13` (10 + 3); set CON 14 → HP max increases by 2; edit `hp.value` → value persists after sheet re-open.
+**E2E acceptance**: Create character with DEX 16 → AC shows `13` (10 + 3); edit `hp.current` → value persists after sheet re-open. *(No E2E for `hp.max` until Classes phase — alpha.2)*
 
 ---
 
@@ -240,7 +109,7 @@ Stories 2 and 3 are independent of each other and can be worked in parallel afte
 1. **Inventory tab scaffold** — Inventory tab with grouped item list (Weapons / Equipment / Consumables / Loot); item rows: name, quantity, weight, price, carried/equipped state. *(Unit tests: grouping logic, stored-vs-carried display)*
 2. **Equipment slots + equip toggle** — mainhand/offhand sentinel constants in `equipmentSlots.mts`; equip/unequip toggle per item; slot collision validation. *(Unit tests: slot validation; equipping occupied slot blocked)*
 3. **Encumbrance + currency** — `carriedWeight` derived from `sum(item.weight × qty)` for `isCarried` items; thresholds from STR score; encumbrance tier display; `currency: CurrencyField` in inventory footer. *(Unit tests: carrying capacity at STR 10 = 100 lb; light/medium/heavy thresholds; stored items excluded from weight)*
-4. **Drag-drop from compendium** — item drop handler; `instantiate` event fires on item add. *(Integration tests: drop item → appears in correct group)*
+4. **Drag-drop from compendium** — override `_onDropItem()` to apply container assignment if dropped onto a container row; `created` lifecycle event fires automatically (Phase 5 infrastructure). *(Integration tests: drop item → appears in correct group)*
 
 **E2E acceptance**: Drag longsword from compendium → appears in Weapons list → equip to mainhand → equipped state shown; add items exceeding STR light load → encumbrance tier shows Medium.
 
@@ -249,7 +118,7 @@ Stories 2 and 3 are independent of each other and can be worked in parallel afte
 ### Story 4 — Active Effects Modify Stats (Stacking Engine on Actor)
 
 **User**: GM  
-**Delivers**: Effects tab shows AEs on the actor; adding a stat-modifying AE changes derived stats immediately; same bonus-type bonuses don't stack (only best applies).  
+**Delivers**: Effects tab shows AEs on the actor; adding a stat-modifying AE changes derived stats immediately; same bonus-type bonuses don't stack (only best applies).
 **Depends on**: Story 2 (stat fields must exist before AEs can modify them).
 
 **Commits:**
@@ -257,7 +126,7 @@ Stories 2 and 3 are independent of each other and can be worked in parallel afte
 2. **`ActorDnd35e.applyActiveEffects()`** — integrate stacking engine: collect changes from all enabled AEs, separate penalties, resolve, write to `system`, enrich `this.overrides` with `bonusType` / `stackResult` / `stackReason` metadata. *(Unit tests: buff applies; penalty applies; duplicate enhancement bonus rejected; overrides populated correctly)*
 3. **Effects tab** — AE list display; enable/disable toggle; stacking debug info visible in expanded view (which bonuses won/were rejected). *(Integration tests: toggle AE enabled → stat updates live)*
 
-**E2E acceptance**: Add `+2 enhancement` STR AE → STR score increases by 2; add second `+2 enhancement` STR AE → STR does NOT increase to +4 (non-stacking); disable first AE from Effects tab → STR reverts.
+**E2E acceptance**: Add `+2 enhancement` STR AE → STR score increases by 2; add second `+2 enhancement` STR AE → STR does NOT increase to +4 (non-stacking); disable first AE from Effects tab → STR reverts; equip item with an AE change targeting `system.abilities.str.base` → actor STR reflects the item's AE (passthrough from item AE to actor stat).
 
 ---
 
@@ -268,26 +137,25 @@ Bring over the core character data from D35E's `template.json` actor template, b
 ```
 ActorSystemModel (character)
 ├── abilities: { str, dex, con, int, wis, cha }
-│   Each: { base: number, mod: number (persisted: false, derived) }
+│   Each: { base: number, mod: number (p:f) }
 │   (damage/drain/penalty added in Phase 20)
-├── attributes
-│   ├── hp: { base, max (persisted: false, derived), value, temp, nonlethal }
-│   ├── bab: { total (persisted: false, derived) }
-│   ├── ac: { normal (p:f), touch (p:f), flatFooted (p:f) } (all derived, start with DEX+10)
-│   ├── saves: { fort, ref, will } each: { base, total (p:f, derived), ability: AbilityKey }
-│   ├── speed: { land, climb, swim, burrow, fly } each: { base, total (p:f, derived) }
-│   ├── init: { bonus, total (p:f, derived) }
-│   ├── sr: number
-│   └── dr: DamageReduction[]
-├── details
-│   ├── level (persisted: false, derived from class items)
-│   ├── xp: { value, max }
-│   ├── alignment: [MoralAxis|null, ChaosAxis|null]
-│   ├── race: string (persisted: false, derived from race item)
-│   └── size: SizeCategory
+├── hp: { base, max (p:f), current, temp, nonlethal }
+├── bab: { total (p:f) }
+├── ac: { normal (p:f), touch (p:f), flatFooted (p:f) }  — start: 10 + DEX mod + size
+├── saves: { fort, ref, will }
+│   Each: { base, total (p:f), ability: AbilityKey }
+├── speed: { land, climb, swim, burrow, fly }
+│   Each: { base, total (p:f) }
+├── init: { bonus, total (p:f) }
+├── sr: number
+├── dr: DamageReduction[]
+├── level (p:f, derived from class items)
+├── xp: { value, max }
+├── alignment: [MoralAxis|null, ChaosAxis|null]
+├── race (p:f, derived from race item)
+├── size: SizeCategory
 ├── currency: CurrencyField             (coin weight → encumbrance; "ignore currency weight" setting disables)
-├── encumbrance: { carriedWeight (p:f), light (p:f), medium (p:f), heavy (p:f), carry (p:f), drag (p:f), level (p:f), carryBonus, carryMultiplier }
-└── conditions: Record<ConditionKey, boolean> (stub — expanded in Phase 20)
+└── encumbrance: { carriedWeight (p:f), light (p:f), medium (p:f), heavy (p:f), carry (p:f), drag (p:f), level (p:f), carryBonus, carryMultiplier }
 ```
 
 > **p:f** = `persisted: false` — initialized from `initial` value every prep cycle, AE-targetable, never saved to DB.
@@ -301,10 +169,15 @@ ActorSystemModel (character)
 
 ## 5.3 Equipment Slot System
 
-- Use the existing `equipmentSlots` constants (head, face, neck, shoulders, etc.)
-- Weapon equip: mainhand / offhand (not in slot list yet — add weapon slots)
-- Only one item per slot (except rings: left + right)
-- Equipping fires active effects (e.g., armor grants AC — implemented in Phase 11)
+Two distinct slot categories:
+
+**Armor/gear slots** (body positions): head, face, neck, shoulders, chest, abdomen, hands, waist, legs, feet, left ring, right ring — use existing `equipmentSlots` constants.
+
+**Weapon slots**: mainhand, offhand — add weapon-specific slot constants to `equipmentSlots.mts` this phase. Distinct from gear slots since weapons are managed by wielding hand, not body position.
+
+One item per slot; exception: both ring slots may each hold one ring independently. Equipping armor fires active effects (e.g., AC bonus from armor — implemented in Phase 11).
+
+> A silhouette-based visual equip UI is a nice-to-have — see WISHLIST.md.
 
 ## 5.4 Ability Score Preparation
 
@@ -331,10 +204,6 @@ ActorSystemModel (character)
 
 Override `update()` on `ActorDnd35e` to refresh the active Pinia store after Foundry persists changes. This ensures Vue reactivity stays in sync. Establish this pattern here and carry it forward to all document types.
 
-## 5.7 Migration Version Tracking
-
-Start tracking `system.migration.version` on actors from this phase onward. Even though migration infrastructure lives in Phase 27, the version field needs to exist early so future migrations can key off it.
-
 ## Completion Checklist
 
 ### ✅ Complete
@@ -345,8 +214,8 @@ Start tracking `system.migration.version` on actors from this phase onward. Even
 **Foundry v14 Integration:**
 - [ ] Use `persisted: false` for ALL derived stat fields: ability mods, AC totals, save totals, init total, BAB total, HP max, speed totals, encumbrance thresholds, level, race string
 - [ ] Set `CONFIG.Actor.trackableAttributes` in `setup` hook:
-  - `character: { bar: ['attributes.hp'], value: ['attributes.ac.normal', 'attributes.init.total'] }`
-  - `npc: { bar: ['attributes.hp'], value: ['details.cr'] }`
+  - `character: { bar: ['hp'], value: ['ac.normal', 'init.total'] }`
+  - `npc: { bar: ['hp'], value: ['ac.normal', 'init.total', 'cr'] }`
 - [ ] Override `Actor.modifyTokenAttribute()` for temp HP, nonlethal damage, custom bar modification
 - [ ] Implement `isOfType(...types)` method on `ActorDnd35e` with TypeScript overloads for type narrowing (PF2E pattern)
 - [ ] Register `CONFIG.Actor.documentClass = ActorProxyDnd35e` in `init` hook
@@ -358,19 +227,17 @@ Start tracking `system.migration.version` on actors from this phase onward. Even
 - [ ] Create `src/documents/actors/baseActor/data/ActorSystemModelBase.mts` — universal base (`ActorSystemModelBase`): speed fields (land/climb/swim/burrow/fly each with base + total `persisted:false`), biography, notes
 - [ ] Create `src/documents/actors/baseActor/data/CreatureSystemModel.mts` — `CreatureSystemModel extends ActorSystemModelBase`: all creature-shared stats
   - [ ] Abilities: str, dex, con, int, wis, cha each with `base: number` + `mod: number (persisted:false)`
-  - [ ] Attributes.hp: `base, max (persisted:false), value, temp, nonlethal`
-  - [ ] Attributes.bab: `total (persisted:false, derived as 0; Classes phase fills progression)`
-  - [ ] Attributes.ac: `normal, touch, flatFooted` all `persisted:false` — start at `10 + DEX mod + size`
-  - [ ] Attributes.saves: fort, ref, will each with `base + total (persisted:false) + ability: AbilityKey`
-  - [ ] Attributes.init: `bonus + total (persisted:false)`
-  - [ ] Attributes.sr: number; attributes.dr: DamageReduction[] array
+  - [ ] `hp`: `base, max (persisted:false), current, temp, nonlethal`
+  - [ ] `bab`: `total (persisted:false, derived as 0; alpha.2 fills class progression)`
+  - [ ] `ac`: `normal, touch, flatFooted` all `persisted:false` — start at `10 + DEX mod + size`
+  - [ ] `saves`: fort, ref, will each with `base + total (persisted:false) + ability: AbilityKey`
+  - [ ] `init`: `bonus + total (persisted:false)`
+  - [ ] `sr`: number; `dr`: DamageReduction[] array
   - [ ] `currency: CurrencyField` at schema root (world-settings currencies; coin weight → encumbrance)
   - [ ] Encumbrance: `carriedWeight (pf), light/medium/heavy/carry/drag thresholds (pf), carryBonus, carryMultiplier`
 - [ ] Create `src/documents/actors/character/data/CharacterSystemModel.mts` — `CharacterSystemModel extends CreatureSystemModel`: character-only fields
-  - [ ] Details: `level (persisted:false)`, `xp: {value, max}`, `alignment`, `race (persisted:false)`, `size: SizeCategory`
+  - [ ] `level (persisted:false)`, `xp: {value, max}`, `alignment`, `race (persisted:false)`, `size: SizeCategory`
   - [ ] `isPartyMember: boolean`
-  - [ ] Conditions as empty `Record<string, boolean>` stub (Phase 20 expands)
-  - [ ] `system.migration.version` field with initial value matching current dnd35e version
 - [ ] Create `src/documents/actors/npc/data/NpcSystemModel.mts` — `NpcSystemModel extends CreatureSystemModel`: **stub only** (Phase 23 adds cr, type/subtype, environment, treasure, advancement)
 - [ ] Create `src/documents/actors/object/data/ObjectSystemModel.mts` — `ObjectSystemModel extends ActorSystemModelBase`: **stub only** (Phase 23 adds HP(object), hardness, breakDC)
 - [ ] Create `src/documents/actors/trap/data/TrapSystemModel.mts` — `TrapSystemModel extends ObjectSystemModel`: **stub only** (Phase 23 adds findDC, disarmDC)
@@ -381,21 +248,21 @@ Start tracking `system.migration.version` on actors from this phase onward. Even
 - [ ] Implement `prepareBaseData()`: Load ability scores, level, size from source
 - [ ] Implement ability modifier calculation: `mod = floor((ability - 10) / 2)` for all six
 - [ ] Implement AC calculation for all three variants: normal (10 + DEX), touch (10 + DEX), flatFooted (10 or less if no DEX)
-- [ ] Implement AC size modifier: add actor.system.details.size modifier to all AC variants
+- [ ] Implement AC size modifier: add `actor.system.size` modifier to all AC variants
 - [ ] Implement carrying capacity from STR score using D&D 3.5e encumbrance table
 - [ ] Implement encumbrance threshold calculation (light = 1/3 carry, medium = 2/3, heavy = carry)
 - [ ] Implement weight calculation from inventory.items sum
 - [ ] Implement carried weight encumbrance check (compare to thresholds)
 - [ ] Implement initiative total = DEX mod + bonus field
-- [ ] Implement BAB calculation stub (rule: compute from class items, stub as 0 for now, Phase 12 fills in class contribution)
-- [ ] Implement save calculations stub (rule: base + ability mod, class contributions in Phase 12)
+- [ ] Implement BAB calculation stub (rule: compute from class items, stub as 0 for now, alpha.2 fills in class contribution)
+- [ ] Implement save calculations stub (rule: base + ability mod, class contributions in alpha.2)
 - [ ] Call `applyActiveEffects()` during `prepareDerivedData()` prep cycle
 - [ ] Test: Prep cycle completes without errors for fresh actor
 
 **Formula-Ready Field Preparation for Phase 8:**
 - [ ] Call `_buildFormulaContexts()` (from Dnd35eDocumentMixin) in `prepareDerivedData()` to populate `#self.*` contexts
 - [ ] Verify RollData includes: abilities, ability modifiers, bab, ac variants, saves, speed, size, initiative, hp
-- [ ] Ensure `getRollData()` returns POJO with all formula-ready paths (e.g., `abilities.str.mod`, `bab`, `attributes.ac.normal`)
+- [ ] Ensure `getRollData()` returns POJO with all formula-ready paths (e.g., `abilities.str.mod`, `bab`, `ac.normal`)
 - [ ] Register formula contexts in Pinia store for IDE autocomplete hints
 - [ ] Document all formula paths available via `#self.*` that Phase 8 actions will consume
 - [ ] Test: `getRollData()` returns complete object with no undefined fields
@@ -434,7 +301,7 @@ Start tracking `system.migration.version` on actors from this phase onward. Even
 - [ ] Create `src/vue/components/sheets/ActorSheetDnd35e.vue` extending `.vue` with tabs array
 - [ ] Implement tab structure: `[Abilities, Inventory, Features, Effects, Biography]` with router-like tab state
 - [ ] **Abilities Tab**: Render all 6 abilities with ability name, base score (editable NumberFormGroup), derived modifier display
-- [ ] **Inventory Tab**: Group items by type (Weapons, Armor, Weapons, Consumables, Loot), equip toggle checkbox per item, weight/price column, total weight display
+- [ ] **Inventory Tab**: Group items by type (Weapons, Equipment, Consumables, Loot), equip toggle checkbox per item, weight/price column, total weight display
 - [ ] **Features Tab**: Placeholder for feats/traits/class features (styling only, data implementation deferred to Phase 10)
 - [ ] **Effects Tab**: List active effects, show effect name, enabled toggle, delete button (use Phase 2's AE component if available)
 - [ ] **Biography Tab**: Textarea for character biography with rich text styling support (defer HTML editor to Phase 23)
@@ -541,131 +408,62 @@ The `resolveActiveEffectChanges()` function (created in Phase 2, §2.5.1) is imp
 
 ## 5.9 Document Event System
 
-A per-document event bus that lets system code, macros, and external modules subscribe to domain events on individual document instances. This is **not** Foundry's global `Hooks` — it's scoped to a single document and carries typed payloads.
+> **Phase 5 status**: `DocumentEventEmitter`, `events` property on all system documents, `DocumentLifeCycle.created`/`destroyed` lifecycle events, and `events.clear()` in `_onDelete()` are all **already implemented**. Phase 6 adds: `wellKnownEvents` registry, typed domain-event payload interfaces, and the `takeDamage → dying/death` cascade in the actor HP method.
 
-### Why Not Global Hooks?
-
-Foundry's `Hooks.on('updateActor', ...)` fires for **every** actor. Document events fire on a **specific** document instance and carry domain-specific payloads (e.g., "this creature died" with cause-of-death data). Subscribers don't need to filter by document ID or check preconditions — if the event fires, it's relevant.
-
-Use cases that motivate this:
-- **Death throes**: A creature with a death effect (e.g., Balor explosion) triggers `death` → subscribers (class features, items, macros) react
-- **Instantiation**: An item added to an actor triggers `instantiate` → the item can run setup logic (register formulas, create companion effects)
-- **Reveal secret**: The identifiable system reveals a property → `revealSecret` fires with what was revealed → UI notifications, chat messages, journal updates react
-- **Class features**: Paladin's Aura of Courage reacts to `death` on the paladin to drop the aura. Rage ends on `death`. Contingency spells fire on `death`.
-- **Macros**: A user writes a macro that listens for `death` on a boss token to trigger a cutscene
+A per-document event bus scoped to a single document instance — not Foundry's global `Hooks`. See Phase 5 for design rationale.
 
 ### Infrastructure: `DocumentEventEmitter`
 
-Lives on `Dnd35eDocumentMixin` so **all** system documents (items, actors, effects) can emit and subscribe. The emitter is instance-scoped — each document has its own subscriber list.
+**Complete (Phase 5).** Every `ItemDnd35e`, `ActorDnd35e`, and `DnD35eActiveEffect` instance carries `events`. `created`/`destroyed` lifecycle events are wired in the mixin.
 
 ```typescript
-// src/helpers/DocumentEventEmitter.mts
+// src/helpers/DocumentEventEmitter.mts — COMPLETE (Phase 5)
 
-type DocumentEventCallback<T = unknown> = (event: DocumentEvent<T>) => void | Promise<void>;
-
-interface DocumentEvent<T = unknown> {
-  type: string;              // Event name, e.g. 'death', 'instantiate', 'revealSecret'
-  document: ClientDocument;  // The document that emitted
-  data: T;                   // Event-specific payload
-  timestamp: number;         // Date.now() at emission
-}
+type EventHandler<T = unknown> = (payload: T) => void | Promise<void>;
 
 class DocumentEventEmitter {
-  #listeners = new Map<string, Set<DocumentEventCallback>>();
-
-  on<T = unknown>(event: string, callback: DocumentEventCallback<T>): void {
-    if (!this.#listeners.has(event)) this.#listeners.set(event, new Set());
-    this.#listeners.get(event)!.add(callback as DocumentEventCallback);
-  }
-
-  off<T = unknown>(event: string, callback: DocumentEventCallback<T>): void {
-    this.#listeners.get(event)?.delete(callback as DocumentEventCallback);
-  }
-
-  once<T = unknown>(event: string, callback: DocumentEventCallback<T>): void {
-    const wrapper: DocumentEventCallback<T> = (e) => {
-      this.off(event, wrapper);
-      return callback(e);
-    };
-    this.on(event, wrapper);
-  }
-
-  async emit<T = unknown>(type: string, data: T, document: ClientDocument): Promise<void> {
-    const event: DocumentEvent<T> = { type, document, data, timestamp: Date.now() };
-    const callbacks = this.#listeners.get(type);
-    if (!callbacks?.size) return;
-    for (const cb of callbacks) {
-      try {
-        await cb(event);
-      } catch (err) {
-        Hooks.onError('DocumentEventEmitter.emit', err as Error, {
-          msg: `Error in '${type}' event handler on ${document.documentName} ${document.id}`,
-          log: 'error',
-        });
-      }
-    }
-  }
-
-  /** Remove all listeners. Called on document deletion cleanup. */
-  clear(): void {
-    this.#listeners.clear();
-  }
-
-  /** List registered event types (for debugging / dev tools). */
-  get registeredEvents(): string[] {
-    return [...this.#listeners.keys()];
-  }
+  // Subscribe. Returns an unsubscribe function.
+  on<T>(event: string, handler: EventHandler<T>): () => void
+  // Subscribe once — auto-unsubscribes after first fire.
+  once<T>(event: string, handler: EventHandler<T>): () => void
+  off<T>(event: string, handler: EventHandler<T>): void
+  // Fire event. Errors forwarded to Hooks.onError; don’t abort other handlers.
+  async emit<T>(event: string, payload: T): Promise<void>
+  // Remove all listeners (call in _onDelete).
+  clear(): void
+  // Event names that currently have ≥1 subscriber.
+  get activeEvents(): string[]
 }
+
+// Phase 6 adds static well-known event registry:
+// static readonly wellKnownEvents: Map<string, { label: string; description: string; appliesTo: string[] }>
+// static registerEventType(type: string, meta: { label: string; description: string; appliesTo: string[] }): void
 ```
 
-### Integration with `Dnd35eDocumentMixin`
-
-```typescript
-// Added to Dnd35eDocumentMixin:
-abstract class Dnd35eDocument extends Base {
-  readonly events = new DocumentEventEmitter();
-  // ...existing constructor, formulas, etc.
-}
-```
-
-Every `ItemDnd35e`, `ActorDnd35e`, and `DnD35eActiveEffect` instance gets an `events` property. Subscribers attach per-instance:
-
-```typescript
-// Example: A class feature item subscribes to its owner's death
-this.parent.events.on('death', (e) => {
-  // Trigger death throe ability
-});
-```
-
-### Default Events
-
-Phase 6 ships the event infrastructure and registers all well-known event types. Events are wired to emit as their triggering systems land in later phases.
+### Domain Events (Phase 6)
 
 #### Actor Events
 
 | Event | Payload | Emitted when | Example use case |
 |-------|---------|-------------|-----------------|
-| `instantiate` | `{ actor: ActorDnd35e }` | Item added to actor (`_onCreate`) | Axe: register formulas. Gem: apply passive bonus |
-| `takeDamage` | `{ amount: number, damageType: string, source?: string, attackerId?: string }` | Damage applied to actor HP | Bloodied effects (4e retrofit), damage-reactive abilities |
+| `takeDamage` | `{ amount: number, damageType: string, source?: string, attackerId?: string }` | Damage applied to actor HP | Damage-reactive abilities |
 | `dying` | `{ previousHp: number, currentHp: number, cause?: string, attackerId?: string }` | Actor HP drops to ≤ 0 but above death threshold | Stabilization checks, bleeding out |
-| `death` | `{ previousHp: number, currentHp: number, cause?: string, attackerId?: string, damage?: number }` | Actor HP drops to ≤ death threshold (default −10) | Draconian death throes, Rage ends, Contingency fires |
-| `preUseAction` | `UseActionContext & { cancel: () => void }` | Before an action executes — calling `cancel()` aborts it | Silence preventing spells, exhaustion blocking actions, curse gates |
-| `postUseAction` | `UseActionContext & { result: ActionResult }` | After an action completes successfully | Curse of the Magi (backlash after casting), resource tracking |
-| `dealDamage` | `{ amount: number, damageType: string, target: ActorDnd35e, context?: UseActionContext }` | Actor deals damage to another actor | Cleave trigger, life-drain effects, vampiric abilities |
+| `death` | `{ previousHp: number, currentHp: number, cause?: string, attackerId?: string, damage?: number }` | Actor HP drops to ≤ world death threshold | Draconian death throes, Rage ends, Contingency fires |
 | `revealSecret` | `{ secretAeId: string, field: string, previousValue: unknown, revealedValue: unknown }` | Secret AE is disabled (revealed) | Chat notification, journal updates, identification macro triggers |
+
+> `preUseAction`, `postUseAction`, `dealDamage`, and `UseActionContext` → **poc.9** (Basic Combat).
 
 #### Item Events
 
 | Event | Payload | Emitted when | Example use case |
 |-------|---------|-------------|-----------------|
-| `instantiate` | `{ actor: ActorDnd35e }` | Item added to actor (`_onCreate`) | Already defined — item setup on creation |
-| `takeDamage` | `{ amount: number, damageType: string, source?: string }` | Damage applied to item HP (sunder, AoE, etc.) | Item durability tracking, shatter effects |
+| `takeDamage` | `{ amount: number, damageType: string, source?: string }` | Damage applied to item HP | Item durability, sunder |
 | `destroyed` | `{ previousHp: number, cause?: string }` | Item HP drops to ≤ 0 | Item breaks, special effects on destruction (cursed items) |
 | `revealSecret` | `{ secretAeId: string, field: string, previousValue: unknown, revealedValue: unknown }` | Secret AE on item is revealed | Same as actor — identification reveals |
 
 #### Damage → Death Cascade
 
-`takeDamage` is the root event. Death/dying are **sub-events** emitted from the same damage-application flow — not separate subscriptions a consumer needs to wire independently:
+`takeDamage` is the root event; `dying`/`death`/`destroyed` emit from the same damage-application flow:
 
 ```
 actor.applyDamage(amount, type, source)
@@ -681,191 +479,41 @@ item.applyDamage(amount, type, source)
       emit 'destroyed' { previousHp, cause }
 ```
 
-The death threshold is configurable per actor (most creatures die at −10; some die at 0; constructs/undead die at 0). Items always use 0.
+**Death threshold** is driven by a world setting. Options:
+- `−10` flat (PHB default)
+- `−[CON score]` (house rule — tougher fighters survive longer)
 
-#### UseActionContext
-
-Action events carry a self-contained `UseActionContext` — everything a macro or module needs to evaluate the action locally without re-resolving references:
-
-```typescript
-interface UseActionContext {
-  actor: ActorDnd35e;          // The actor executing the action
-  item: ItemDnd35e;             // The source item that declared the action
-  action: ActionDataModel;      // The full resolved action data model
-  itemId: string;               // Convenience — item.id
-  actionId: string;             // Convenience — action.id
-  params: unknown[];            // Additional parameters passed at invocation
-}
-```
-
-The context is built once at the start of `actor.useAction()` and passed through the entire lifecycle: `preUseAction` → execution → `postUseAction`. Macros receive this as a single object and can inspect `context.action.type`, read `context.item.system`, check `context.actor.system.hp`, etc. — no lookups needed.
-
-#### preUseAction Cancellation Pattern
-
-`preUseAction` supports cancellation via a `cancel()` callback merged into the context. If any subscriber calls `cancel()`, the action execution is aborted and the action budget is not consumed. The emitter checks a cancelled flag after all callbacks run:
-
-```typescript
-// In actor.useAction(itemId, actionId, ...params):
-const item = this.items.get(itemId);
-const action = item.system.actions.get(actionId);
-const context: UseActionContext = { actor: this, item, action, itemId, actionId, params };
-
-const cancelled = { value: false };
-const payload = { ...context, cancel: () => { cancelled.value = true; } };
-await this.events.emit('preUseAction', payload, this);
-if (cancelled.value) return; // Action aborted — budget not consumed
-
-// ... execute the action
-const result = await action.execute(context);
-
-await this.events.emit('postUseAction', { ...context, result }, this);
-```
-
-Multiple subscribers can call `cancel()` — it's idempotent. The cancellation reason is not tracked in the base implementation (subscribers should post their own chat messages explaining why the action was blocked).
-
-#### Action Invocation Model
-
-Actions are always executed in the context of the owning actor. The actor maintains an array of available actions (sourced from owned items, class features, racial abilities, etc.). Invocation follows the pattern:
-
-```typescript
-actor.useAction(itemId: string, actionId: string, ...params: unknown[])
-```
-
-The actor looks up the item by `itemId`, finds the action by `actionId` on that item, builds a `UseActionContext` with all resolved references, then executes it. The `preUseAction` / `postUseAction` events fire on the actor — not on the item — because the actor is the execution context. Subscribers attach once on the actor and see all actions. They can filter by `context.action.type`, `context.itemId`, or any property on the resolved data model.
-
-The exact signature and dispatch mechanism is an explore-at-phase-start decision for Phase 10. Phase 6 defines the `UseActionContext` interface and event payloads so subscribers have a stable contract.
-
-**`instantiate`** fires when an item is first added to an actor (in `_onCreate` if the item has a parent actor). It does NOT fire on world-level item creation or on data preparation cycles — only on the initial creation event. Items use this to run one-time setup: register additional formulas, create companion effects, or initialize state.
-
-**`takeDamage`** fires on every damage application — both actor and item. This is the root event for damage-reactive abilities. Subscribers see the raw damage amount, type, and source. The `dying`, `death`, and `destroyed` sub-events fire from the same flow when HP thresholds are crossed.
-
-**`death`** fires when an actor's HP drops to the death threshold or below (default −10, configurable per actor). It fires once per death transition (HP above threshold → HP at/below threshold), not on every update while already dead.
-
-**`dying`** fires when an actor's HP drops to 0 or below but remains above the death threshold. This represents the bleeding-out state in D&D 3.5e. It fires once per transition into the dying range.
-
-**`preUseAction`** fires before any action executes on the actor. The payload is a full `UseActionContext` plus `cancel()`. Subscribers can inspect `context.action` (the resolved data model), `context.item`, `context.actor`, or any nested property — then call `cancel()` to abort. Fires for all action types — attacks, spells, abilities, item uses. The action system (Phase 10) wires the emission point.
-
-**`postUseAction`** fires after an action completes successfully (not fired if cancelled). The payload is `UseActionContext` plus `result: ActionResult`. Macros can read the full action context alongside the outcome. The action system (Phase 10) wires the emission point.
-
-**`dealDamage`** fires on the actor that dealt the damage (not the target). Optionally carries `context: UseActionContext` when the damage came from an action (absent for environmental or effect-based damage). This is the hook point for on-hit abilities that care about dealing damage (Cleave, vampiric touch, life drain). Distinct from the `EffectTrigger` system (Phase 10) which handles combat-specific triggers like `onKill` and `onCrit` — `dealDamage` is broader and fires on all damage sources.
-
-**`destroyed`** fires when an item's HP drops to 0 or below. This is the item equivalent of `death` — items have a single threshold at 0.
-
-**`revealSecret`** fires when a Secret AE is disabled (revealed). The payload includes the Secret AE id, the field path that was masked, the display value (what was shown), and the real value (what is now revealed). This is the hook point for chat notifications ("The sword reveals itself to be a +2 Flaming Longsword!"), journal updates, and macro triggers.
-
-### Extensibility
-
-Macros and modules register custom events by simply emitting/subscribing to any string key:
-
-```typescript
-// A module registers a custom event type
-actor.events.on('myModule.stunned', (e) => { /* react */ });
-
-// The module emits it from its own logic
-actor.events.emit('myModule.stunned', { rounds: 3 }, actor);
-```
-
-No registration step needed — event types are open strings. System events use unprefixed names (`death`, `instantiate`). Module events should use a namespace prefix (`myModule.eventName`) to avoid collisions.
-
-### Well-Known Event Registry
-
-While event types are open strings (anything can be emitted/subscribed), the system maintains a static registry of **well-known events** with labels and descriptions. This serves two purposes: documentation for developers, and a future UI dropdown for GM-authored traits.
-
-```typescript
-// On DocumentEventEmitter (static):
-static readonly wellKnownEvents = new Map<string, { label: string; description: string }>();
-
-static registerEventType(type: string, meta: { label: string; description: string }): void {
-  DocumentEventEmitter.wellKnownEvents.set(type, meta);
-}
-```
-
-Registered at system init:
-
-```typescript
-// Actor events
-DocumentEventEmitter.registerEventType('instantiate', {
-  label: 'Instantiate',
-  description: 'Fires when an item is first added to an actor.',
-  appliesTo: ['actor', 'item'],
-});
-DocumentEventEmitter.registerEventType('takeDamage', {
-  label: 'Take Damage',
-  description: 'Fires when damage is applied to the document\'s HP.',
-  appliesTo: ['actor', 'item'],
-});
-DocumentEventEmitter.registerEventType('dying', {
-  label: 'Dying',
-  description: 'Fires when an actor\'s HP drops to ≤ 0 but above death threshold.',
-  appliesTo: ['actor'],
-});
-DocumentEventEmitter.registerEventType('death', {
-  label: 'Death',
-  description: 'Fires when an actor\'s HP drops to the death threshold (default −10).',
-  appliesTo: ['actor'],
-});
-DocumentEventEmitter.registerEventType('destroyed', {
-  label: 'Destroyed',
-  description: 'Fires when an item\'s HP drops to ≤ 0.',
-  appliesTo: ['item'],
-});
-DocumentEventEmitter.registerEventType('preUseAction', {
-  label: 'Pre-Use Action',
-  description: 'Fires before an action executes. Calling cancel() aborts the action.',
-  appliesTo: ['actor'],
-});
-DocumentEventEmitter.registerEventType('postUseAction', {
-  label: 'Post-Use Action',
-  description: 'Fires after an action completes successfully.',
-  appliesTo: ['actor'],
-});
-DocumentEventEmitter.registerEventType('dealDamage', {
-  label: 'Deal Damage',
-  description: 'Fires on the actor that dealt damage to another actor.',
-  appliesTo: ['actor'],
-});
-DocumentEventEmitter.registerEventType('revealSecret', {
-  label: 'Reveal Secret',
-  description: 'Fires when a Secret AE is disabled (revealed), exposing the real value.',
-  appliesTo: ['actor', 'item'],
-});
-```
-
-Modules extend: `DocumentEventEmitter.registerEventType('myModule.stunned', { label: 'Stunned', description: '...' })`. The registry is informational — unregistered events still work fine. See Phase 8, §11.5 for how this feeds a future trait-authoring dropdown.
-
-### Lifecycle & Cleanup
-
-- `events.clear()` is called in the document's `_onDelete()` to prevent stale references
-- Listeners are **not persisted** — they're runtime-only, re-established during each session (class features re-subscribe in `prepareDerivedData()` or `_onCreate()`)
-- The emitter is synchronous-first but supports async callbacks (awaited in sequence, not parallel) — a failing callback does not block subsequent callbacks
+A separate **"Monsters die at 0"** world toggle makes NPC actors without class levels die immediately at 0 HP rather than entering the dying range. Per-actor override still applies (constructs/undead always die at 0 regardless). Items always use 0.
 
 ### Completion Checklist (Document Event System)
 
-- [ ] Create `src/helpers/DocumentEventEmitter.mts` with `DocumentEventEmitter` class
-- [ ] Export `DocumentEvent<T>` and `DocumentEventCallback<T>` types
-- [ ] Add `readonly events: DocumentEventEmitter` to `Dnd35eDocumentMixin`
-- [ ] Wire `events.clear()` in document `_onDelete()` cleanup
-- [ ] Implement static `wellKnownEvents` registry on `DocumentEventEmitter` with `registerEventType()` method and `appliesTo` metadata
-- [ ] Register all well-known events at system init: `instantiate`, `takeDamage`, `dying`, `death`, `destroyed`, `preUseAction`, `postUseAction`, `dealDamage`, `revealSecret`
-- [ ] Define typed payload interfaces for each event (e.g., `TakeDamageEvent`, `DeathEvent`, `PreUseActionEvent`)
-- [ ] Emit `instantiate` in `ItemDnd35e._onCreate()` when item has a parent actor
-- [ ] Implement `takeDamage` → `dying` / `death` cascade in actor damage application method (threshold-based sub-event emission)
-- [ ] Implement `takeDamage` → `destroyed` cascade in item damage application method (HP ≤ 0)
-- [ ] Implement `preUseAction` cancellation pattern with `cancel()` callback (emission wired in Phase 10 action system)
-- [ ] Define `postUseAction`, `dealDamage` event payload interfaces (emission wired in Phase 10 action system)
-- [ ] Define `revealSecret` event type and payload interface (emission wired during Secret AE phase)
+**Already done (Phase 5):**
+- [x] Create `src/helpers/DocumentEventEmitter.mts` with `DocumentEventEmitter` class
+- [x] Export `EventHandler<T>` type
+- [x] Add `readonly events: DocumentEventEmitter` to `Dnd35eDocumentMixin`
+- [x] Wire `events.clear()` in document `_onDelete()` cleanup
+- [x] Implement `DocumentLifeCycle.created` / `destroyed` lifecycle events wired in mixin
+- [x] `on()` returns an unsubscribe `() => void`; `once()` auto-unsubscribes
+- [x] Failing callback logs via `Hooks.onError` and does not block other callbacks
+
+**Phase 6 — Remaining:**
+- [ ] Add static `wellKnownEvents` registry + `registerEventType()` to `DocumentEventEmitter`
+- [ ] Register well-known domain events at system init: `takeDamage`, `dying`, `death`, `destroyed`, `revealSecret` (`preUseAction`/`postUseAction`/`dealDamage` registered in poc.9)
+- [ ] Define typed payload interfaces: `TakeDamagePayload`, `DeathPayload`, `DyingPayload`, `DestroyedPayload`, `RevealSecretPayload`
+- [ ] Implement `takeDamage → dying → death` cascade in actor damage application method
+- [ ] Implement world setting: death threshold mode (`−10` flat / `−CON score`)
+- [ ] Implement world setting: "Monsters die at 0" toggle for NPC actors without class levels
+- [ ] Per-actor override: constructs/undead always die at 0 regardless of world setting
+- [ ] Implement `takeDamage → destroyed` cascade in item damage application method
+- [ ] Define `RevealSecretPayload` interface (emission wired in Secret AE phase)
 - [ ] Test: Subscribe to `takeDamage` on actor, apply damage, callback fires with amount/type
-- [ ] Test: `takeDamage` → `dying` fires when HP drops to 0 but above −10
-- [ ] Test: `takeDamage` → `death` fires when HP drops to −10 or below
+- [ ] Test: `takeDamage → dying` fires when HP drops to 0 but above −10
+- [ ] Test: `takeDamage → death` fires when HP drops to −10 or below
 - [ ] Test: `death` threshold is configurable per actor (constructs/undead die at 0)
-- [ ] Test: `death` fires once per transition, not on every update while dead
-- [ ] Test: Item `takeDamage` → `destroyed` fires when item HP drops to 0
-- [ ] Test: `preUseAction` cancel() prevents action execution (wired in Phase 10)
-- [ ] Test: Subscribe to `death` on actor, reduce HP to −10, callback fires with payload
-- [ ] Test: `instantiate` fires once on item creation, not on subsequent updates
-- [ ] Test: `events.clear()` removes all listeners, subsequent emit is no-op
-- [ ] Test: Failing callback logs error via `Hooks.onError` but doesn't block other callbacks
-- [ ] Test: `once()` auto-unsubscribes after first fire
+- [ ] Test: `death` fires once per transition, not on every update while already dead
+- [ ] Test: Item `takeDamage → destroyed` fires when item HP drops to 0
+- [ ] Test: `on()` unsubscribe function works; `once()` auto-unsubscribes after first fire
+- [ ] Test: `events.clear()` removes all listeners; subsequent `emit()` is a no-op
 
 ---
 
@@ -873,8 +521,8 @@ Modules extend: `DocumentEventEmitter.registerEventType('myModule.stunned', { la
 
 | Action | Path |
 |--------|------|
-| Create | `src/helpers/DocumentEventEmitter.mts` — `DocumentEventEmitter` class, `DocumentEvent<T>`, `DocumentEventCallback<T>` types |
-| Modify | `src/documents/document/DocumentDnd35e.mts` — add `readonly events: DocumentEventEmitter` to mixin |
+| Modify | `src/helpers/DocumentEventEmitter.mts` — **Phase 5 created this file.** Phase 6 adds static `wellKnownEvents` registry + `registerEventType()` |
+| *(Phase 5 done)* | `src/documents/document/DocumentDnd35e.mts` — `readonly events: DocumentEventEmitter` already added in Phase 5 |
 | Create | `src/documents/actors/baseActor/data/ActorSystemModelBase.mts` — `ActorSystemModelBase`: speed, biography/notes |
 | Create | `src/documents/actors/baseActor/data/CreatureSystemModel.mts` — `CreatureSystemModel extends ActorSystemModelBase`: abilities, HP, AC, saves, BAB, init, senses, encumbrance, currency |
 | Create | `src/documents/actors/character/data/CharacterSystemModel.mts` — `CharacterSystemModel extends CreatureSystemModel`: xp, description fields, isPartyMember |

--- a/docs/migration-plan/poc/phase-09-basic-tokens.md
+++ b/docs/migration-plan/poc/phase-09-basic-tokens.md
@@ -1,0 +1,32 @@
+# POC Phase 9: Basic Tokens
+
+**Status**: 📄 Stub
+
+> **Milestone**: POC  
+> **Dependencies**: poc.6  
+> **Goal**: A token can be created on a scene, moved around the map, and correctly reflects its actor. Token has the right class, properties, and actor linkage. Minimal proof before poc.10 (Basic Combat) depends on tokens being on the canvas.
+
+---
+
+## Overview
+
+Phase 9 is a thin verification layer between the actor foundation (poc.6) and combat (poc.10). It proves the actor ↔ token relationship works end-to-end before anything tries to do combat tracking on top of it. Expected to be very little work since Foundry handles most of this out of the box.
+
+**What to verify:**
+- Token can be placed on a scene from an actor
+- Token can be moved (position updates)
+- `token.actor` resolves to the correct `ActorDnd35e` instance
+- Token document class is `TokenDocumentDnd35e` (or the system's registered class)
+- Token size derives correctly from `actor.system.size`
+- Foundry's default token bar shows HP
+
+---
+
+## TODO (Stub — to flesh out at phase-start)
+
+- [ ] Verify token document class registration
+- [ ] Verify `token.actor` → `ActorDnd35e` instance with correct `system` shape
+- [ ] Verify token size derives from `actor.system.size` (size category → grid squares)
+- [ ] Verify HP bar displays `system.hp.current` / `system.hp.max` by default
+- [ ] Smoke test: place token on scene, move it, confirm position persists
+- [ ] E2E: token created from actor drag → correct name, size, HP bar shown

--- a/docs/migration-plan/poc/phase-09-basic-tokens.md
+++ b/docs/migration-plan/poc/phase-09-basic-tokens.md
@@ -1,6 +1,6 @@
 # POC Phase 9: Basic Tokens
 
-**Status**: ⚪ Planned
+**Status**: 📝 Planned
 
 > **Milestone**: POC  
 > **Dependencies**: poc.6  

--- a/docs/migration-plan/poc/phase-09-basic-tokens.md
+++ b/docs/migration-plan/poc/phase-09-basic-tokens.md
@@ -1,6 +1,6 @@
 # POC Phase 9: Basic Tokens
 
-**Status**: � Planned
+**Status**: ⚪ Planned
 
 > **Milestone**: POC  
 > **Dependencies**: poc.6  

--- a/docs/migration-plan/poc/phase-09-basic-tokens.md
+++ b/docs/migration-plan/poc/phase-09-basic-tokens.md
@@ -1,32 +1,277 @@
 # POC Phase 9: Basic Tokens
 
-**Status**: 📄 Stub
+**Status**: � Planned
 
 > **Milestone**: POC  
 > **Dependencies**: poc.6  
-> **Goal**: A token can be created on a scene, moved around the map, and correctly reflects its actor. Token has the right class, properties, and actor linkage. Minimal proof before poc.10 (Basic Combat) depends on tokens being on the canvas.
+> **Goal**: A token can be created on a scene, moved, and correctly reflects its actor. Token has the right document and canvas classes, actor linkage, size derived from `system.size`, and HP bar by default. Minimal proof before poc.10 (Basic Combat) depends on tokens.
 
 ---
 
 ## Overview
 
-Phase 9 is a thin verification layer between the actor foundation (poc.6) and combat (poc.10). It proves the actor ↔ token relationship works end-to-end before anything tries to do combat tracking on top of it. Expected to be very little work since Foundry handles most of this out of the box.
+Phase 6 creates `ActorDnd35e` and the character schema. Phase 9 wires it to the Foundry canvas so actors appear as tokens on the table. Expected to be a thin phase — Foundry handles most token mechanics out of the box.
 
-**What to verify:**
-- Token can be placed on a scene from an actor
-- Token can be moved (position updates)
-- `token.actor` resolves to the correct `ActorDnd35e` instance
-- Token document class is `TokenDocumentDnd35e` (or the system's registered class)
-- Token size derives correctly from `actor.system.size`
-- Foundry's default token bar shows HP
+**Existing scaffolding (already in `src/`):**
+- `TokenDnd35e` canvas class at `src/canvas/token/TokenDnd35e.mts` — stub extending `fc.placeables.Token`. Typed, not yet registered.
+- `TokenDocumentDnd35e` at `src/documents/scene/tokenDocument/TokenDocumentDnd35e.mts` — **type alias only**, not a real class. Phase 9 converts it.
+- `SIZES` constant at `src/constants/sizes.mts` — all 9 size categories defined.
+
+**What Phase 9 adds:**
+1. `SIZE_TOKEN_DIMENSIONS` size → grid square mapping in `sizes.mts`
+2. `TokenDocumentDnd35e` becomes a real class with `_preCreate()` for size derivation
+3. `ActorDnd35e._preCreate()` sets prototype token defaults (size, vision, disposition, HP bar)
+4. Register `CONFIG.Token.documentClass`, `CONFIG.Token.objectClass`, `CONFIG.Actor.documentClass`
+5. All five movement speeds (land/swim/climb/burrow/fly) visible on character sheet
+6. `TokenDnd35e._getAnimationMovementSpeed()` wired to actor land speed
+7. Ruler / movement budget display (explore at phase start, fallback to poc.10)
 
 ---
 
-## TODO (Stub — to flesh out at phase-start)
+## 9.1 Size Category → Token Dimensions
 
-- [ ] Verify token document class registration
-- [ ] Verify `token.actor` → `ActorDnd35e` instance with correct `system` shape
-- [ ] Verify token size derives from `actor.system.size` (size category → grid squares)
-- [ ] Verify HP bar displays `system.hp.current` / `system.hp.max` by default
-- [ ] Smoke test: place token on scene, move it, confirm position persists
-- [ ] E2E: token created from actor drag → correct name, size, HP bar shown
+D&D 3.5e size categories map to Foundry grid squares (width = height, token is always square):
+
+| Size | Grid squares |
+|------|-------------|
+| Fine | 0.5 |
+| Diminutive | 0.5 |
+| Tiny | 1 |
+| Small | 1 |
+| Medium | 1 (default) |
+| Large | 2 (2×2) |
+| Huge | 3 (3×3) |
+| Gargantuan | 4 (4×4) |
+| Colossal | 6 (6×6) |
+
+```typescript
+// src/constants/sizes.mts — add alongside existing SIZES constant
+const SIZE_TOKEN_DIMENSIONS: Record<Size, number> = {
+  fine: 0.5,
+  diminutive: 0.5,
+  tiny: 1,
+  small: 1,
+  medium: 1,
+  large: 2,
+  huge: 3,
+  gargantuan: 4,
+  colossal: 6,
+} as const;
+```
+
+---
+
+## 9.2 TokenDocumentDnd35e (Real Class)
+
+Convert from a type alias to a real class. `_preCreate()` reads actor size and sets token dimensions.
+
+```typescript
+// src/documents/scene/tokenDocument/TokenDocumentDnd35e.mts
+import TokenDocument from '@client/documents/token.mjs';
+import { SIZE_TOKEN_DIMENSIONS } from '@constants/sizes.mjs';
+import type { SceneDnd35e } from '../SceneDnd35e.mjs';
+
+class TokenDocumentDnd35e<TParent extends SceneDnd35e | null = SceneDnd35e | null>
+  extends TokenDocument<TParent> {
+
+  override async _preCreate(
+    data: PreCreate<foundry.documents.TokenSource>,
+    options: object,
+    user: foundry.documents.User
+  ): Promise<boolean | void> {
+    const result = await super._preCreate(data, options, user);
+    if (result === false) return result;
+
+    const size = (this.actor as ActorDnd35e | null)?.system?.size;
+    if (size && size in SIZE_TOKEN_DIMENSIONS) {
+      const dim = SIZE_TOKEN_DIMENSIONS[size as Size];
+      this.updateSource({ width: dim, height: dim });
+    }
+    return result;
+  }
+}
+
+export { TokenDocumentDnd35e };
+```
+
+---
+
+## 9.3 Actor Prototype Token Defaults
+
+`ActorDnd35e._preCreate()` sets sensible prototype token defaults for new Character actors so they don't need manual configuration after creation.
+
+Includes basic vision (`sight.enabled: true`) so placed tokens can see the scene. No darkvision or other senses yet — Phase 6 has no senses schema; that defers to Phase 23 when race and NPC types land.
+
+```typescript
+// ActorDnd35e — add _preCreate override
+override async _preCreate(
+  data: PreCreate<foundry.documents.ActorSource>,
+  options: object,
+  user: foundry.documents.User
+): Promise<boolean | void> {
+  const result = await super._preCreate(data, options, user);
+  if (result === false) return result;
+
+  if (this.type === 'character') {
+    this.updateSource({
+      'prototypeToken.actorLink': true,
+      'prototypeToken.disposition': CONST.TOKEN_DISPOSITIONS.FRIENDLY,
+      'prototypeToken.displayBars': CONST.TOKEN_DISPLAY_MODES.OWNER_HOVER,
+      'prototypeToken.displayName': CONST.TOKEN_DISPLAY_MODES.OWNER,
+      'prototypeToken.bar1': { attribute: 'hp' },
+      'prototypeToken.sight': { enabled: true, visionMode: 'basic' },
+    });
+  }
+  return result;
+}
+```
+
+---
+
+## 9.4 Registration
+
+```typescript
+// In registerActors() init hook (or a dedicated canvas registration function):
+CONFIG.Token.objectClass   = TokenDnd35e;
+CONFIG.Token.documentClass = TokenDocumentDnd35e;
+CONFIG.Actor.documentClass = ActorProxyDnd35e;  // may already be in Phase 6
+```
+
+> **Note on `CONFIG.Actor.documentClass`**: The current `registerActors()` in Phase 6 only wires FormulaFamiliar schemas — it does not register `ActorProxyDnd35e`. Confirm at implementation time whether Phase 6 adds this or Phase 9 does.
+
+---
+
+## 9.5 Movement Speed
+
+### Schema dependency
+
+Phase 6 §5.1 plans `speed: { land, climb, swim, burrow, fly }` on `ActorSystemModelBase`, each with `{ base: number, total: number (persisted: false) }`. Poc.9 depends on Phase 6 delivering those fields.
+
+Phase 6 Story 2 shows "speed" on the sheet but vaguely. If Phase 6 only displays land speed, poc.9 adds a dedicated Speed section showing all five modes (land, swim, climb, burrow, fly), with non-zero modes displayed and zero-value modes grayed out or hidden.
+
+### Animation speed (visual)
+
+`Token._getAnimationMovementSpeed()` controls how fast the token slides across the canvas in grid squares per second (Foundry default: 6). **This is purely visual** — it is NOT the D&D movement budget. Override in `TokenDnd35e` so the slide speed matches the character's land speed:
+
+```typescript
+// TokenDnd35e — override canvas animation speed
+protected override _getAnimationMovementSpeed(): number {
+  const landSpeed = this.document.actor?.system?.speed?.land?.total;
+  if (landSpeed && landSpeed > 0) {
+    // 5ft per grid square — 30ft = 6 squares/sec (matches Foundry default)
+    return landSpeed / 5;
+  }
+  return (CONFIG.Token as Record<string, unknown> & { movement?: { defaultSpeed?: number } })
+    .movement?.defaultSpeed ?? 6;
+}
+```
+
+### Ruler / movement budget display (open decision)
+
+**What we want**: while dragging a token, the ruler label shows "25 / 30 ft" (distance used vs. budget) and the path line or waypoint marker changes color when the budget is exceeded.
+
+**Extension points found in type definitions**:
+- `TokenRuler._getWaypointLabelContext(waypoint, state)` — injects data into the Handlebars label template
+- `TokenRuler._getWaypointStyle(waypoint)` — controls marker radius/color per waypoint
+- `TokenRuler._getSegmentStyle(waypoint)` — controls path line color per segment
+- `TokenPlannedMovement.unreachableWaypoints` — Foundry tracks waypoints beyond the movement budget if cost functions are configured
+
+**Open decision at phase start**: Explore whether subclassing `TokenRuler` is required, or if a simpler hook point exists (e.g. `Token#_refreshRuler` or a movement action config). Determine whether wiring `CONFIG.Token.movement` action costs is needed before the ruler can show budget-aware colors.
+
+**Fallback**: if full budget display is complex, poc.9 ships the animation speed wiring only. The ruler budget display defers to poc.10 (Basic Combat), where per-action movement tracking is needed anyway. Decide at phase start.
+
+---
+
+## Phase Delivery Plan
+
+Two sequential stories.
+
+```
+Story 1 → Story 2
+```
+
+### Story 1 — Token placement, sizing, actor linkage, and vision
+
+**User**: GM  
+**Delivers**: Character actor dragged to scene appears as a correctly-sized, actor-linked token with HP bar and basic vision enabled.  
+**Depends on**: Phase 6 (CharacterSystemModel, ActorDnd35e in place).
+
+**Commits:**
+1. **`SIZE_TOKEN_DIMENSIONS` + real `TokenDocumentDnd35e` class** — add size mapping to `sizes.mts`; convert `TokenDocumentDnd35e` from type alias to real class with `_preCreate()`. *(Unit tests: all 9 size categories map correctly; Medium → 1, Large → 2, Huge → 3)*
+2. **Actor prototype token defaults** — `ActorDnd35e._preCreate()` for character `actorLink`, `disposition`, `displayBars`, `displayName`, `bar1`, `sight`. *(Unit tests: new Character actor prototypeToken has `actorLink: true`, `bar1.attribute: 'hp'`, `sight.enabled: true`)*
+3. **Registration** — wire `CONFIG.Token.objectClass`, `CONFIG.Token.documentClass`, `CONFIG.Actor.documentClass` in init hook. *(Unit test: CONFIG values are correct class references after init)*
+
+**E2E acceptance**: Create Character actor (Medium, HP 20) → drag to scene → 1×1 token placed → HP bar shows 20/20 → move token → position persists after page reload.
+
+---
+
+### Story 2 — Movement speed
+
+**User**: GM / Player  
+**Delivers**: All five actor movement speeds visible on character sheet; moving a token on canvas animates at the correct speed; ruler shows distance traveled.  
+**Depends on**: Story 1 + Phase 6 Story 2 (speed schema fields exist).
+
+**Commits:**
+1. **Speed sheet UI** — if Phase 6 Story 2 only shows land speed, add all five modes (land, swim, climb, burrow, fly) to the sheet with zero-value modes grayed. *(Skip if Phase 6 already covers all five.)*
+2. **Animation speed wiring** — override `TokenDnd35e._getAnimationMovementSpeed()` to derive from `actor.system.speed.land.total`. *(Unit test: Large token with 30ft land speed returns 6 from `_getAnimationMovementSpeed()`)*
+3. **Ruler budget display** — *explore at phase start*. Implement `_getWaypointLabelContext()` / `_getWaypointStyle()` / `_getSegmentStyle()` overrides (or simpler hook if found). If ruler subclassing proves too complex for poc.9, defer to poc.10 and document the finding.
+
+**E2E acceptance**: Character with 30ft speed drags token across canvas → ruler shows distance in feet → token animation speed visually matches 6 squares/second (30ft ÷ 5ft).
+
+---
+
+## Completion Checklist
+
+### ❌ Not Started
+
+**Size mapping:**
+- [ ] Add `SIZE_TOKEN_DIMENSIONS: Record<Size, number>` to `src/constants/sizes.mts`
+- [ ] Export `SIZE_TOKEN_DIMENSIONS` from `sizes.mts`
+
+**TokenDocumentDnd35e:**
+- [ ] Convert `TokenDocumentDnd35e` from type alias to real class extending `TokenDocument`
+- [ ] Override `_preCreate()` to derive `width`/`height` from `actor.system.size`
+- [ ] Update `src/documents/scene/tokenDocument/index.mts` to export the class (not just the type)
+
+**Actor prototype token defaults:**
+- [ ] Override `ActorDnd35e._preCreate()` to set prototype token defaults for `character` type
+- [ ] Defaults: `actorLink: true`, `disposition: FRIENDLY`, `displayBars: OWNER_HOVER`, `displayName: OWNER`, `bar1.attribute: 'hp'`
+- [ ] Vision defaults: `sight.enabled: true`, `sight.visionMode: 'basic'`
+
+**Registration:**
+- [ ] Register `CONFIG.Token.objectClass = TokenDnd35e` in init hook
+- [ ] Register `CONFIG.Token.documentClass = TokenDocumentDnd35e` in init hook
+- [ ] Register `CONFIG.Actor.documentClass = ActorProxyDnd35e` in init hook (confirm not already in Phase 6)
+
+**Movement speed:**
+- [ ] Verify Phase 6 Story 2 delivers `speed.{land,climb,swim,burrow,fly}` fields (each `{ base, total }`)
+- [ ] If Phase 6 only shows land speed on sheet, add all five modes to Speed section (zero-value modes grayed)
+- [ ] Override `TokenDnd35e._getAnimationMovementSpeed()` → `actor.system.speed.land.total / 5`
+- [ ] Explore ruler budget display extension points at phase start; implement or defer to poc.10
+
+**Tests:**
+- [ ] Unit: `SIZE_TOKEN_DIMENSIONS` covers all 9 size categories
+- [ ] Unit: Medium → 1, Large → 2, Huge → 3, Colossal → 6
+- [ ] Unit: new Character actor `prototypeToken.actorLink` is `true`
+- [ ] Unit: new Character actor `prototypeToken.bar1.attribute` is `'hp'`
+- [ ] Unit: new Character actor `prototypeToken.sight.enabled` is `true`
+- [ ] Unit: `TokenDocumentDnd35e._preCreate()` sets 2×2 for a Large actor
+- [ ] Unit: `CONFIG.Token.objectClass` is `TokenDnd35e` after init hook runs
+- [ ] Unit: `_getAnimationMovementSpeed()` returns 6 for a 30ft land speed actor
+- [ ] E2E: drag Character actor to scene → 1×1 token with HP bar appears
+- [ ] E2E: move token → position persists after reload
+- [ ] E2E: drag token across canvas → ruler shows distance in feet
+
+---
+
+## Files to Create/Modify
+
+| Action | Path |
+|--------|------|
+| Modify | `src/constants/sizes.mts` — add `SIZE_TOKEN_DIMENSIONS` |
+| Modify | `src/documents/scene/tokenDocument/TokenDocumentDnd35e.mts` — convert to real class, add `_preCreate()` |
+| Modify | `src/documents/scene/tokenDocument/index.mts` — export class (not just type) |
+| Modify | `src/documents/actors/baseActor/ActorDnd35e.mts` — add `_preCreate()` for prototype token defaults |
+| Modify | `src/documents/actors/registration.mts` — add `CONFIG.Token.*` and `CONFIG.Actor.documentClass` registration |
+| Modify | `src/canvas/token/TokenDnd35e.mts` — add `_getAnimationMovementSpeed()` override |
+| Modify (maybe) | `src/canvas/token/TokenRulerDnd35e.mts` (new file) — ruler subclass for budget display (explore at phase start) |

--- a/docs/migration-plan/poc/phase-10-basic-combat.md
+++ b/docs/migration-plan/poc/phase-10-basic-combat.md
@@ -1,0 +1,94 @@
+# POC Phase 10: Basic Combat Stub
+
+**Status**: 📄 Stub
+
+> **Milestone**: POC  
+> **Dependencies**: poc.6, poc.7, poc.9  
+> **Goal**: The combat tracker is functional. A character can take a basic move, a double move, or a main-hand attack — the minimal action economy loop proving the system before alpha.3 builds the full action system.
+
+---
+
+## Overview
+
+Phase 9 is the POC-level proof that a combat exchange works end-to-end. It sits between the actor/roll foundation (poc.6/poc.7) and the full Action System (alpha.3), proving the minimal loop before committing to the full architecture.
+
+**What Phase 6 already provides:**
+- Actor HP, `DocumentEventEmitter`, `takeDamage`/`dying`/`death` event cascade
+- `wellKnownEvents` registry and `registerEventType()` infrastructure
+- `destroyed` cascade on item HP
+
+**What Phase 9 adds:**
+- `UseActionContext` interface and action event payload interfaces
+- `preUseAction`/`postUseAction`/`dealDamage` domain events wired and emitted
+- A minimal "roll to hit → apply damage" flow through the actor
+- Basic chat card showing attack result
+
+This deliberately stops short of the full action system. Alpha.3 builds the complete `ActionDataModel`, execution engine, and combat maneuvers on top of this foundation.
+
+---
+
+## Action Events
+
+### Actor Events
+
+| Event | Payload | Emitted when | Example use case |
+|-------|---------|-------------|----------------|
+| `preUseAction` | `UseActionContext & { cancel: () => void }` | Before action executes — `cancel()` aborts | Silence, exhaustion, curse gates |
+| `postUseAction` | `UseActionContext & { result: ActionResult }` | After action completes | Resource tracking, backlash effects |
+| `dealDamage` | `{ amount: number, damageType: string, target: ActorDnd35e, context?: UseActionContext }` | Actor deals damage to another | Cleave trigger, life-drain |
+
+### UseActionContext
+
+```typescript
+interface UseActionContext {
+  actor: ActorDnd35e;      // The actor executing the action
+  item: ItemDnd35e;        // Item that declared the action
+  action: ActionDataModel; // Resolved action data model
+  itemId: string;
+  actionId: string;
+  params: unknown[];
+}
+```
+
+### preUseAction Cancellation Pattern
+
+`preUseAction` merges `cancel: () => void` into the context. Any subscriber calling `cancel()` aborts execution before the action budget is consumed. Multiple calls are idempotent.
+
+```typescript
+// In actor.useAction(itemId, actionId, ...params):
+const item = this.items.get(itemId);
+const action = item.system.actions.get(actionId);
+const context: UseActionContext = { actor: this, item, action, itemId, actionId, params };
+
+const cancelled = { value: false };
+const payload = { ...context, cancel: () => { cancelled.value = true; } };
+await this.events.emit('preUseAction', payload);
+if (cancelled.value) return; // Action aborted — budget not consumed
+
+// ... execute the action
+const result = await action.execute(context);
+
+await this.events.emit('postUseAction', { ...context, result });
+```
+
+---
+
+## TODO (Stub — to flesh out at phase-start)
+
+This phase is a stub. Full spec to be written when Phase 9 planning begins.
+
+**Event infrastructure:**
+- [ ] Define `UseActionContext` interface
+- [ ] Define `PreUseActionPayload`, `PostUseActionPayload`, `DealDamagePayload` typed interfaces
+- [ ] Register `preUseAction`, `postUseAction`, `dealDamage` in `wellKnownEvents` at system init
+
+**Basic combat loop:**
+- [ ] ...attack action wiring...
+- [ ] ...D20Roll with FormulaFamiliar `#self.bab` + `#self.abilities.str.mod` context...
+- [ ] ...hit/miss determination against target AC...
+- [ ] ...damage roll → `applyDamage()` → `takeDamage` event cascade...
+- [ ] ...basic chat card for attack result...
+
+**Explore-at-phase-start:**
+- [ ] How much of alpha.3's `ActionDataModel` do we need here vs. a lighter stub?
+- [ ] Does poc.9 define `ActionResult` or stub it as `unknown`?

--- a/docs/migration-plan/poc/phase-10-basic-combat.md
+++ b/docs/migration-plan/poc/phase-10-basic-combat.md
@@ -1,6 +1,6 @@
-# POC Phase 10: Basic Combat Stub
+# POC Phase 10: Basic Combat
 
-**Status**: 📄 Stub
+**Status**: 📋 Planned
 
 > **Milestone**: POC  
 > **Dependencies**: poc.6, poc.7, poc.9  
@@ -8,45 +8,427 @@
 
 ---
 
-## Overview
+## Table of Contents
 
-Phase 9 is the POC-level proof that a combat exchange works end-to-end. It sits between the actor/roll foundation (poc.6/poc.7) and the full Action System (alpha.3), proving the minimal loop before committing to the full architecture.
+1. [Overview & Scope](#overview--scope)
+2. [CombatantDnd35e & Action Economy](#combatantdnd35e--action-economy)
+3. [Initiative & Combat Tracker](#initiative--combat-tracker)
+4. [ActionDataModel — First Cut](#actiondatamodel--first-cut)
+5. [Default Weapon Actions](#default-weapon-actions)
+6. [SIZE_REACH & Target Validation](#size_reach--target-validation)
+7. [Movement Budget Hook](#movement-budget-hook)
+8. [Action Execution Engine](#action-execution-engine)
+9. [Chat Card](#chat-card)
+10. [Sheet & Canvas Triggers](#sheet--canvas-triggers)
+11. [Open Decisions](#open-decisions)
+12. [Stories & Completion Checklist](#stories--completion-checklist)
 
-**What Phase 6 already provides:**
+---
+
+## Overview & Scope
+
+Phase 10 is the POC-level proof that a combat exchange works end-to-end. It sits between the actor/roll foundation (poc.6/poc.7) and the full Action System (alpha.3), proving the minimal loop before committing to the full architecture.
+
+### What Phase 6 already provides
 - Actor HP, `DocumentEventEmitter`, `takeDamage`/`dying`/`death` event cascade
 - `wellKnownEvents` registry and `registerEventType()` infrastructure
 - `destroyed` cascade on item HP
 
-**What Phase 9 adds:**
-- `UseActionContext` interface and action event payload interfaces
-- `preUseAction`/`postUseAction`/`dealDamage` domain events wired and emitted
-- A minimal "roll to hit → apply damage" flow through the actor
-- Basic chat card showing attack result
+### What Phase 7 already provides
+- `D20Roll` and `DamageRoll` custom roll classes
+- `ActorRollData` / `ItemRollData` shapes
+- `FormulaFamiliar` resolve pipeline (`#self.*`, `@attr` bridge)
+- `getRollData()` derived from schema metadata
 
-This deliberately stops short of the full action system. Alpha.3 builds the complete `ActionDataModel`, execution engine, and combat maneuvers on top of this foundation.
+### What Phase 9 already provides
+- `TokenDocumentDnd35e` real class with `_preCreate()` size defaults
+- `SIZE_TOKEN_DIMENSIONS` constant
+- 5-mode movement speed fields on the actor sheet (`walk`, `fly`, `swim`, `burrow`, `climb`)
+- `_getAnimationMovementSpeed()` override on `TokenDnd35e`
+
+### What Phase 10 adds
+- `CombatantDnd35e` with `system.actions` tracking (standard, move)
+- Initiative formula wired to `system.attributes.init.total`
+- Combat tracker rows show action icon pips (S/M); pips reset on turn start
+- `ActionDataModel` first cut: attack + damage + chain (scoped to single melee attack)
+- Default weapon actions seeded on weapon `_onCreate()`
+- `SIZE_REACH` constant: size → reach in feet
+- Movement budget hook (`preUpdateToken`): token drag → distance → action consumed
+- `UseActionContext`, `preUseAction` / `postUseAction` / `dealDamage` domain events
+- `useAction()` execution engine on `ActorDnd35e`
+- D20Roll vs target AC → hit/miss → chain → DamageRoll → `takeDamage()`
+- Chat card: attack result with roll details
+- Two attack triggers: weapon row button on character sheet + canvas right-click menu
+
+### Scope boundaries — deliberately excluded
+| Feature | Deferred to |
+|---------|-------------|
+| Iterative attacks / full attack action | alpha.3 |
+| Ranged attacks | alpha.3 |
+| Two-weapon fighting | alpha.3 |
+| Swift/free/immediate actions | alpha.3 |
+| Attacks of Opportunity | alpha.3 |
+| Progressive full-attack BG3 flow | alpha.3 |
+| Token HUD action palette | alpha.3 |
+| Combat maneuvers (trip, grapple, bull rush) | alpha.3 |
+| Spell attacks | alpha.11 |
 
 ---
 
-## Action Events
+## §10.1 CombatantDnd35e & Action Economy
 
-### Actor Events
+### CombatantSystemModel schema
+
+```typescript
+// src/documents/combat/combatant/CombatantSystemModel.mts
+class CombatantSystemModel extends foundry.abstract.TypeDataModel {
+  static defineSchema() {
+    return {
+      actions: new foundry.data.fields.SchemaField({
+        standard: new foundry.data.fields.BooleanField({ initial: true,
+          label: 'DND35E.COMBAT.ACTIONS.standard' }),
+        move: new foundry.data.fields.BooleanField({ initial: true,
+          label: 'DND35E.COMBAT.ACTIONS.move' }),
+        // swift deferred to alpha.3
+      }),
+    };
+  }
+}
+```
+
+### CombatantDnd35e class
+
+```typescript
+// src/documents/combat/combatant/CombatantDnd35e.mts
+class CombatantDnd35e extends foundry.documents.BaseCombatant {
+  declare system: CombatantSystemModel;
+
+  /** Reset action slots at the start of this combatant's turn. */
+  async resetActions(): Promise<void> {
+    await this.update({ 'system.actions.standard': true, 'system.actions.move': true });
+  }
+}
+```
+
+Register: `CONFIG.Combatant.documentClass = CombatantDnd35e`
+
+### Turn-start reset hook
+
+```typescript
+// src/hooks/onUpdateCombat.mts
+Hooks.on('updateCombat', async (combat: CombatDnd35e, diff: object) => {
+  if (!('turn' in diff)) return;
+  const combatant = combat.combatant;
+  if (!combatant) return;
+  await combatant.resetActions();
+});
+```
+
+### Action consumption
+
+When the execution engine or movement hook consumes an action, it updates the combatant directly:
+
+```typescript
+// Consume standard action
+await combat.combatant?.update({ 'system.actions.standard': false });
+// Consume move action
+await combat.combatant?.update({ 'system.actions.move': false });
+```
+
+---
+
+## §10.2 Initiative & Combat Tracker
+
+### Initiative formula
+
+```typescript
+// src/constants/combat.mts (or CONFIG setup in main.mts)
+CONFIG.Combat.initiative = {
+  formula: '1d20 + @attributes.init.total',
+  decimals: 2,
+};
+```
+
+`@attributes.init.total` resolves via `actor.getRollData()` from the actor's initiative total (computed in poc.6).
+
+### Combat tracker action pips
+
+The default `CombatTracker` template is extended to show action state for each combatant row. Two icon pips appear to the right of the initiative value:
+
+- **S** (swords icon) — standard action remaining; greyed when `system.actions.standard === false`
+- **M** (boot icon) — move action remaining; greyed when `system.actions.move === false`
+
+Implementation: Subclass `CombatTracker` (or use a template override) to inject pip HTML. Register: `CONFIG.ui.combat = CombatTrackerDnd35e`.
+
+The exact Foundry v14 template extension API (subclass vs template partial vs `renderCombatTracker` hook) should be evaluated at phase start. **Fallback**: use the `renderCombatTracker` Foundry hook to inject the pips via DOM manipulation if subclassing proves unwieldy.
+
+---
+
+## §10.3 ActionDataModel — First Cut
+
+Actions are **embedded DataModel instances** within an item's system data — not separate Foundry Documents.
+
+### ActionDataModel schema
+
+```typescript
+// src/documents/items/action/ActionDataModel.mts
+class ActionDataModel extends foundry.abstract.DataModel {
+  static defineSchema() {
+    return {
+      id: new foundry.data.fields.StringField({ required: true, blank: false }),
+      name: new foundry.data.fields.StringField({ required: true, blank: false }),
+      type: new foundry.data.fields.StringField({
+        // poc.10: attack only. Alpha.3 adds: check, save, damage, heal, effect, utility
+        choices: ['attack'],
+        initial: 'attack',
+      }),
+      activation: new foundry.data.fields.StringField({
+        // poc.10: standard/move. Alpha.3 adds: swift, free, fullRound, immediate, passive, aoo
+        choices: ['standard', 'move'],
+        initial: 'standard',
+      }),
+
+      // Attack check (used when type === 'attack')
+      check: new foundry.data.fields.SchemaField({
+        formula: new FormulaField({
+          label: 'DND35E.ACTION.checkFormula',
+          // Default: "1d20 + #self.attributes.bab.total + #self.abilities.str.mod"
+        }),
+        against: new foundry.data.fields.StringField({
+          choices: ['ac', 'touchAc', 'flatFootedAc'],
+          initial: 'ac',
+        }),
+      }, { required: false, nullable: true, initial: null }),
+
+      // Damage roll (triggered on hit via chain)
+      damage: new foundry.data.fields.SchemaField({
+        formula: new FormulaField({
+          label: 'DND35E.ACTION.damageFormula',
+          // Default filled from weapon's damage die + #self.abilities.str.mod
+        }),
+        type: new foundry.data.fields.StringField({
+          label: 'DND35E.ACTION.damageType',
+        }),
+        critRange: new foundry.data.fields.NumberField({ initial: 20, integer: true }),
+        critMultiplier: new foundry.data.fields.NumberField({ initial: 2, integer: true }),
+      }, { required: false, nullable: true, initial: null }),
+
+      // Execution chain: what to trigger after this action resolves
+      chain: new foundry.data.fields.ArrayField(
+        new foundry.data.fields.EmbeddedDataField(ActionChainLinkModel)
+      ),
+    };
+  }
+}
+
+class ActionChainLinkModel extends foundry.abstract.DataModel {
+  static defineSchema() {
+    return {
+      trigger: new foundry.data.fields.StringField({
+        choices: ['onSuccess', 'onFailure', 'onCrit', 'onFumble', 'always'],
+      }),
+      actionId: new foundry.data.fields.StringField(),
+      description: new foundry.data.fields.StringField(),
+    };
+  }
+}
+```
+
+> **Alpha.3 extension note**: Alpha.3 adds `save`, `heal`, `effect`, `utility` action types; `swift`/`free`/`immediate`/`aoo` activations; `effect` block; `provokesAoO`; healing block; `onKill`/`onChoice` chain triggers; full execution state machine; progressive full-attack flow.
+
+### FormulaFamiliar contexts
+
+The `check.formula` and `damage.formula` fields declare the following FormulaFamiliar contexts:
+
+```typescript
+const actionFormulaContexts: FormulaContext[] = [
+  {
+    contextName: 'Actor',
+    resolvePath: 'parent.parent',   // ActionDataModel → Item → Actor
+    documentType: 'Actor',
+    aliases: ['self'],
+    // Exposes: #self.abilities.str.mod, #self.attributes.bab.total, etc.
+  },
+  {
+    contextName: 'Item',
+    resolvePath: 'parent',
+    documentType: 'Item',
+    aliases: ['item', 'weapon'],
+    // Exposes: #item.enhancement, #item.damage, etc.
+  },
+  {
+    contextName: 'Target',
+    resolvePath: 'runtime',         // Resolved at execution time
+    documentType: 'Actor',
+    aliases: [],
+    // Exposes: #target.attributes.ac.normal, #target.attributes.ac.touch, etc.
+  },
+];
+```
+
+### Embedding actions in WeaponSystemModel
+
+```typescript
+// In WeaponSystemModel.defineSchema()
+actions: new foundry.data.fields.ArrayField(
+  new foundry.data.fields.EmbeddedDataField(ActionDataModel),
+  { label: 'DND35E.ITEM.actions' }
+),
+```
+
+---
+
+## §10.4 Default Weapon Actions
+
+When a weapon item is created, `_onCreate()` seeds a default attack action:
+
+```typescript
+// In WeaponDnd35e._onCreate()
+protected override async _onCreate(data: object, options: object, userId: string): Promise<void> {
+  await super._onCreate(data, options, userId);
+  if (game.userId !== userId) return;
+
+  const defaultActions: Partial<ActionDataModel>[] = [{
+    id: foundry.utils.randomID(),
+    name: game.i18n.localize('DND35E.ACTION.defaultAttackName'),  // "Attack"
+    type: 'attack',
+    activation: 'standard',
+    check: {
+      formula: '1d20 + #self.attributes.bab.total + #self.abilities.str.mod',
+      against: 'ac',
+    },
+    damage: {
+      formula: this.system.damage.formula ?? '1d4',  // use weapon's damage formula
+      type: this.system.damage.type ?? 'bludgeoning',
+      critRange: 20,
+      critMultiplier: 2,
+    },
+    chain: [
+      { trigger: 'onSuccess', actionId: 'damage', description: 'On hit, roll damage' },
+    ],
+  }];
+
+  await this.update({ 'system.actions': defaultActions });
+}
+```
+
+> **Note**: The `damage` chain reference (`actionId: 'damage'`) is resolved by the execution engine via the action's own `damage` block rather than a separate action lookup. Clarify and finalize during implementation.
+
+---
+
+## §10.5 SIZE_REACH & Target Validation
+
+### Constant
+
+```typescript
+// src/constants/sizes.mts — alongside SIZE_TOKEN_DIMENSIONS
+export const SIZE_REACH: Record<Size, number> = {
+  fine:       0,   // no reach, can't threaten
+  diminutive: 0,
+  tiny:       0,
+  small:      5,
+  medium:     5,
+  large:      10,
+  huge:       15,
+  gargantuan: 15,
+  colossal:   20,
+};
+```
+
+Values are in feet (5ft grid). Based on D&D 3.5e SRD Table 8-4.
+
+### Target validation
+
+Before executing an attack action, the execution engine validates that the target is within reach:
+
+```typescript
+function isWithinReach(attacker: TokenDnd35e, target: TokenDnd35e, reach: number): boolean {
+  const distance = canvas.grid.measurePath([attacker.center, target.center]).distance;
+  return distance <= reach;
+}
+```
+
+---
+
+## §10.6 Movement Budget Hook
+
+Token drag → distance check → action consumption. This is new territory; the exact Foundry v14 hook API should be verified at phase start.
+
+### Expected design
+
+```typescript
+// src/hooks/onPreUpdateToken.mts
+Hooks.on('preUpdateToken', (tokenDoc: TokenDocumentDnd35e, diff: object, options: object) => {
+  if (!('x' in diff || 'y' in diff)) return;
+  if (!canvas.scene?.active) return;
+  const combat = game.combat;
+  if (!combat?.started) return;  // only enforce during active combat
+
+  const combatant = combat.getCombatantByToken(tokenDoc.id);
+  if (!combatant) return;
+
+  const currentPos = { x: tokenDoc.x, y: tokenDoc.y };
+  const newPos = { x: diff.x ?? tokenDoc.x, y: diff.y ?? tokenDoc.y };
+  const distance = canvas.grid.measurePath([currentPos, newPos]).distance;  // feet
+  const speed = combatant.actor?.system.movement.walk ?? 30;
+  const actions = combatant.system.actions;
+
+  if (distance <= speed) {
+    if (!actions.move) { ui.notifications.warn('No move action remaining.'); return false; }
+  } else if (distance <= speed * 2) {
+    if (!actions.move || !actions.standard) {
+      ui.notifications.warn('Insufficient actions for double move.'); return false;
+    }
+  } else {
+    ui.notifications.warn('Cannot move that far this turn.'); return false;
+  }
+});
+```
+
+Action consumption fires on `updateToken` after the position change is committed.
+
+> **Open decision at phase start**: Does Foundry v14's `preUpdateToken` allow returning `false` to cancel? Verify `TokenDocument._preUpdate()` signature. Fallback: allow the move, flag overage warning on combatant.
+
+---
+
+## §10.7 Action Execution Engine
+
+### UseActionContext & events
+
+These were deferred from poc.6 §5.9. They are registered here.
+
+```typescript
+// Register at system init
+registerEventType('preUseAction');
+registerEventType('postUseAction');
+registerEventType('dealDamage');
+```
+
+Event payloads:
 
 | Event | Payload | Emitted when | Example use case |
 |-------|---------|-------------|----------------|
-| `preUseAction` | `UseActionContext & { cancel: () => void }` | Before action executes — `cancel()` aborts | Silence, exhaustion, curse gates |
+| `preUseAction` | `UseActionContext & { cancel: () => void }` | Before action executes | Silence, exhaustion, curse gates |
 | `postUseAction` | `UseActionContext & { result: ActionResult }` | After action completes | Resource tracking, backlash effects |
-| `dealDamage` | `{ amount: number, damageType: string, target: ActorDnd35e, context?: UseActionContext }` | Actor deals damage to another | Cleave trigger, life-drain |
-
-### UseActionContext
+| `dealDamage` | `{ amount: number; damageType: string; target: ActorDnd35e; context?: UseActionContext }` | Actor deals damage to another | Cleave trigger, life-drain |
 
 ```typescript
 interface UseActionContext {
-  actor: ActorDnd35e;      // The actor executing the action
-  item: ItemDnd35e;        // Item that declared the action
-  action: ActionDataModel; // Resolved action data model
+  actor: ActorDnd35e;
+  item: ItemDnd35e;
+  action: ActionDataModel;
   itemId: string;
   actionId: string;
   params: unknown[];
+}
+
+interface ActionResult {
+  hit: boolean;
+  criticalHit: boolean;
+  attackTotal?: number;
+  targetAc?: number;
+  damageDealt?: number;
+  cancelled: boolean;
 }
 ```
 
@@ -55,29 +437,298 @@ interface UseActionContext {
 `preUseAction` merges `cancel: () => void` into the context. Any subscriber calling `cancel()` aborts execution before the action budget is consumed. Multiple calls are idempotent.
 
 ```typescript
-// In actor.useAction(itemId, actionId, ...params):
-const item = this.items.get(itemId);
-const action = item.system.actions.get(actionId);
-const context: UseActionContext = { actor: this, item, action, itemId, actionId, params };
-
 const cancelled = { value: false };
-const payload = { ...context, cancel: () => { cancelled.value = true; } };
-await this.events.emit('preUseAction', payload);
-if (cancelled.value) return; // Action aborted — budget not consumed
+await this.events.emit('preUseAction', { ...context, cancel: () => { cancelled.value = true; } });
+if (cancelled.value) return { hit: false, criticalHit: false, cancelled: true };
+```
 
-// ... execute the action
-const result = await action.execute(context);
+### useAction() on ActorDnd35e
 
-await this.events.emit('postUseAction', { ...context, result });
+```typescript
+async useAction(itemId: string, actionId: string, targetId?: string): Promise<ActionResult | null> {
+  const item = this.items.get(itemId);
+  const action = item.system.actions?.find((a: ActionDataModel) => a.id === actionId);
+  const context: UseActionContext = { actor: this, item, action, itemId, actionId, params: [targetId] };
+
+  // preUseAction — allow cancellation
+  let cancelled = false;
+  await this.events.emit('preUseAction', { ...context, cancel: () => { cancelled = true; } });
+  if (cancelled) return { hit: false, criticalHit: false, cancelled: true };
+
+  // Validate action economy (during active combat only)
+  const combat = game.combat;
+  const combatant = combat?.getCombatantByActor(this.id);
+  if (combat?.started && combatant) {
+    const actions = combatant.system.actions;
+    if (action.activation === 'standard' && !actions.standard) {
+      ui.notifications.warn(game.i18n.localize('DND35E.COMBAT.noStandardAction'));
+      return null;
+    }
+  }
+
+  const result = await this._executeAttackAction(context, targetId);
+
+  // Consume action slot
+  if (combat?.started && combatant && !result.cancelled) {
+    await combatant.update({ 'system.actions.standard': false });
+  }
+
+  await this.events.emit('postUseAction', { ...context, result });
+  return result;
+}
+```
+
+### _executeAttackAction()
+
+```typescript
+private async _executeAttackAction(context: UseActionContext, targetId?: string): Promise<ActionResult> {
+  const { actor, item, action } = context;
+  const target = targetId ? (game.actors?.get(targetId) ?? null) : null;
+  const targetToken = canvas.tokens?.placeables.find(t => t.actor?.id === targetId) ?? null;
+  const attackerToken = canvas.tokens?.placeables.find(t => t.actor?.id === actor.id) ?? null;
+
+  // Reach validation
+  if (attackerToken && targetToken) {
+    const reach = SIZE_REACH[actor.system.details.size as Size] ?? 5;
+    if (!isWithinReach(attackerToken, targetToken, reach)) {
+      ui.notifications.warn(game.i18n.localize('DND35E.COMBAT.targetOutOfReach'));
+      return { hit: false, criticalHit: false, cancelled: false };
+    }
+  }
+
+  // Attack roll
+  const rollData = { ...actor.getRollData(), target: target?.getRollData() ?? {} };
+  const attackRoll = await new D20Roll(action.check?.formula ?? '1d20', rollData).evaluate();
+  const targetAc = target?.system.attributes.ac[action.check?.against ?? 'normal'] ?? 10;
+  const hit = attackRoll.total >= targetAc;
+  const criticalHit = attackRoll.isCrit && hit;
+
+  // Deal damage on hit
+  let damageDealt = 0;
+  if (hit && action.damage && target) {
+    const damageRoll = await new DamageRoll(
+      action.damage.formula,
+      rollData,
+      { critical: criticalHit, critMultiplier: action.damage.critMultiplier }
+    ).evaluate();
+    damageDealt = damageRoll.total;
+
+    await this.events.emit('dealDamage', { amount: damageDealt, damageType: action.damage.type, target, context });
+    await target.takeDamage(damageDealt, { damageType: action.damage.type, source: actor });
+  }
+
+  const result: ActionResult = { hit, criticalHit, attackTotal: attackRoll.total, targetAc, damageDealt, cancelled: false };
+  await createAttackChatCard(context, attackRoll, result, target);
+  return result;
+}
 ```
 
 ---
 
-## TODO (Stub — to flesh out at phase-start)
+## §10.8 Chat Card
 
-This phase is a stub. Full spec to be written when Phase 9 planning begins.
+A chat card is created for each attack, hit or miss.
 
-**Event infrastructure:**
+**Card content:**
+- Attacker name + weapon name
+- Attack roll: formula + dice result + total
+- Hit/miss indicator (vs target AC)
+- Damage roll + total (if hit)
+- Crit indicator (if critical hit)
+
+```typescript
+// src/documents/actors/baseActor/attack/createAttackChatCard.mts
+export async function createAttackChatCard(
+  context: UseActionContext,
+  attackRoll: D20Roll,
+  result: ActionResult,
+  target: ActorDnd35e | null
+): Promise<void> {
+  const html = await renderTemplate('systems/dnd35e/templates/chat/attack-card.hbs', {
+    actorName: context.actor.name,
+    weaponName: context.item.name,
+    attackRoll,
+    result,
+    targetName: target?.name ?? null,
+  });
+
+  await ChatMessage.create({
+    content: html,
+    rolls: [attackRoll],
+    speaker: ChatMessage.getSpeaker({ actor: context.actor }),
+  });
+}
+```
+
+Template: `src/templates/chat/attack-card.hbs`
+
+---
+
+## §10.9 Sheet & Canvas Triggers
+
+### Sheet trigger
+
+Each weapon row on the character sheet shows an attack button:
+
+```vue
+<button type="button" class="field-control-btn" @click="onAttack(weapon.id)">
+  <i class="fas fa-sword" />
+</button>
+```
+
+```typescript
+async function onAttack(itemId: string): Promise<void> {
+  const targetToken = game.user?.targets?.first() ?? null;
+  if (!targetToken && game.combat?.started) {
+    ui.notifications.warn(game.i18n.localize('DND35E.COMBAT.selectTargetFirst'));
+    return;
+  }
+  const defaultAction = store.actor.items.get(itemId)?.system.actions?.[0];
+  if (!defaultAction) return;
+  await store.actor.useAction(itemId, defaultAction.id, targetToken?.actor?.id);
+}
+```
+
+### Canvas right-click trigger
+
+When a player right-clicks their own controlled token, an "Attack with..." submenu lists equipped weapons with attack actions. Selecting one triggers `actor.useAction()` with the currently targeted token.
+
+> **Open decision at phase start**: Exact Foundry v14 API for canvas token context menu. Candidates: (a) override `Token._getContextMenuOptions()`, (b) `getTokenContextOptions` hook, (c) extend `TokenHUD`. Verify which is available and idiomatic in v14.
+
+---
+
+## §10.10 Open Decisions
+
+| # | Decision | Fallback |
+|---|----------|----------|
+| 1 | Canvas right-click API (`Token._getContextMenuOptions()` vs `getTokenContextOptions` hook vs `TokenHUD`) | Sheet-only attack until resolved; canvas trigger deferred to Story 5 |
+| 2 | `preUpdateToken` cancellation: does `return false` prevent the move in v14? | Allow move, emit warning, flag overage on combatant |
+| 3 | Combat tracker extension: subclass `CombatTracker` vs `renderCombatTracker` hook | Use hook + DOM injection |
+| 4 | Chain resolution: does `actionId: 'damage'` look up a separate action or is it resolved from `action.damage` directly? | Infer from `action.damage` block directly in poc.10; full chain lookup in alpha.3 |
+
+---
+
+## §10.11 Files to Create / Modify
+
+### New files
+| File | Description |
+|------|-------------|
+| `src/documents/combat/combatant/CombatantDnd35e.mts` | Custom Combatant class |
+| `src/documents/combat/combatant/CombatantSystemModel.mts` | `system.actions` DataModel |
+| `src/documents/items/action/ActionDataModel.mts` | ActionDataModel + ActionChainLinkModel |
+| `src/hooks/onUpdateCombat.mts` | Turn-start action reset hook |
+| `src/hooks/onPreUpdateToken.mts` | Movement budget validation hook |
+| `src/hooks/onUpdateToken.mts` | Movement action consumption hook |
+| `src/documents/actors/baseActor/attack/createAttackChatCard.mts` | Chat card factory |
+| `src/templates/chat/attack-card.hbs` | Attack result Handlebars template |
+
+### Modified files
+| File | Change |
+|------|--------|
+| `src/constants/sizes.mts` | Add `SIZE_REACH` constant |
+| `src/documents/actors/baseActor/ActorDnd35e.mts` | Add `useAction()` + `_executeAttackAction()` |
+| `src/documents/items/weapon/WeaponSystemModel.mts` | Add `actions` field |
+| `src/documents/items/weapon/WeaponDnd35e.mts` | Add `_onCreate()` to seed default attack action |
+| `src/vue/sheets/actor/character/CharacterSheet.vue` | Add attack button to weapon row |
+| `src/canvas/token/TokenDnd35e.mts` | Register canvas right-click attack submenu |
+| `src/main.mts` (or init) | Register `CombatantDnd35e`, initiative formula, event types, tracker |
+
+---
+
+## §10.12 Stories & Completion Checklist
+
+### Story 1 — Combat tracker with initiative
+**User**: GM / Player  
+**Delivers**: "Start combat → see token order by initiative; action pips show S/M remaining; pips reset on turn start"  
+**Routing**: Lead dev (CombatantDnd35e) + Jr dev (initiative formula, hook, pip template)
+
+- [ ] Create `CombatantSystemModel` with `actions.standard` + `actions.move` boolean fields
+- [ ] Create `CombatantDnd35e` extending `Combatant`; add `resetActions()` method
+- [ ] Register `CONFIG.Combatant.documentClass = CombatantDnd35e` in system init
+- [ ] Wire initiative formula: `'1d20 + @attributes.init.total'`
+- [ ] `updateCombat` hook: call `combatant.resetActions()` on turn advance
+- [ ] Extend combat tracker rendering: S/M pips per row, greyed when action unavailable
+
+**Verify**: Roll initiative → combatants ordered. Advance turn → pips reset. Use attack → S greys.
+
+---
+
+### Story 2 — ActionDataModel first cut
+**User**: Developer / GM authoring weapons  
+**Delivers**: "Weapon has a default Attack action with formula; formula autocomplete resolves `#self.attributes.bab.total`"  
+**Routing**: Lead dev (schema, contexts) + Jr dev (weapon `_onCreate`, action display)
+
+- [ ] Create `ActionChainLinkModel` schema
+- [ ] Create `ActionDataModel` schema (attack type: `check`, `damage`, `chain`, `activation`)
+- [ ] Add `actions` field (array) to `WeaponSystemModel`
+- [ ] Attach FormulaFamiliar contexts to `check.formula` and `damage.formula`
+- [ ] Implement `WeaponDnd35e._onCreate()` to seed default attack action
+- [ ] Display action list on weapon sheet (read-only for poc.10)
+
+**Verify**: Create weapon → `system.actions[0]` is an attack action with correct formulas. FormulaFamiliar autocomplete includes `#self.abilities.str.mod`.
+
+---
+
+### Story 3 — Move action on canvas
+**User**: Player (during combat)  
+**Delivers**: "Drag token ≤ speed → [M] consumed; drag > speed ≤ 2× speed → [S][M] consumed; drag beyond → blocked"  
+**Routing**: Lead dev (movement hook) + Jr dev (SIZE_REACH constant, tracker update)
+
+- [ ] Add `SIZE_REACH` constant to `src/constants/sizes.mts`
+- [ ] Implement `preUpdateToken` hook: distance calc, validate against speed budget, cancel if over-budget
+- [ ] Double-move logic: spend standard as extra move action
+- [ ] `updateToken` hook: consume appropriate action slots on combatant after move commits
+- [ ] Tracker row reflects consumed pips after token moves
+
+**Verify**: Move token ≤ speed → [M] consumed. Move > speed ≤ 2× → [S][M] consumed. Move > 2× → blocked with warning.
+
+---
+
+### Story 4 — Melee attack + chat card
+**User**: Player (during combat, from character sheet)  
+**Delivers**: "Click attack on weapon row → target selected → d20 rolled → hit/miss + damage in chat → [S] consumed"  
+**Routing**: Lead dev (execution engine, events) + Jr dev (chat template, sheet button)
+
+- [ ] Register `preUseAction`, `postUseAction`, `dealDamage` in `wellKnownEvents`
+- [ ] Define `UseActionContext` and `ActionResult` interfaces
+- [ ] Implement `actor.useAction()` with `preUseAction` cancellation pattern
+- [ ] Implement `_executeAttackAction()`: reach check, D20Roll vs target AC, hit/miss
+- [ ] Damage roll on hit → `dealDamage` event → `target.takeDamage()`
+- [ ] `postUseAction` emitted with result; standard action slot consumed
+- [ ] Create `createAttackChatCard()` factory + `attack-card.hbs` template
+- [ ] Add attack button to weapon row on character sheet
+- [ ] Wire sheet button to `actor.useAction()` with targeted actor ID
+
+**Verify**: In combat, target a token, click attack on weapon row → chat card appears with roll result and hit/miss/damage → [S] pip greys in tracker.
+
+---
+
+### Story 5 — Canvas right-click attack trigger
+**User**: Player (on canvas)  
+**Delivers**: "Right-click own token → 'Attack with...' submenu lists equipped weapons → triggers same attack flow"  
+**Routing**: Lead dev (context menu API exploration + wiring)
+
+- [ ] Explore at phase start: identify Foundry v14 API for canvas token context menu entries
+- [ ] Register "Attack with..." submenu entries listing equipped weapons
+- [ ] Wire to `actor.useAction(itemId, defaultActionId, targetId)` — same path as Story 4
+
+**Verify**: Right-click controlled token in combat → submenu shows equipped weapons → selecting one triggers attack identically to sheet trigger.
+
+---
+
+### Parallelization
+
+```
+Story 1 (Combat tracker)     ──────────────────────►  Story 3 (Move action)
+                                                              │
+Story 2 (ActionDataModel)    ──────────────────────►         ▼
+                                                       Story 4 (Melee attack)
+                                                              │
+                                                              ▼
+                                                       Story 5 (Canvas trigger)
+```
+
+Stories 1 and 2 can begin simultaneously. Story 3 depends on Story 1 (needs `CombatantDnd35e` action tracking). Story 4 depends on all three prior stories. Story 5 depends on Story 4.
 - [ ] Define `UseActionContext` interface
 - [ ] Define `PreUseActionPayload`, `PostUseActionPayload`, `DealDamagePayload` typed interfaces
 - [ ] Register `preUseAction`, `postUseAction`, `dealDamage` in `wellKnownEvents` at system init

--- a/docs/migration-plan/poc/phase-10-basic-combat.md
+++ b/docs/migration-plan/poc/phase-10-basic-combat.md
@@ -1,6 +1,6 @@
 # POC Phase 10: Basic Combat
 
-**Status**: 📋 Planned
+**Status**: 📝 Planned
 
 > **Milestone**: POC  
 > **Dependencies**: poc.6, poc.7, poc.9  

--- a/docs/migration-plan/poc/refactor-naming-conventions.md
+++ b/docs/migration-plan/poc/refactor-naming-conventions.md
@@ -20,7 +20,7 @@ Foundry's own vocabulary calls these things **documents**: `Document` is the roo
 4. **Drop the `Base` marker** where it only restates `abstract class`. Keep it when it's the most accurate descriptor *and* avoids a `Dnd35e` collision suffix.
 5. **File-name casing rule** (PascalCase / camelCase / lowercase) aligned with JS/TS community standards, applied repo-wide.
 6. **Folder-name casing**: camelCase when the folder groups multiple files (`baseItem/`, `formGroups/`); PascalCase only when the folder is dedicated to a single same-named export (`TabDivider/TabDivider.vue`). Full file-casing rule lives in §R.2.9.
-7. **Co-locate code with its purpose**, not its incidental neighbours. Custom `DataField` subclasses (`PriceField`, `PriceData`, `SectionField`) live in top-level `src/fields/` — they're schema primitives, not utility helpers. Settings-only files live under `settings/<category>/`.
+7. **Co-locate code with its purpose**, not its incidental neighbours. Custom `DataField` subclasses (`CurrencyField`, `CurrencyData`, `SectionField`) live in top-level `src/fields/` — they're schema primitives, not utility helpers. Settings-only files live under `settings/<category>/`.
 8. **Tab `.vue` naming**. `documents/items/baseItem/sheet/tabs/Effects.vue` → `ItemEffects.vue` for parity with the `<ConceptType><TabPurpose>` convention all other tab files already follow.
 
 ### In-scope, multi-wave
@@ -62,7 +62,7 @@ These rules are the target state. The checklist in §R.5 enforces them.
 src/
   canvas/                ← runtime placeables (Canvas, Token, Region — NOT documents)
   constants/             ← system-wide constants and CONFIG.dnd35e shape
-  fields/                ← custom DataField subclasses + factories (PriceField, SectionField, fieldBuilders)
+  fields/                ← custom DataField subclasses + factories (CurrencyField, SectionField, fieldBuilders)
   documents/             ← all Foundry documents (was entities/ + scene/)
     document/            ← cross-document base (was entities/components/CoreMixin/)
     identifiable/        ← cross-document mixin (was entities/components/Identifiable/)

--- a/docs/migration-plan/post-release/WISHLIST.md
+++ b/docs/migration-plan/post-release/WISHLIST.md
@@ -29,6 +29,14 @@ Allow negative currency counts in `CurrencyField` to represent debts. A "negativ
 
 ## Actor System
 
+### Silhouette Equipment UI
+
+A character body silhouette with clickable slot regions for equipment management. Players click a slot on the body outline to equip/unequip items directly, providing a visual, tactile inventory UX in place of a flat dropdown list.
+
+Scope: armor/gear slots (head, face, neck, shoulders, chest, abdomen, hands, waist, legs, feet, rings) displayed on a character silhouette graphic; weapon slots (mainhand/offhand) shown separately. Requires SVG or canvas overlay with hit-testing per slot region. Foundation slot system is in Phase 6 (poc.6) — this is a purely visual enhancement on top.
+
+---
+
 ### Object actor ↔ physical item linkage
 An Object actor (doors, walls, chests) is the actor representation of a physical item in the world. Long-term, these should be linkable: an Object actor could reference an item from its own inventory to drive its stats (HP, hardness, breakDC) — so a "reinforced oak door" item defines the stats, and the actor is just the live instance. Traps follow the same model (a trap actor references the trap device item for its mechanics).
 

--- a/docs/migration-plan/post-release/WISHLIST.md
+++ b/docs/migration-plan/post-release/WISHLIST.md
@@ -19,3 +19,17 @@ Approaches to evaluate:
 Affects: `packs/_source/documentation/`, SRD import pipeline.
 
 ---
+
+## Currency & Vaults
+
+### Debt tracking
+Allow negative currency counts in `CurrencyField` to represent debts. A "negative coin" balance means the character owes that amount. Requires UI treatment (visual distinction for negatives, debt summary).
+
+---
+
+## Actor System
+
+### Object actor ↔ physical item linkage
+An Object actor (doors, walls, chests) is the actor representation of a physical item in the world. Long-term, these should be linkable: an Object actor could reference an item from its own inventory to drive its stats (HP, hardness, breakDC) — so a "reinforced oak door" item defines the stats, and the actor is just the live instance. Traps follow the same model (a trap actor references the trap device item for its mechanics).
+
+This avoids stat duplication and lets a chest item and a chest actor share the same stat block. Design is non-trivial — deferred post-release.

--- a/docs/migration-plan/post-release/phase-09-random-treasure.md
+++ b/docs/migration-plan/post-release/phase-09-random-treasure.md
@@ -33,7 +33,7 @@ A GM prepares a compendium of art objects for random treasure. When a player loo
 
 ### How It Works
 
-The `price` field on `PhysicalItemSystemModel` is a `PriceField` (not a `FormulaField`), so price itself doesn't support formulas directly. Instead, the item uses the **`_preCreate` formula resolution** that already exists on `Dnd35eDocumentMixin`:
+The `price` field on `PhysicalItemSystemModel` is a `CurrencyField` (not a `FormulaField`), so price itself doesn't support formulas directly. Instead, the item uses the **`_preCreate` formula resolution** that already exists on `Dnd35eDocumentMixin`:
 
 1. **Compendium source**: The art object's `system.price` is set to a placeholder value (e.g., `0 srd_gp`)
 2. **Price formula field**: Add a `priceFormula: FormulaField` to `PhysicalItemSystemModel` that holds a dice expression like `2d6 * 100`

--- a/docs/migration-plan/roadmap.md
+++ b/docs/migration-plan/roadmap.md
@@ -180,7 +180,7 @@ Dependencies use `wave.N` notation (e.g. `poc.1`, `alpha.3`, `beta.2`).
 | 6 | [Actor Foundation](poc/phase-06-actor-foundation.md) | ✅ Approved | poc.1, poc.3 | Character actor: abilities, AC shell, HP, saves, skills, inventory, tokens, equipment slots |
 | 7 | [Roll Formulas & Custom Rolls](poc/phase-07-roll-formulas.md) | 📋 Outlined | poc.6 | D20Roll, DamageRoll, FormulaFamiliar roll data, formula paths |
 | 8 | [Pipeline & Branching](poc/phase-08-pipeline-and-branching.md) | 🔶 In Progress | — | Branching model, PR gate (`test.yml`), release pipeline (`build.yml`), `phases.json` sync. Independent of POC content; can land any time before POC closes. |
-| 9 | [Basic Tokens](poc/phase-09-basic-tokens.md) | 📄 Stub | poc.6 | Token placed on scene, moved, `token.actor` resolves correctly, size and HP bar wired. Thin proof before poc.10. |
+| 9 | [Basic Tokens](poc/phase-09-basic-tokens.md) | � Planned | poc.6 | Token placed on scene, moved, `token.actor` resolves correctly, size and HP bar wired. Thin proof before poc.10. |
 | 10 | [Basic Combat](poc/phase-10-basic-combat.md) | 📄 Stub | poc.6, poc.7, poc.9 | Combat tracker functional; detects basic move, double move, and main-hand attack. Seeds alpha.3 Action System. |
 
 **Exit criteria**: A Character actor exists on a scene with derived ability scores, saves, HP, and skills. Weapons can be created, identified, and equipped. Material AEs modify item stats with correct stacking. Roll formulas resolve with FormulaFamiliar context. Compendium items can be imported with origin tracking. All strings are localized. Test framework is in place with unit/integration test examples covering poc.1–3.

--- a/docs/migration-plan/roadmap.md
+++ b/docs/migration-plan/roadmap.md
@@ -166,7 +166,7 @@ Dependencies use `wave.N` notation (e.g. `poc.1`, `alpha.3`, `beta.2`).
 
 ### Wave: POC — Proof of Concept
 
-`docs/migration-plan/poc/` | poc.1–poc.8
+`docs/migration-plan/poc/` | poc.1–poc.10
 
 **Goal**: Foundation, data infrastructure, and testing patterns. Every building block exists in isolation before being composed.
 
@@ -177,9 +177,11 @@ Dependencies use `wave.N` notation (e.g. `poc.1`, `alpha.3`, `beta.2`).
 | 3 | [Localization](poc/phase-03-localization.md) | ✅ Complete | — | LOCALIZATION_PREFIXES, lang files, FormGroup auto-labels |
 | 4 | [Testing Infrastructure](poc/phase-04-testing-infrastructure.md) | ✅ Complete | poc.1, poc.2, poc.3 | Vitest, Foundry mocks, coverage tooling — establishes test patterns; back-fills poc.1–3 tests |
 | 5 | [Compendium Foundation](poc/phase-05-compendium-foundation.md) | 🔶 In Progress | poc.1, poc.2, poc.3 | Pack pipeline, origin tracking, UUID helpers, migration version field |
-| 6 | [Actor Foundation](poc/phase-06-actor-foundation.md) | � Planned | poc.1, poc.3 | Character actor: abilities, AC shell, HP, saves, skills, inventory, tokens, equipment slots |
+| 6 | [Actor Foundation](poc/phase-06-actor-foundation.md) | ✅ Approved | poc.1, poc.3 | Character actor: abilities, AC shell, HP, saves, skills, inventory, tokens, equipment slots |
 | 7 | [Roll Formulas & Custom Rolls](poc/phase-07-roll-formulas.md) | 📋 Outlined | poc.6 | D20Roll, DamageRoll, FormulaFamiliar roll data, formula paths |
 | 8 | [Pipeline & Branching](poc/phase-08-pipeline-and-branching.md) | 🔶 In Progress | — | Branching model, PR gate (`test.yml`), release pipeline (`build.yml`), `phases.json` sync. Independent of POC content; can land any time before POC closes. |
+| 9 | [Basic Tokens](poc/phase-09-basic-tokens.md) | 📄 Stub | poc.6 | Token placed on scene, moved, `token.actor` resolves correctly, size and HP bar wired. Thin proof before poc.10. |
+| 10 | [Basic Combat](poc/phase-10-basic-combat.md) | 📄 Stub | poc.6, poc.7, poc.9 | Combat tracker functional; detects basic move, double move, and main-hand attack. Seeds alpha.3 Action System. |
 
 **Exit criteria**: A Character actor exists on a scene with derived ability scores, saves, HP, and skills. Weapons can be created, identified, and equipped. Material AEs modify item stats with correct stacking. Roll formulas resolve with FormulaFamiliar context. Compendium items can be imported with origin tracking. All strings are localized. Test framework is in place with unit/integration test examples covering poc.1–3.
 
@@ -289,6 +291,8 @@ flowchart TD
         P6["poc.6 Actor + Token"]
         P7["poc.7 Roll Formulas"]
         P8["poc.8 Pipeline"]
+        P9["poc.9 Basic Tokens"]
+        P10["poc.10 Basic Combat"]
         P1 --> P2
     end
     P1 --> P4
@@ -298,6 +302,10 @@ flowchart TD
     P2 --> P5
     P3 --> P5
     P1 --> P6
+    P6 --> P9
+    P6 --> P10
+    P7 --> P10
+    P9 --> P10
     P3 --> P6
     P6 --> P7
 

--- a/docs/migration-plan/roadmap.md
+++ b/docs/migration-plan/roadmap.md
@@ -181,7 +181,7 @@ Dependencies use `wave.N` notation (e.g. `poc.1`, `alpha.3`, `beta.2`).
 | 7 | [Roll Formulas & Custom Rolls](poc/phase-07-roll-formulas.md) | 📋 Outlined | poc.6 | D20Roll, DamageRoll, FormulaFamiliar roll data, formula paths |
 | 8 | [Pipeline & Branching](poc/phase-08-pipeline-and-branching.md) | 🔶 In Progress | — | Branching model, PR gate (`test.yml`), release pipeline (`build.yml`), `phases.json` sync. Independent of POC content; can land any time before POC closes. |
 | 9 | [Basic Tokens](poc/phase-09-basic-tokens.md) | � Planned | poc.6 | Token placed on scene, moved, `token.actor` resolves correctly, size and HP bar wired. Thin proof before poc.10. |
-| 10 | [Basic Combat](poc/phase-10-basic-combat.md) | 📄 Stub | poc.6, poc.7, poc.9 | Combat tracker functional; detects basic move, double move, and main-hand attack. Seeds alpha.3 Action System. |
+| 10 | [Basic Combat](poc/phase-10-basic-combat.md) | � Planned | poc.6, poc.7, poc.9 | Combat tracker functional; detects basic move, double move, and main-hand attack. Seeds alpha.3 Action System. |
 
 **Exit criteria**: A Character actor exists on a scene with derived ability scores, saves, HP, and skills. Weapons can be created, identified, and equipped. Material AEs modify item stats with correct stacking. Roll formulas resolve with FormulaFamiliar context. Compendium items can be imported with origin tracking. All strings are localized. Test framework is in place with unit/integration test examples covering poc.1–3.
 

--- a/docs/migration-plan/roadmap.md
+++ b/docs/migration-plan/roadmap.md
@@ -177,13 +177,13 @@ Dependencies use `wave.N` notation (e.g. `poc.1`, `alpha.3`, `beta.2`).
 | 3 | [Localization](poc/phase-03-localization.md) | ✅ Complete | — | LOCALIZATION_PREFIXES, lang files, FormGroup auto-labels |
 | 4 | [Testing Infrastructure](poc/phase-04-testing-infrastructure.md) | ✅ Complete | poc.1, poc.2, poc.3 | Vitest, Foundry mocks, coverage tooling — establishes test patterns; back-fills poc.1–3 tests |
 | 5 | [Compendium Foundation](poc/phase-05-compendium-foundation.md) | 🔶 In Progress | poc.1, poc.2, poc.3 | Pack pipeline, origin tracking, UUID helpers, migration version field |
-| 6 | [Actor Foundation](poc/phase-06-actor-foundation.md) | ✅ Approved | poc.1, poc.3 | Character actor: abilities, AC shell, HP, saves, skills, inventory, tokens, equipment slots |
+| 6 | [Actor Foundation](poc/phase-06-actor-foundation.md) | ✅ Approved | poc.1, poc.3 | Character actor: abilities, AC shell, HP, saves, inventory, tokens, equipment slots |
 | 7 | [Roll Formulas & Custom Rolls](poc/phase-07-roll-formulas.md) | 📋 Outlined | poc.6 | D20Roll, DamageRoll, FormulaFamiliar roll data, formula paths |
 | 8 | [Pipeline & Branching](poc/phase-08-pipeline-and-branching.md) | 🔶 In Progress | — | Branching model, PR gate (`test.yml`), release pipeline (`build.yml`), `phases.json` sync. Independent of POC content; can land any time before POC closes. |
 | 9 | [Basic Tokens](poc/phase-09-basic-tokens.md) | 📝 Planned | poc.6 | Token placed on scene, moved, `token.actor` resolves correctly, size and HP bar wired. Thin proof before poc.10. |
 | 10 | [Basic Combat](poc/phase-10-basic-combat.md) | 📝 Planned | poc.6, poc.7, poc.9 | Combat tracker functional; detects basic move, double move, and main-hand attack. Seeds alpha.3 Action System. |
 
-**Exit criteria**: A Character actor exists on a scene with derived ability scores, saves, HP, and skills. Weapons can be created, identified, and equipped. Material AEs modify item stats with correct stacking. Roll formulas resolve with FormulaFamiliar context. Compendium items can be imported with origin tracking. All strings are localized. Test framework is in place with unit/integration test examples covering poc.1–3.
+**Exit criteria**: A Character actor exists on a scene with derived ability scores, saves, and HP. Weapons can be created, identified, and equipped. Material AEs modify item stats with correct stacking. Roll formulas resolve with FormulaFamiliar context. Compendium items can be imported with origin tracking. All strings are localized. Test framework is in place with unit/integration test examples covering poc.1–3.
 
 > **Phase 6 includes Token & Scene**: Token placement, size derivation, Pinia token store, and actor ↔ token linking are part of getting actors visible on the table. TargetingManager stub and movement/action economy integration remain in alpha.7.
 

--- a/docs/migration-plan/roadmap.md
+++ b/docs/migration-plan/roadmap.md
@@ -180,8 +180,8 @@ Dependencies use `wave.N` notation (e.g. `poc.1`, `alpha.3`, `beta.2`).
 | 6 | [Actor Foundation](poc/phase-06-actor-foundation.md) | ✅ Approved | poc.1, poc.3 | Character actor: abilities, AC shell, HP, saves, skills, inventory, tokens, equipment slots |
 | 7 | [Roll Formulas & Custom Rolls](poc/phase-07-roll-formulas.md) | 📋 Outlined | poc.6 | D20Roll, DamageRoll, FormulaFamiliar roll data, formula paths |
 | 8 | [Pipeline & Branching](poc/phase-08-pipeline-and-branching.md) | 🔶 In Progress | — | Branching model, PR gate (`test.yml`), release pipeline (`build.yml`), `phases.json` sync. Independent of POC content; can land any time before POC closes. |
-| 9 | [Basic Tokens](poc/phase-09-basic-tokens.md) | � Planned | poc.6 | Token placed on scene, moved, `token.actor` resolves correctly, size and HP bar wired. Thin proof before poc.10. |
-| 10 | [Basic Combat](poc/phase-10-basic-combat.md) | � Planned | poc.6, poc.7, poc.9 | Combat tracker functional; detects basic move, double move, and main-hand attack. Seeds alpha.3 Action System. |
+| 9 | [Basic Tokens](poc/phase-09-basic-tokens.md) | 📝 Planned | poc.6 | Token placed on scene, moved, `token.actor` resolves correctly, size and HP bar wired. Thin proof before poc.10. |
+| 10 | [Basic Combat](poc/phase-10-basic-combat.md) | 📝 Planned | poc.6, poc.7, poc.9 | Combat tracker functional; detects basic move, double move, and main-hand attack. Seeds alpha.3 Action System. |
 
 **Exit criteria**: A Character actor exists on a scene with derived ability scores, saves, HP, and skills. Weapons can be created, identified, and equipped. Material AEs modify item stats with correct stacking. Roll formulas resolve with FormulaFamiliar context. Compendium items can be imported with origin tracking. All strings are localized. Test framework is in place with unit/integration test examples covering poc.1–3.
 

--- a/docs/migration-plan/roadmap.md
+++ b/docs/migration-plan/roadmap.md
@@ -177,7 +177,7 @@ Dependencies use `wave.N` notation (e.g. `poc.1`, `alpha.3`, `beta.2`).
 | 3 | [Localization](poc/phase-03-localization.md) | ✅ Complete | — | LOCALIZATION_PREFIXES, lang files, FormGroup auto-labels |
 | 4 | [Testing Infrastructure](poc/phase-04-testing-infrastructure.md) | ✅ Complete | poc.1, poc.2, poc.3 | Vitest, Foundry mocks, coverage tooling — establishes test patterns; back-fills poc.1–3 tests |
 | 5 | [Compendium Foundation](poc/phase-05-compendium-foundation.md) | 🔶 In Progress | poc.1, poc.2, poc.3 | Pack pipeline, origin tracking, UUID helpers, migration version field |
-| 6 | [Actor Foundation](poc/phase-06-actor-foundation.md) | 📋 Outlined | poc.1, poc.3 | Character actor: abilities, AC shell, HP, saves, skills, inventory, tokens, equipment slots |
+| 6 | [Actor Foundation](poc/phase-06-actor-foundation.md) | � Planned | poc.1, poc.3 | Character actor: abilities, AC shell, HP, saves, skills, inventory, tokens, equipment slots |
 | 7 | [Roll Formulas & Custom Rolls](poc/phase-07-roll-formulas.md) | 📋 Outlined | poc.6 | D20Roll, DamageRoll, FormulaFamiliar roll data, formula paths |
 | 8 | [Pipeline & Branching](poc/phase-08-pipeline-and-branching.md) | 🔶 In Progress | — | Branching model, PR gate (`test.yml`), release pipeline (`build.yml`), `phases.json` sync. Independent of POC content; can land any time before POC closes. |
 

--- a/docs/reference/foundry-data-fields-cheatsheet.md
+++ b/docs/reference/foundry-data-fields-cheatsheet.md
@@ -52,7 +52,7 @@
   - [How `applyChange` Works](#how-applychange-works)
   - [Change Modes by Field Type](#change-modes-by-field-type)
   - [Extending a Field for Custom `applyChange`](#extending-a-field-for-custom-applychange)
-  - [Example: PriceField for Price Objects](#example-pricefield-for-price-objects)
+  - [Example: CurrencyField for Currency Values](#example-currencyfield-for-currency-values)
 - [When to Extend a Field](#when-to-extend-a-field)
 
 ---
@@ -586,27 +586,27 @@ You should extend a field when:
 
 You can also override `applyChange` itself for complete control, but usually the individual methods are sufficient.
 
-### Example: PriceField for Price Objects
+### Example: CurrencyField for Currency Values
 
-A `Price` is `CoinStack[]` where each `CoinStack` is `{ coinId: string, count: number }`. The natural base is `ArrayField` with a `SchemaField` element, but extending `ArrayField` gives us Price-aware AE behavior:
+A `Price` is `CoinStack[]` where each `CoinStack` is `{ coinId: string, count: number }`. The natural base is `ArrayField` with a `SchemaField` element, but extending `ArrayField` gives us currency-aware AE behavior:
 
 ```ts
-// src/data/fields/PriceField.mts
+// src/fields/CurrencyField.mts
 
 import type { CoinStack, Price } from "../../settings/currency/_types.mts";
 
 /**
- * A specialized ArrayField for Price (CoinStack[]) values.
+ * A specialized ArrayField for currency (CoinStack[]) values.
  *
  * Provides Active Effect change modes that operate on coin stacks by coinId:
  * - add: merge coin counts by coinId (adds counts for matching coins, appends new ones)
  * - subtract: reduce coin counts by coinId (removes stacks that reach 0)
  * - multiply: multiply all coin counts by a scalar
- * - override: replace entire price
+ * - override: replace entire currency value
  * - upgrade: per-coinId max of counts
  * - downgrade: per-coinId min of counts
  */
-class PriceField extends foundry.data.fields.ArrayField {
+class CurrencyField extends foundry.data.fields.ArrayField {
   constructor(options = {}, context = {}) {
     super(
       new foundry.data.fields.SchemaField({
@@ -674,23 +674,23 @@ class PriceField extends foundry.data.fields.ArrayField {
 
   /** Add: merge coin stacks by coinId. */
   override _applyChangeAdd(value: Price, delta: Price, _model: any, _change: any): Price {
-    const map = PriceField.#toMap(value);
+    const map = CurrencyField.#toMap(value);
     for (const stack of delta) {
       map.set(stack.coinId, (map.get(stack.coinId) ?? 0) + stack.count);
     }
-    return PriceField.#fromMap(map);
+    return CurrencyField.#fromMap(map);
   }
 
   /** Subtract: reduce coin counts by coinId. Removes stacks at 0 or below. */
   override _applyChangeSubtract(value: Price, delta: Price, _model: any, _change: any): Price {
-    const map = PriceField.#toMap(value);
+    const map = CurrencyField.#toMap(value);
     for (const stack of delta) {
       const current = map.get(stack.coinId) ?? 0;
       const result = current - stack.count;
       if (result <= 0) map.delete(stack.coinId);
       else map.set(stack.coinId, result);
     }
-    return PriceField.#fromMap(map);
+    return CurrencyField.#fromMap(map);
   }
 
   /** Multiply: scale all coin counts by a numeric factor. */
@@ -709,22 +709,22 @@ class PriceField extends foundry.data.fields.ArrayField {
 
   /** Upgrade: per-coinId, take the higher count. */
   override _applyChangeUpgrade(value: Price, delta: Price, _model: any, _change: any): Price {
-    const map = PriceField.#toMap(value);
+    const map = CurrencyField.#toMap(value);
     for (const stack of delta) {
       map.set(stack.coinId, Math.max(map.get(stack.coinId) ?? 0, stack.count));
     }
-    return PriceField.#fromMap(map);
+    return CurrencyField.#fromMap(map);
   }
 
   /** Downgrade: per-coinId, take the lower count. Only affects existing coins. */
   override _applyChangeDowngrade(value: Price, delta: Price, _model: any, _change: any): Price {
-    const map = PriceField.#toMap(value);
+    const map = CurrencyField.#toMap(value);
     for (const stack of delta) {
       if (map.has(stack.coinId)) {
         map.set(stack.coinId, Math.min(map.get(stack.coinId)!, stack.count));
       }
     }
-    return PriceField.#fromMap(map);
+    return CurrencyField.#fromMap(map);
   }
 }
 ```
@@ -735,7 +735,7 @@ class PriceField extends foundry.data.fields.ArrayField {
 static override defineSchema() {
   return {
     ...super.defineSchema(),
-    price: new PriceField(),
+    price: new CurrencyField(),
   };
 }
 ```
@@ -758,7 +758,7 @@ static override defineSchema() {
 
 | Reason | Example |
 | --- | --- |
-| **Custom AE change semantics** | `PriceField` — domain-aware add/subtract on coin stacks. |
+| **Custom AE change semantics** | `CurrencyField` — domain-aware add/subtract on coin stacks. |
 | **Custom delta casting** | Parsing shorthand strings (`"5 gp"`) into structured data. |
 | **Custom cleaning/coercion** | Normalizing or sorting values during `_cleanType`. |
 | **Custom validation** | Business rules beyond simple type/range checks. |

--- a/tests/unit/models/weapon.model.test.mts
+++ b/tests/unit/models/weapon.model.test.mts
@@ -59,7 +59,6 @@ describe('WeaponSystemModel schema', () => {
   describe('field types', () => {
     it('boolean flags use BooleanField', () => {
       t.assertFieldType('isBaseWeaponType', BooleanField);
-      // isMasterwork is derived, not a schema field
       t.assertFieldType('noAmmoRequired', BooleanField);
     });
 
@@ -101,7 +100,6 @@ describe('WeaponSystemModel schema', () => {
   describe('declared defaults', () => {
     it('non-combat flags default to false', () => {
       t.assertDefault('isBaseWeaponType', false);
-      // isMasterwork is derived — no schema default
       t.assertDefault('noAmmoRequired', false);
     });
 


### PR DESCRIPTION
## Summary

Planning branch covering Session 0 (Phase 6 review + approval) through full planning of poc.9 and poc.10.

---

## Changes by category

### Phase status updates (roadmap.md)
- **poc.6 Actor Foundation** — marked ✅ Approved after review
- **poc.9 Basic Tokens** — Stub to 📋 Planned
- **poc.10 Basic Combat** — Stub to 📋 Planned

### poc.9 Basic Tokens (new file)
**2 stories:**
- **Story 1** — Token placement, sizing, actor linkage, vision defaults. Converts `TokenDocumentDnd35e` from type alias to real class. `SIZE_TOKEN_DIMENSIONS` constant. `ActorDnd35e._preCreate()` prototype token defaults (actorLink, HP bar, basic vision).
- **Story 2** — Movement speed: all 5 modes on actor sheet (walk/fly/swim/burrow/climb). `_getAnimationMovementSpeed()` override. Ruler budget display marked as open decision.

### poc.10 Basic Combat (new file)
**5 stories (1+2 parallel, 3-4-5 sequential):**
- **Story 1** — `CombatantDnd35e` with `system.actions` (standard/move). Initiative formula. Combat tracker S/M pips, reset on turn start.
- **Story 2** — `ActionDataModel` first cut: attack+damage+chain schema, FormulaFamiliar contexts (`#self`/`#item`/`#target`), default weapon action seeded on `_onCreate()`.
- **Story 3** — Movement budget hook: `preUpdateToken` distance, consume move/standard. `SIZE_REACH` constant.
- **Story 4** — Melee attack execution engine: `preUseAction`/`postUseAction`/`dealDamage` events, D20Roll vs AC, reach check, damage via `takeDamage()`, chat card. Sheet trigger.
- **Story 5** — Canvas right-click attack submenu (Foundry v14 API TBD at phase start).

4 open decisions documented. Alpha.3 extension seam explicitly called out in `ActionDataModel` spec.

### poc.6 Actor Foundation spec (major rewrite)
- Delivery plan refined: 4 stories with clear commit breakdown per story
- `PriceField` to `CurrencyField` rename planned as a pre-story (3-commit PR: rename, `persisted:false` audit, pack source items)
- Phase references corrected: "Phase 8 (Action System)" corrected to poc.10 / alpha.3 throughout
- Completion checklist expanded and reorganized
- `preUseAction`/`postUseAction`/`dealDamage` deferral note updated to reference poc.10

### Knowledge base / instruction files
- `dnd35e-patterns.instructions.md` — new file, codebase architecture patterns
- `e2e-testing.instructions.md` — additions from session learnings
- `e2e-testing/SKILL.md` — additions
- `phase-planning/SKILL.md` — open question protocol + WISHLIST scope rule
- `foundry-data-fields-cheatsheet.md` — additional field types documented

### Architecture & reference docs
- `architecture-overview.md` — updates
- `PropertyMap-Actors.md` — major rewrite reflecting Phase 6 schema decisions
- `beta/phase-01-equipment-loot.md` — additions
- `WISHLIST.md` — new entries from session

### Minor fixes
- `poc/phase-02-task-decomposition.md` — wording fix
- `refactor-naming-conventions.md` — wording fix
- `post-release/phase-09-random-treasure.md` — numbering fix
- `tests/unit/models/weapon.model.test.mts` — removed two stale comments
