### PR TITLE
POC Phase 9 - Story 1: Token Placement, Sizing & Actor Linkage

### DIFF
--- a/docs/migration-plan/poc/phase-09-basic-tokens.md
+++ b/docs/migration-plan/poc/phase-09-basic-tokens.md
@@ -1,16 +1,16 @@
 # POC Phase 9: Basic Tokens
 
-**Status**: 📝 Planned
+**Status**: 🔶 In Progress (Story 1 complete)
 
 > **Milestone**: POC  
 > **Dependencies**: poc.6  
-> **Goal**: A token can be created on a scene, moved, and correctly reflects its actor. Token has the right document and canvas classes, actor linkage, size derived from `system.size`, and HP bar by default. Minimal proof before poc.10 (Basic Combat) depends on tokens.
+> **Goal**: A token can be created on a scene, moved, and correctly reflects its actor. Token has the right document and canvas classes, actor linkage, size derived from `system.size`, and HP bar by default. Movement budget is visualized on the ruler, and D&D senses (darkvision, low-light vision, tremorsense) are automatically wired to Foundry canvas vision — no manual GM configuration needed. Polished proof before poc.10 (Basic Combat) depends on tokens.
 
 ---
 
 ## Overview
 
-Phase 6 creates `ActorDnd35e` and the character schema. Phase 9 wires it to the Foundry canvas so actors appear as tokens on the table. Expected to be a thin phase — Foundry handles most token mechanics out of the box.
+Phase 6 creates `ActorDnd35e` and the character schema. Phase 9 wires it to the Foundry canvas so actors appear as tokens on the table, with polished movement and vision behavior — not just a thin placement proof. Foundry handles the placement mechanics out of the box; the added value is the ruler budget display and the senses-to-vision pipeline, both of which are new for this system.
 
 **Existing scaffolding (already in `src/`):**
 - `TokenDnd35e` canvas class at `src/canvas/token/TokenDnd35e.mts` — stub extending `fc.placeables.Token`. Typed, not yet registered.
@@ -20,11 +20,11 @@ Phase 6 creates `ActorDnd35e` and the character schema. Phase 9 wires it to the 
 **What Phase 9 adds:**
 1. `SIZE_TOKEN_DIMENSIONS` size → grid square mapping in `sizes.mts`
 2. `TokenDocumentDnd35e` becomes a real class with `_preCreate()` for size derivation
-3. `ActorDnd35e._preCreate()` sets prototype token defaults (size, vision, disposition, HP bar)
-4. Register `CONFIG.Token.documentClass`, `CONFIG.Token.objectClass`, `CONFIG.Actor.documentClass`
-5. All five movement speeds (land/swim/climb/burrow/fly) visible on character sheet
-6. `TokenDnd35e._getAnimationMovementSpeed()` wired to actor land speed
-7. Ruler / movement budget display (explore at phase start, fallback to poc.10)
+3. `Creature._preCreate()` sets prototype token defaults (disposition, HP bar, basic vision) — lives on `Creature`, not `ActorDnd35e`, since senses/size-adjacent creature data lives there and it type-safely covers all creature actor types (character, future NPC)
+4. Register `CONFIG.Token.documentClass`, `CONFIG.Token.objectClass` (`CONFIG.Actor.documentClass` already registered by Phase 6)
+5. `TokenRulerDnd35e` subclass for movement budget display (distance / speed, path color changes when budget exceeded)
+6. Full vision system: map D&D senses (darkvision, low-light, tremorsense) to Foundry visionMode/detectionModes
+7. Wire senses to tokens: `Creature._preCreate()` applies default vision; update hooks sync changes
 
 ---
 
@@ -98,31 +98,33 @@ export { TokenDocumentDnd35e };
 
 ## 9.3 Actor Prototype Token Defaults
 
-`ActorDnd35e._preCreate()` sets sensible prototype token defaults for new Character actors so they don't need manual configuration after creation.
+`Creature._preCreate()` sets sensible prototype token defaults for new creature-type actors (currently Character; automatically covers future NPC types too) so they don't need manual configuration after creation. Placed on `Creature` rather than `ActorDnd35e` because it's the shared base for all creature actor types and keeps this type-safe without a `this.type === 'character'` string check.
 
-Includes basic vision (`sight.enabled: true`) so placed tokens can see the scene. No darkvision or other senses yet — Phase 6 has no senses schema; that defers to Phase 23 when race and NPC types land.
+Includes basic vision (`sight.enabled: true`) so placed tokens can see the scene. No darkvision or other senses yet — that's Story 3.
+
+The default values themselves are extracted into a pure helper, `buildPrototypeTokenDefaults()`, so they can be unit tested without needing the full Document class chain:
 
 ```typescript
-// ActorDnd35e — add _preCreate override
-override async _preCreate(
-  data: PreCreate<foundry.documents.ActorSource>,
-  options: object,
-  user: foundry.documents.User
+// src/documents/actors/creature/logic/buildPrototypeTokenDefaults.mts
+const buildPrototypeTokenDefaults = (): PrototypeTokenDefaults => ({
+  actorLink: true,
+  disposition: CONST.TOKEN_DISPOSITIONS.FRIENDLY,
+  displayBars: CONST.TOKEN_DISPLAY_MODES.OWNER_HOVER,
+  displayName: CONST.TOKEN_DISPLAY_MODES.OWNER,
+  bar1: { attribute: 'hp' },
+  sight: { enabled: true, visionMode: 'basic' },
+});
+
+// Creature.mts
+protected override async _preCreate(
+  data: this['_source'],
+  options: DatabaseCreateCallbackOptions,
+  user: foundry.documents.BaseUser
 ): Promise<boolean | void> {
   const result = await super._preCreate(data, options, user);
-  if (result === false) return result;
+  if (result === false) return false;
 
-  if (this.type === 'character') {
-    this.updateSource({
-      'prototypeToken.actorLink': true,
-      'prototypeToken.disposition': CONST.TOKEN_DISPOSITIONS.FRIENDLY,
-      'prototypeToken.displayBars': CONST.TOKEN_DISPLAY_MODES.OWNER_HOVER,
-      'prototypeToken.displayName': CONST.TOKEN_DISPLAY_MODES.OWNER,
-      'prototypeToken.bar1': { attribute: 'hp' },
-      'prototypeToken.sight': { enabled: true, visionMode: 'basic' },
-    });
-  }
-  return result;
+  this.updateSource({ prototypeToken: buildPrototypeTokenDefaults() });
 }
 ```
 
@@ -134,60 +136,67 @@ override async _preCreate(
 // In registerActors() init hook (or a dedicated canvas registration function):
 CONFIG.Token.objectClass   = TokenDnd35e;
 CONFIG.Token.documentClass = TokenDocumentDnd35e;
-CONFIG.Actor.documentClass = ActorProxyDnd35e;  // may already be in Phase 6
+CONFIG.Actor.documentClass = ActorProxyDnd35e;  // already completed in Phase 6
 ```
-
-> **Note on `CONFIG.Actor.documentClass`**: The current `registerActors()` in Phase 6 only wires FormulaFamiliar schemas — it does not register `ActorProxyDnd35e`. Confirm at implementation time whether Phase 6 adds this or Phase 9 does.
 
 ---
 
-## 9.5 Movement Speed
+## 9.5 Movement Speed, Ruler, and Vision
 
 ### Schema dependency
 
-Phase 6 §5.1 plans `speed: { land, climb, swim, burrow, fly }` on `ActorSystemModelBase`, each a single persisted number field (no `.base`/`.total` split). Poc.9 depends on Phase 6 delivering those fields.
+Phase 6 §5.1 plans `speed: { land, climb, swim, burrow, fly }` on `ActorSystemModelBase`, each a single persisted number field.
 
-Phase 6 Story 2 shows "speed" on the sheet but vaguely. If Phase 6 only displays land speed, poc.9 adds a dedicated Speed section showing all five modes (land, swim, climb, burrow, fly), with non-zero modes displayed and zero-value modes grayed out or hidden.
+> **Animation speed skipped**: `Token._getAnimationMovementSpeed()` (visual slide speed across canvas) is NOT wired to actor land speed in poc.9. Other Foundry systems don't typically do this, and Foundry's default (6 squares/sec) is acceptable — the effort isn't justified for POC. Revisit later if desired.
 
-### Animation speed (visual)
+### Vision System: Senses to Canvas Vision
 
-`Token._getAnimationMovementSpeed()` controls how fast the token slides across the canvas in grid squares per second (Foundry default: 6). **This is purely visual** — it is NOT the D&D movement budget. Override in `TokenDnd35e` so the slide speed matches the character's land speed:
+**What we want**: Actor senses (darkvision, low-light, tremorsense) automatically wire to token vision modes and detection modes. GMs create a dwarf with darkvision 60ft, place it on the canvas, and the token can immediately see in darkness without manual Foundry UI config.
 
-```typescript
-// TokenDnd35e — override canvas animation speed
-protected override _getAnimationMovementSpeed(): number {
-  const landSpeed = this.document.actor?.system?.speed?.land;
-  if (landSpeed && landSpeed > 0) {
-    // 5ft per grid square — 30ft = 6 squares/sec (matches Foundry default)
-    return landSpeed / 5;
-  }
-  return (CONFIG.Token as Record<string, unknown> & { movement?: { defaultSpeed?: number } })
-    .movement?.defaultSpeed ?? 6;
-}
-```
+**D&D 3.5e Senses → Foundry Mapping**:
 
-### Ruler / movement budget display (open decision)
+| D&D Sense | visionMode | detectionMode | How it works |
+|-----------|-----------|---|---|
+| Darkvision | `'darkvision'` | `'basicSight'` (range) | See in grayscale, distance limited |
+| Low-light vision | `'lightAmplification'` | `'basicSight'` (range) | Enhanced dim-light vision |
+| Tremorsense | (none — keep `'basic'`) | `'feelTremor'` (range) | Detect via vibrations, works in darkness |
+
+**Exclusivity rule**: Only one visionMode can be active. If actor has multiple senses, priority is: darkvision > low-light > basic.
+
+DetectionModes stack — actor can have tremorsense + seeInvisibility all active at once.
+
+**Implementation**:
+- Helper `_buildTokenVisionFromSenses(senses[])` — maps D&D sense array to Foundry `sight` and `detectionModes[]` objects
+- `Creature._preCreate()` — wire default vision (if no senses, use `sight.visionMode: 'basic'`)
+- Update hook on actor senses changes → sync token vision live
+
+**Scope for POC**: Implement darkvision + low-light + tremorsense. Defer blindsight/scent (would need custom DetectionMode subclasses) to Alpha vision phase.
+
+### Ruler / Movement Budget Display
 
 **What we want**: while dragging a token, the ruler label shows "25 / 30 ft" (distance used vs. budget) and the path line or waypoint marker changes color when the budget is exceeded.
 
-**Extension points found in type definitions**:
-- `TokenRuler._getWaypointLabelContext(waypoint, state)` — injects data into the Handlebars label template
-- `TokenRuler._getWaypointStyle(waypoint)` — controls marker radius/color per waypoint
-- `TokenRuler._getSegmentStyle(waypoint)` — controls path line color per segment
-- `TokenPlannedMovement.unreachableWaypoints` — Foundry tracks waypoints beyond the movement budget if cost functions are configured
+**Implementation**:
+- Subclass `TokenRuler` as `TokenRulerDnd35e`
+- Override `_getWaypointLabelContext()` — inject `{ distance, budget }` for label template
+- Override `_getWaypointStyle()` — color waypoint red if beyond budget
+- Override `_getSegmentStyle()` — color path line red if segment goes beyond budget
 
-**Open decision at phase start**: Explore whether subclassing `TokenRuler` is required, or if a simpler hook point exists (e.g. `Token#_refreshRuler` or a movement action config). Determine whether wiring `CONFIG.Token.movement` action costs is needed before the ruler can show budget-aware colors.
-
-**Fallback**: if full budget display is complex, poc.9 ships the animation speed wiring only. The ruler budget display defers to poc.10 (Basic Combat), where per-action movement tracking is needed anyway. Decide at phase start.
+**Spike at phase start**: Confirm `TokenPlannedMovement` exposes movement cost API and verify no hard requirement on combat mechanics. If API is insufficient, defer to poc.10 and document the blocker.
 
 ---
 
 ## Phase Delivery Plan
 
-Two sequential stories.
+Three sequential stories with some parallelization.
 
 ```
-Story 1 → Story 2
+Story 1
+  ↓
+Story 2 (parallel: spike TokenRuler)
+Story 3 (spike: vision architecture)
+  ↓
+Implementation: Vision wiring to tokens
 ```
 
 ### Story 1 — Token placement, sizing, actor linkage, and vision
@@ -197,57 +206,106 @@ Story 1 → Story 2
 **Depends on**: Phase 6 (CharacterSystemModel, ActorDnd35e in place).
 
 **Commits:**
-1. **`SIZE_TOKEN_DIMENSIONS` + real `TokenDocumentDnd35e` class** — add size mapping to `sizes.mts`; convert `TokenDocumentDnd35e` from type alias to real class with `_preCreate()`. *(Unit tests: all 9 size categories map correctly; Medium → 1, Large → 2, Huge → 3)*
-2. **Actor prototype token defaults** — `ActorDnd35e._preCreate()` for character `actorLink`, `disposition`, `displayBars`, `displayName`, `bar1`, `sight`. *(Unit tests: new Character actor prototypeToken has `actorLink: true`, `bar1.attribute: 'hp'`, `sight.enabled: true`)*
-3. **Registration** — wire `CONFIG.Token.objectClass`, `CONFIG.Token.documentClass`, `CONFIG.Actor.documentClass` in init hook. *(Unit test: CONFIG values are correct class references after init)*
+1. **`SIZE_TOKEN_DIMENSIONS` + real `TokenDocumentDnd35e` class** — add size mapping to `sizes.mts`; convert `TokenDocumentDnd35e` from type alias to real class with `_preCreate()`. Size field itself lives on base `ActorSystemModel` (not `CreatureSystemModel`) so every actor type gets token sizing for free. *(Unit tests: all 9 size categories map correctly; Medium → 1, Large → 2, Huge → 3 — done in `tokenDocument.model.test.mts`)*
+2. **Actor prototype token defaults** — `Creature._preCreate()` (not `ActorDnd35e`) calling pure helper `buildPrototypeTokenDefaults()` for `actorLink`, `disposition`, `displayBars`, `displayName`, `bar1`, `sight`. *(Unit tests: `actorLink: true`, `bar1.attribute: 'hp'`, `sight.enabled: true` — done in `buildPrototypeTokenDefaults.test.mts`)*
+3. **Registration** — wire `CONFIG.Token.objectClass`, `CONFIG.Token.documentClass` in init hook (`CONFIG.Actor.documentClass = ActorProxyDnd35e` already registered by Phase 6's `registerActors()`). Confirmed via dev testing; no dedicated unit test (one-line CONFIG wiring, would require new CONFIG/Hooks mocks for no logic coverage).
 
-**E2E acceptance**: Create Character actor (Medium, HP 20) → drag to scene → 1×1 token placed → HP bar shows 20/20 → move token → position persists after page reload.
+**E2E acceptance**: Create Character actor (Large, HP 20) → drag to scene → 2×2 token placed → HP bar shows 20/20 → move token → position persists after page reload.
 
 ---
 
-### Story 2 — Movement speed
+### Story 2 — Movement Budget Display (Ruler)
 
 **User**: GM / Player  
-**Delivers**: All five actor movement speeds visible on character sheet; moving a token on canvas animates at the correct speed; ruler shows distance traveled.  
-**Depends on**: Story 1 + Phase 6 Story 2 (speed schema fields exist).
+**Delivers**: While dragging a token, ruler labels show distance traveled and remaining movement budget; path turns red when budget exceeded.  
+**Depends on**: Story 1 (tokens placed and movable).
 
-**Commits:**
-1. **Speed sheet UI** — if Phase 6 Story 2 only shows land speed, add all five modes (land, swim, climb, burrow, fly) to the sheet with zero-value modes grayed. *(Skip if Phase 6 already covers all five.)*
-2. **Animation speed wiring** — override `TokenDnd35e._getAnimationMovementSpeed()` to derive from `actor.system.speed.land` (single persisted field, no `.total` split; effective/AE-adjusted value is read via `getViewAwareFieldValue` or the live post-prepare value). *(Unit test: Large token with 30ft land speed returns 6 from `_getAnimationMovementSpeed()`)*
-3. **Ruler budget display** — *explore at phase start*. Implement `_getWaypointLabelContext()` / `_getWaypointStyle()` / `_getSegmentStyle()` overrides (or simpler hook if found). If ruler subclassing proves too complex for poc.9, defer to poc.10 and document the finding.
+**Spike (parallel)**:
+1. **TokenRuler API investigation** — Confirm `TokenPlannedMovement` exposes waypoint cost/distance API; verify no hard blocker on combat mechanics before ruler can function.
+2. **TokenRuler registration mechanism (unconfirmed)** — Our bundled type definitions expose `CONFIG.Canvas.rulerClass: typeof Ruler`, which is the generic canvas measuring Ruler, **not** the per-token `TokenRuler` used while dragging a token (`Token#ruler: BaseTokenRuler`). No `CONFIG.Token.rulerClass` hook exists in the type defs. Determine at spike time whether Token exposes a static `rulerClass` property to override (subclass responsibility, similar to how `TokenDnd35e` overrides other protected methods), or another extension point. If no clean hook exists, document the finding and consider deferring Story 2 to poc.10.
 
-**E2E acceptance**: Character with 30ft speed drags token across canvas → ruler shows distance in feet → token animation speed visually matches 6 squares/second (30ft ÷ 5ft).
+**Commits** (if spike succeeds):
+1. **`TokenRulerDnd35e` subclass** — extend `TokenRuler`, override `_getWaypointLabelContext()`, `_getWaypointStyle()`, `_getSegmentStyle()` to inject distance budget labels and path coloring. *(Unit test: waypoint beyond 30ft budget returns red color)*
+2. **Movement budget calculation** — read `actor.system.speed.land` (single persisted field) as the token's movement budget. *(Unit test: 30ft speed actor returns 30 from budget getter)*
+3. **Path coloring logic** — cumulative distance per segment; flag segment red if total distance exceeds budget. *(Unit test: 40ft drag on 30ft actor marks last 10ft red)*
+
+**E2E acceptance**: Drag token 40ft (actor has 30ft speed) → first 30ft normal color, last 10ft red → label shows "40 / 30 ft".
+
+---
+
+### Story 3 — Vision System (Darkvision, Low-light, Tremorsense)
+
+**User**: GM / Player  
+**Delivers**: Actor with darkvision/low-light/tremorsense automatically appears on canvas with those senses active. Token can see in darkness, detect via tremors, etc. No manual Foundry UI config needed.
+**Depends on**: Story 1 (tokens placed) + Phase 6 (senses schema exists on CreatureSystemModel.bio.senses).
+
+**Spike (sequential after Story 1)**:
+1. **D&D sense → Foundry architecture** — verify visionMode is exclusive, detectionModes are stackable arrays; confirm Foundry has pre-built darkvision, lightAmplification, feelTremor; determine if custom DetectionMode is required for scent/blindsight (defer if yes).
+2. **Sense priority logic** — if actor has darkvision + low-light, which visionMode wins? Answer: darkvision (strictly better). Define precedence: darkvision > low-light > basic.
+
+**Commits**:
+1. **`_buildTokenVisionFromSenses()` helper** — pure function mapping `system.bio.senses[]` array to Foundry `sight` and `detectionModes[]` objects. *(Unit test: darkvision 60ft → `{visionMode: 'darkvision', range: 60}`; tremorsense 120ft → `{id: 'feelTremor', range: 120}`; both → visionMode darkvision + both detectionModes)*
+2. **Wire to `Creature._preCreate()`** — apply default vision (build from senses array or fall back to basic if none). Also add `_refreshTokenVision()` method for future use. *(Unit test: new actor with darkvision has token `sight.visionMode: 'darkvision'`)*
+3. **Update hook on senses change** — when actor senses change, sync all placed tokens: `actor.updateEmbeddedDocuments('Token', [{...new vision}])`. *(Unit test: add darkvision to actor, verify placed token updates live)*
+4. **Unit tests** — sense mapping for all 3 types, priority resolution (multiple visionModes), no regression on basic vision.
+5. **E2E tests** — create dwarf with darkvision, place on dark scene, token can see; add tremorsense via drag-drop item, token detects in darkness.
+
+**E2E acceptance**: Dwarf (darkvision 60ft) dragged to dark scene → token sight cone renders in grayscale, sees 60ft in darkness → add Tremorsense 90ft item → token can feel vibrations up to 90ft (independent of darkvision range).
 
 ---
 
 ## Completion Checklist
 
-### ❌ Not Started
+### 🔶 In Progress
 
 **Size mapping:**
-- [ ] Add `SIZE_TOKEN_DIMENSIONS: Record<Size, number>` to `src/constants/sizes.mts`
-- [ ] Export `SIZE_TOKEN_DIMENSIONS` from `sizes.mts`
+- [x] Add `SIZE_TOKEN_DIMENSIONS: Record<Size, number>` to `src/constants/sizes.mts`
+- [x] Export `SIZE_TOKEN_DIMENSIONS` from `sizes.mts`
+- [x] `size` field moved from `CreatureSystemModel`/`CreatureSystemData` to base `ActorSystemModel`/`ActorSystemData` (all actor types have a size, not just creatures)
 
 **TokenDocumentDnd35e:**
-- [ ] Convert `TokenDocumentDnd35e` from type alias to real class extending `TokenDocument`
-- [ ] Override `_preCreate()` to derive `width`/`height` from `actor.system.size`
-- [ ] Update `src/documents/scene/tokenDocument/index.mts` to export the class (not just the type)
+- [x] Convert `TokenDocumentDnd35e` from type alias to real class extending `TokenDocument`
+- [x] Override `_preCreate()` to derive `width`/`height` from `actor.system.size`
+- [x] Update `src/documents/scene/tokenDocument/index.mts` to export the class (not just the type)
 
 **Actor prototype token defaults:**
-- [ ] Override `ActorDnd35e._preCreate()` to set prototype token defaults for `character` type
-- [ ] Defaults: `actorLink: true`, `disposition: FRIENDLY`, `displayBars: OWNER_HOVER`, `displayName: OWNER`, `bar1.attribute: 'hp'`
-- [ ] Vision defaults: `sight.enabled: true`, `sight.visionMode: 'basic'`
+- [x] Override `Creature._preCreate()` to set prototype token defaults (covers all creature actor types, not gated by `type === 'character'`)
+- [x] Defaults: `actorLink: true`, `disposition: FRIENDLY`, `displayBars: OWNER_HOVER`, `displayName: OWNER`, `bar1.attribute: 'hp'` — extracted into pure `buildPrototypeTokenDefaults()` helper for testability
+- [x] Vision defaults: `sight.enabled: true`, `sight.visionMode: 'basic'`
 
 **Registration:**
-- [ ] Register `CONFIG.Token.objectClass = TokenDnd35e` in init hook
-- [ ] Register `CONFIG.Token.documentClass = TokenDocumentDnd35e` in init hook
-- [ ] Register `CONFIG.Actor.documentClass = ActorProxyDnd35e` in init hook (confirm not already in Phase 6)
+- [x] Register `CONFIG.Token.objectClass = TokenDnd35e` in init hook
+- [x] Register `CONFIG.Token.documentClass = TokenDocumentDnd35e` in init hook
+- [x] Confirm `CONFIG.Actor.documentClass = ActorProxyDnd35e` is already registered by Phase 6's `registerActors()` (verified in code — no action needed)
 
-**Movement speed:**
-- [ ] Verify Phase 6 Story 2 delivers `speed.{land,climb,swim,burrow,fly}` fields (each a single persisted number, no `.total` split)
-- [ ] If Phase 6 only shows land speed on sheet, add all five modes to Speed section (zero-value modes grayed)
-- [ ] Override `TokenDnd35e._getAnimationMovementSpeed()` → `actor.system.speed.land / 5`
-- [ ] Explore ruler budget display extension points at phase start; implement or defer to poc.10
+**Story 1 unit tests:**
+- [x] `tests/unit/models/tokenDocument.model.test.mts` — all 9 size categories map correctly
+- [x] `tests/unit/models/buildPrototypeTokenDefaults.test.mts` — actorLink, disposition, display modes, HP bar, basic vision
+
+**Story 1 status: done, dev-tested in Foundry, unit tests passing.**
+
+### ❌ Not Started
+
+**Movement budget display (Story 2):**
+- [ ] Create `src/canvas/token/TokenRulerDnd35e.mts` subclass extending `TokenRuler`
+- [ ] Override `_getWaypointLabelContext()` to inject `{ distance, budget, remaining }` into label template
+- [ ] Override `_getWaypointStyle()` to color waypoint red if `distance > budget`
+- [ ] Override `_getSegmentStyle()` to color segment line red if cumulative distance exceeds budget
+- [ ] Add helper to read actor land speed as movement budget
+- [ ] Spike: confirm `TokenPlannedMovement` API is sufficient; no combat mechanics blocker
+- [ ] Spike: determine correct extension point to wire `TokenRulerDnd35e` onto `TokenDnd35e` (no `CONFIG.Token.rulerClass` exists in current type defs — verify actual mechanism before implementing)
+
+**Vision system (Story 3):**
+- [ ] Create `src/helpers/tokenVision.mts` with `_buildTokenVisionFromSenses(senses[])` helper
+- [ ] Mapping: darkvision → visionMode `'darkvision'` + detectionMode `'basicSight'`
+- [ ] Mapping: low-light → visionMode `'lightAmplification'` + detectionMode `'basicSight'`
+- [ ] Mapping: tremorsense → visionMode unchanged + detectionMode `'feelTremor'`
+- [ ] Priority logic: if actor has multiple visionModes, darkvision > low-light > basic
+- [ ] Update `ActorDnd35e._preCreate()` to call `_buildTokenVisionFromSenses()` and wire to prototypeToken
+- [ ] Add `_refreshTokenVision()` method to ActorDnd35e (called by update hooks)
+- [ ] Create update hook: actor senses change → sync all placed tokens via `updateEmbeddedDocuments`
+- [ ] Unit tests: all 3 sense mappings work; priority resolution; basic vision fallback
+- [ ] E2E tests: dwarf with darkvision placed on dark scene sees correctly; tremorsense update propagates live
 
 **Tests:**
 - [ ] Unit: `SIZE_TOKEN_DIMENSIONS` covers all 9 size categories
@@ -257,10 +315,15 @@ Story 1 → Story 2
 - [ ] Unit: new Character actor `prototypeToken.sight.enabled` is `true`
 - [ ] Unit: `TokenDocumentDnd35e._preCreate()` sets 2×2 for a Large actor
 - [ ] Unit: `CONFIG.Token.objectClass` is `TokenDnd35e` after init hook runs
-- [ ] Unit: `_getAnimationMovementSpeed()` returns 6 for a 30ft land speed actor
+- [ ] Unit: `_buildTokenVisionFromSenses([{type: 'darkvision', distance: 60}])` → `{visionMode: 'darkvision', range: 60, detectionModes: [{id: 'basicSight', range: 60}]}`
+- [ ] Unit: priority logic: actor with [darkvision 60, lowLight 90] → visionMode `'darkvision'` (not low-light)
+- [ ] Unit: tremorsense 120ft → detectionMode `'feelTremor'` stacks with darkvision visionMode
 - [ ] E2E: drag Character actor to scene → 1×1 token with HP bar appears
 - [ ] E2E: move token → position persists after reload
-- [ ] E2E: drag token across canvas → ruler shows distance in feet
+- [ ] E2E: drag token across canvas → ruler waypoints show distance labels (if TokenRuler succeeds)
+- [ ] E2E: drag 40ft on 30ft-speed actor → path turns red after 30ft
+- [ ] E2E: dwarf (darkvision 60) on dark scene → token sight works, sees in grayscale
+- [ ] E2E: add tremorsense item to actor → placed token detects in darkness live (no reload)
 
 ---
 
@@ -271,7 +334,7 @@ Story 1 → Story 2
 | Modify | `src/constants/sizes.mts` — add `SIZE_TOKEN_DIMENSIONS` |
 | Modify | `src/documents/scene/tokenDocument/TokenDocumentDnd35e.mts` — convert to real class, add `_preCreate()` |
 | Modify | `src/documents/scene/tokenDocument/index.mts` — export class (not just type) |
-| Modify | `src/documents/actors/baseActor/ActorDnd35e.mts` — add `_preCreate()` for prototype token defaults |
-| Modify | `src/documents/actors/registration.mts` — add `CONFIG.Token.*` and `CONFIG.Actor.documentClass` registration |
-| Modify | `src/canvas/token/TokenDnd35e.mts` — add `_getAnimationMovementSpeed()` override |
-| Modify (maybe) | `src/canvas/token/TokenRulerDnd35e.mts` (new file) — ruler subclass for budget display (explore at phase start) |
+| Modify | `src/documents/actors/baseActor/ActorDnd35e.mts` — add `_preCreate()` for prototype token defaults, add `_refreshTokenVision()` method, add senses update hook |
+| Modify | `src/documents/actors/registration.mts` — add `CONFIG.Token.objectClass`/`documentClass` registration (`CONFIG.Actor.documentClass` already registered) |
+| Create | `src/canvas/token/TokenRulerDnd35e.mts` — ruler subclass for movement budget display |
+| Create | `src/helpers/tokenVision.mts` — `_buildTokenVisionFromSenses()` helper and vision priority logic |

--- a/docs/migration-plan/roadmap.md
+++ b/docs/migration-plan/roadmap.md
@@ -180,7 +180,7 @@ Dependencies use `wave.N` notation (e.g. `poc.1`, `alpha.3`, `beta.2`).
 | 6 | [Actor Foundation](poc/phase-06-actor-foundation.md) | 🔶 In Progress | poc.1, poc.3 | Character actor: abilities, AC shell, HP, saves, inventory, tokens, equipment slots |
 | 7 | [Roll Formulas & Custom Rolls](poc/phase-07-roll-formulas.md) | 📋 Outlined | poc.6 | D20Roll, DamageRoll, FormulaFamiliar roll data, formula paths |
 | 8 | [Pipeline & Branching](poc/phase-08-pipeline-and-branching.md) | 🔶 In Progress | — | Branching model, PR gate (`test.yml`), release pipeline (`build.yml`), `phases.json` sync. Independent of POC content; can land any time before POC closes. |
-| 9 | [Basic Tokens](poc/phase-09-basic-tokens.md) | 📝 Planned | poc.6 | Token placed on scene, moved, `token.actor` resolves correctly, size and HP bar wired. Thin proof before poc.10. |
+| 9 | [Basic Tokens](poc/phase-09-basic-tokens.md) | 🔶 In Progress | poc.6 | Token placed on scene with correct size and HP bar, actor linkage wired; movement budget display on ruler; vision system (darkvision, low-light, tremorsense) automatically maps to canvas. Polished proof before poc.10. |
 | 10 | [Basic Combat](poc/phase-10-basic-combat.md) | 📝 Planned | poc.6, poc.7, poc.9 | Combat tracker functional; detects basic move, double move, and main-hand attack. Seeds alpha.3 Action System. |
 | 11 | [POC Cleanup](poc/phase-11-poc-cleanup.md) | 📖 Rough Sketch | poc.1–poc.10 | End-of-POC hardening bucket. Initial task: make FormGroup updaters consistently async and Promise-returning. |
 

--- a/src/canvas/token/TokenDnd35e.mts
+++ b/src/canvas/token/TokenDnd35e.mts
@@ -1,8 +1,8 @@
 import type TokenLayer from '@client/canvas/layers/tokens.mjs';
 import type { TokenDocumentDnd35e } from '@scene/tokenDocument/TokenDocumentDnd35e.mjs';
 
-class TokenDnd35e<TDocument extends TokenDocumentDnd35e = 
-TokenDocumentDnd35e> extends foundry.canvas.placeables.Token<TDocument>
+class TokenDnd35e<TDocument extends TokenDocumentDnd35e = TokenDocumentDnd35e>
+  extends foundry.canvas.placeables.Token<TDocument>
 {
   declare readonly layer: TokenLayer<this>;
 }

--- a/src/canvas/token/TokenDnd35e.mts
+++ b/src/canvas/token/TokenDnd35e.mts
@@ -1,7 +1,9 @@
 import type TokenLayer from '@client/canvas/layers/tokens.mjs';
 import type { TokenDocumentDnd35e } from '@scene/tokenDocument/TokenDocumentDnd35e.mjs';
 
-class TokenDnd35e<TDocument extends TokenDocumentDnd35e = TokenDocumentDnd35e> extends fc.placeables.Token<TDocument> {
+class TokenDnd35e<TDocument extends TokenDocumentDnd35e = 
+TokenDocumentDnd35e> extends foundry.canvas.placeables.Token<TDocument>
+{
   declare readonly layer: TokenLayer<this>;
 }
 

--- a/src/constants/sizes.mts
+++ b/src/constants/sizes.mts
@@ -20,9 +20,23 @@ const SIZE_MODIFIERS: Record<Size, number> = {
   fine: 8,
 };
 
+/** D&D 3.5e size category -> Foundry token grid squares (width = height, tokens are always square). */
+const SIZE_TOKEN_DIMENSIONS: Record<Size, number> = {
+  fine: 0.5,
+  diminutive: 0.5,
+  tiny: 1,
+  small: 1,
+  medium: 1,
+  large: 2,
+  huge: 3,
+  gargantuan: 4,
+  colossal: 6,
+};
+
 export {
   SIZE_MODIFIERS,
   SIZE_SELECT_OPTIONS,
+  SIZE_TOKEN_DIMENSIONS,
   SIZES,
 };
 

--- a/src/documents/actors/baseActor/data/ActorSystemData.mts
+++ b/src/documents/actors/baseActor/data/ActorSystemData.mts
@@ -1,4 +1,5 @@
 import type { FlyManeuverability } from '@constants/index.mjs';
+import type { Size } from '@constants/sizes.mjs';
 import type { DocumentSystemData } from '@documents/document/index.mjs';
 import type { CurrencyData } from '@fields/currency/CurrencyData.mjs';
 
@@ -18,7 +19,10 @@ interface SpeedData {
   flyManeuverability: FlyManeuverability | null;
 }
 
-interface ActorSystemSourceProperties extends DocumentSystemData {}
+interface ActorSystemSourceProperties extends DocumentSystemData {
+  /** Every actor type has a size (creatures, objects, traps, etc.) — used for token dimensions. */
+  size: Size;
+}
 
 interface ActorSystemSource extends ActorSystemSourceProperties {
   speed: SpeedData;

--- a/src/documents/actors/baseActor/data/ActorSystemModel.mts
+++ b/src/documents/actors/baseActor/data/ActorSystemModel.mts
@@ -1,7 +1,7 @@
-import { FLY_MANEUVERABILITIES } from '@constants/index.mjs';
+import { FLY_MANEUVERABILITIES, SIZES } from '@constants/index.mjs';
 import { DocumentSystemModel } from '@documents/document/data/DocumentSystemModel.mjs';
 import { CurrencyField } from '@fields/currency/CurrencyField.mjs';
-import { requiredNumberField, useDnd35eField } from '@fields/fieldBuilders.mjs';
+import { requiredNumberField, requiredTypedStringField, useDnd35eField } from '@fields/fieldBuilders.mjs';
 import { CurrencyData } from '@fields/index.mjs';
 
 import type { ActorSystemData, ActorSystemSource } from './ActorSystemData.mjs';
@@ -31,6 +31,8 @@ abstract class ActorSystemModel extends DocumentSystemModel<foundry.documents.Ac
     });
 
     schema.inventoryValue = useDnd35eField(new CurrencyField({ persisted: false }));
+
+    schema.size = useDnd35eField(requiredTypedStringField(SIZES, 'medium'));
 
     return schema;
   }

--- a/src/documents/actors/creature/Creature.mts
+++ b/src/documents/actors/creature/Creature.mts
@@ -1,5 +1,6 @@
 import { ActorDnd35e } from '@actors/baseActor/index.mjs';
 import type { DocumentConstructionContext } from '@common/_types.mjs';
+import type { DatabaseCreateCallbackOptions } from '@common/abstract/_types.mjs';
 import { getEncumberedSpeed } from '@constants/carryingCapacity.mjs';
 import { DOCUMENT_UPDATE_TYPES } from '@constants/documentUpdateTypes.mjs';
 import type { DocumentUpdateMetadata, DocumentUpdateOptions } from '@documents/document/DocumentDnd35e.mjs';
@@ -12,6 +13,7 @@ import type { CreatureSystemData, CreatureSystemSource } from './data/index.mjs'
 import { CreatureLifeCycle } from './events/CreatureLifeCycle.mjs';
 import { registerCreatureEventChecks } from './events/index.mjs';
 import { registerCreatureEvents } from './events/registerCreatureEvents.mjs';
+import { buildPrototypeTokenDefaults } from './logic/buildPrototypeTokenDefaults.mjs';
 import { handleUpdateHpViaDamage } from './logic/updateHpViaDamage.mjs';
 import { handleUpdateHpViaHealing } from './logic/updateHpViaHealing.mjs';
 import { handleNonLethalDamageUpdate } from './logic/updateNonlethalDamage.mjs';
@@ -159,6 +161,25 @@ abstract class Creature extends ActorDnd35e {
     ...super.LifeCycle,
     ...CreatureLifeCycle,
   } as const;
+
+  /**
+   * Prototype token defaults shared by all creature-type actors (characters, NPCs,
+   * etc.): linked token, friendly disposition, owner-hover HP bar, and basic vision
+   * enabled so a freshly-placed token isn't blind. Size derivation happens separately
+   * in `TokenDocumentDnd35e._preCreate()` from `system.size` once the token is placed.
+   */
+  protected override async _preCreate(
+    data: this['_source'],
+    options: DatabaseCreateCallbackOptions,
+    user: foundry.documents.BaseUser
+  ): Promise<boolean | void> {
+    const result = await super._preCreate(data, options, user);
+    if (result === false) return false;
+
+    this.updateSource({
+      prototypeToken: buildPrototypeTokenDefaults(),
+    });
+  }
 
   override prepareDerivedData(): void {
     super.prepareDerivedData();

--- a/src/documents/actors/creature/Creature.mts
+++ b/src/documents/actors/creature/Creature.mts
@@ -177,7 +177,10 @@ abstract class Creature extends ActorDnd35e {
     if (result === false) return false;
 
     this.updateSource({
-      prototypeToken: buildPrototypeTokenDefaults(),
+      prototypeToken: {
+        ...buildPrototypeTokenDefaults(),
+        ...data.prototypeToken, 
+      },
     });
   }
 

--- a/src/documents/actors/creature/data/CreatureSystemData.mts
+++ b/src/documents/actors/creature/data/CreatureSystemData.mts
@@ -1,7 +1,6 @@
 import type { AbilityKey } from '@constants/abilities.mjs';
 import type { LawAxis, MoralAxis } from '@constants/alignment.mjs';
 import type { SenseType } from '@constants/senses.mjs';
-import type { Size } from '@constants/sizes.mjs';
 import type { CurrencyData } from '@fields/currency/CurrencyData.mjs';
 import type { FormulaDataSource } from '@helpers/formulae/index.mjs';
 import type { WeaponDamage } from '@items/physical/weapon/data/index.mjs';
@@ -108,7 +107,6 @@ interface SettingsData {
 
 interface CreatureSystemSourceProperties {
   bio:          BioSource;
-  size:         Size;
   notes:        string;
   settings:     SettingsData;
 }

--- a/src/documents/actors/creature/data/CreatureSystemModel.mts
+++ b/src/documents/actors/creature/data/CreatureSystemModel.mts
@@ -7,7 +7,6 @@ import {
   MASKED_EDIT_STRATEGY,
   MORAL_AXES,
   SENSE_TYPES,
-  SIZES,
 } from '@constants/index.mjs';
 import { CurrencyField } from '@fields/currency/CurrencyField.mjs';
 import {
@@ -177,8 +176,6 @@ abstract class CreatureSystemModel extends ActorSystemModel {
     });
 
     schema.level = useDnd35eField(derivedNumberField(1), { familiar: { aliases: ['lvl'] } });
-
-    schema.size = useDnd35eField(requiredTypedStringField(SIZES, 'medium'));
 
     schema.settings = new SchemaField({
       isPartyMember: new BooleanField({ initial: false }),

--- a/src/documents/actors/creature/logic/buildPrototypeTokenDefaults.mts
+++ b/src/documents/actors/creature/logic/buildPrototypeTokenDefaults.mts
@@ -1,0 +1,25 @@
+interface PrototypeTokenDefaults {
+  actorLink: boolean;
+  disposition: number;
+  displayBars: number;
+  displayName: number;
+  bar1: { attribute: string };
+  sight: { enabled: boolean; visionMode: string };
+}
+
+/**
+ * Prototype token defaults shared by all creature-type actors (characters, NPCs,
+ * etc.): linked token, friendly disposition, owner-hover HP bar, and basic vision
+ * enabled so a freshly-placed token isn't blind. See `Creature._preCreate()`.
+ */
+const buildPrototypeTokenDefaults = (): PrototypeTokenDefaults => ({
+  actorLink: true,
+  disposition: CONST.TOKEN_DISPOSITIONS.FRIENDLY,
+  displayBars: CONST.TOKEN_DISPLAY_MODES.OWNER_HOVER,
+  displayName: CONST.TOKEN_DISPLAY_MODES.OWNER,
+  bar1: { attribute: 'hp' },
+  sight: { enabled: true, visionMode: 'basic' },
+});
+
+export { buildPrototypeTokenDefaults };
+export type { PrototypeTokenDefaults };

--- a/src/documents/actors/registration.mts
+++ b/src/documents/actors/registration.mts
@@ -2,7 +2,9 @@ import { characterActorType } from '@actors/actorTypes.mjs';
 import { ActorProxyDnd35e } from '@actors/baseActor/index.mjs';
 import { Character, CharacterSystemModel } from '@actors/character/index.mjs';
 import { CharacterSheet } from '@actors/character/sheet/CharacterSheet.mjs';
+import { TokenDnd35e } from '@canvas/token/TokenDnd35e.mjs';
 import { gatherAspectsFromSchema, registerFamiliarSchema } from '@helpers/formulae/index.mjs';
+import { TokenDocumentDnd35e } from '@scene/tokenDocument/index.mjs';
 import { SYSTEM_ID } from '@settings/shared.mjs';
 
 import { ACTOR_TYPES } from './actorTypes.mjs';
@@ -17,6 +19,8 @@ export const registerActors = () => {
 
   foundry.helpers.Hooks.once('init', () => {
     CONFIG.Actor.documentClass = ActorProxyDnd35e;
+    CONFIG.Token.objectClass = TokenDnd35e;
+    CONFIG.Token.documentClass = TokenDocumentDnd35e;
 
     Object.assign(CONFIG.Actor.dataModels, {
       [characterActorType]: CharacterSystemModel,

--- a/src/documents/scene/tokenDocument/TokenDocumentDnd35e.mts
+++ b/src/documents/scene/tokenDocument/TokenDocumentDnd35e.mts
@@ -1,7 +1,25 @@
-import TokenDocument from '@client/documents/token.mjs';
+import type { ActorDnd35e } from '@actors/baseActor/index.mjs';
+import type { DatabaseCreateCallbackOptions } from '@common/abstract/_types.mjs';
+import { SIZE_TOKEN_DIMENSIONS } from '@constants/sizes.mjs';
 
-import { SceneDnd35e } from '../SceneDnd35e.mjs';
+import type { SceneDnd35e } from '../SceneDnd35e.mjs';
 
-type TokenDocumentDnd35e<TParent extends SceneDnd35e | null = SceneDnd35e | null> = TokenDocument<TParent>;
+class TokenDocumentDnd35e<TParent extends SceneDnd35e | null = SceneDnd35e | null> extends TokenDocument<TParent> {
+  protected override async _preCreate(
+    data: this['_source'],
+    options: DatabaseCreateCallbackOptions,
+    user: foundry.documents.BaseUser
+  ): Promise<boolean | void> {
+    const result = await super._preCreate(data, options, user);
+    if (result === false) return false;
 
-export type { TokenDocumentDnd35e };
+    const actor = this.actor as ActorDnd35e | null;
+    const size = actor?.system?.size;
+    if (size && size in SIZE_TOKEN_DIMENSIONS) {
+      const dim = SIZE_TOKEN_DIMENSIONS[size];
+      this.updateSource({ width: dim, height: dim });
+    }
+  }
+}
+
+export { TokenDocumentDnd35e };

--- a/src/documents/scene/tokenDocument/index.mts
+++ b/src/documents/scene/tokenDocument/index.mts
@@ -1,3 +1,3 @@
-export type { TokenDocumentDnd35e } from './TokenDocumentDnd35e.mjs';
+export { TokenDocumentDnd35e } from './TokenDocumentDnd35e.mjs';
 // export { PrototypeTokenConfigPF2e } from "./sheets/prototype-config.ts";
 // export { TokenConfigPF2e } from "./sheets/token-config.ts";

--- a/tests/e2e/equip-toggle.spec.ts
+++ b/tests/e2e/equip-toggle.spec.ts
@@ -63,7 +63,6 @@ test.describe('equip/unequip toggle', () => {
 
     // Find the weapon row in the inventory table
     const weaponRow = page.locator(`${sheet} table tbody tr`).filter({ hasText: 'Longsword' });
-    // expect(weaponRow).toBeDefined();
     await expect(weaponRow).toHaveCount(1);
 
     // Weapon should start unequipped (no visual indicator or disabled state)

--- a/tests/e2e/equip-toggle.spec.ts
+++ b/tests/e2e/equip-toggle.spec.ts
@@ -63,7 +63,8 @@ test.describe('equip/unequip toggle', () => {
 
     // Find the weapon row in the inventory table
     const weaponRow = page.locator(`${sheet} table tbody tr`).filter({ hasText: 'Longsword' });
-    expect(weaponRow).toBeDefined();
+    // expect(weaponRow).toBeDefined();
+    await expect(weaponRow).toHaveCount(1);
 
     // Weapon should start unequipped (no visual indicator or disabled state)
     const initialEquipButton = weaponRow.locator('[data-equip-toggle]');

--- a/tests/setup.mts
+++ b/tests/setup.mts
@@ -167,3 +167,29 @@ function mergeObject<T extends Record<string, any>> (
   updateSource (..._args: any[]): void {}
   async update (..._args: any[]): Promise<this> { return this; }
 };
+
+(globalThis as any).TokenDocument = class {
+  static metadata = {};
+  constructor (..._args: any[]) {}
+  async _preCreate (..._args: any[]): Promise<boolean | void> { return true; }
+  updateSource (..._args: any[]): void {}
+  async update (..._args: any[]): Promise<this> { return this; }
+};
+
+// --- CONST -----------------------------------------------------------------
+(globalThis as any).CONST = {
+  TOKEN_DISPOSITIONS: {
+    SECRET: -2,
+    HOSTILE: -1,
+    NEUTRAL: 0,
+    FRIENDLY: 1,
+  },
+  TOKEN_DISPLAY_MODES: {
+    NONE: 0,
+    CONTROL: 10,
+    OWNER_HOVER: 20,
+    HOVER: 30,
+    OWNER: 40,
+    ALWAYS: 50,
+  },
+};

--- a/tests/unit/models/buildPrototypeTokenDefaults.test.mts
+++ b/tests/unit/models/buildPrototypeTokenDefaults.test.mts
@@ -1,0 +1,26 @@
+import { buildPrototypeTokenDefaults } from '@actors/creature/logic/buildPrototypeTokenDefaults.mjs';
+import { describe, expect, it } from 'vitest';
+
+describe('buildPrototypeTokenDefaults', () => {
+  it('links the token to its actor', () => {
+    expect(buildPrototypeTokenDefaults().actorLink).toBe(true);
+  });
+
+  it('defaults to friendly disposition', () => {
+    expect(buildPrototypeTokenDefaults().disposition).toBe(CONST.TOKEN_DISPOSITIONS.FRIENDLY);
+  });
+
+  it('shows HP bar on owner hover, name on owner', () => {
+    const defaults = buildPrototypeTokenDefaults();
+    expect(defaults.displayBars).toBe(CONST.TOKEN_DISPLAY_MODES.OWNER_HOVER);
+    expect(defaults.displayName).toBe(CONST.TOKEN_DISPLAY_MODES.OWNER);
+  });
+
+  it('tracks HP on bar1', () => {
+    expect(buildPrototypeTokenDefaults().bar1).toEqual({ attribute: 'hp' });
+  });
+
+  it('enables basic vision so a freshly-placed token is not blind', () => {
+    expect(buildPrototypeTokenDefaults().sight).toEqual({ enabled: true, visionMode: 'basic' });
+  });
+});

--- a/tests/unit/models/tokenDocument.model.test.mts
+++ b/tests/unit/models/tokenDocument.model.test.mts
@@ -1,0 +1,42 @@
+import { TokenDocumentDnd35e } from '@scene/tokenDocument/TokenDocumentDnd35e.mjs';
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * Unit tests for TokenDocumentDnd35e._preCreate() size-derived token dimensions.
+ *
+ * Uses Object.create to bypass the real constructor (which chains through the
+ * core TokenDocument/Document machinery) and invoke _preCreate() directly with
+ * a fake `actor` and a spy on `updateSource`.
+ */
+describe('TokenDocumentDnd35e._preCreate size derivation', () => {
+  const buildToken = (size: string | null) => {
+    const token = Object.create(TokenDocumentDnd35e.prototype) as TokenDocumentDnd35e;
+    (token as unknown as { actor: unknown }).actor = size ? { system: { size } } : null;
+    (token as unknown as { updateSource: unknown }).updateSource = vi.fn();
+    return token;
+  };
+
+  it.each([
+    ['fine', 0.5],
+    ['diminutive', 0.5],
+    ['tiny', 1],
+    ['small', 1],
+    ['medium', 1],
+    ['large', 2],
+    ['huge', 3],
+    ['gargantuan', 4],
+    ['colossal', 6],
+  ])('%s size maps to %s grid square(s)', async (size, expectedDimension) => {
+    const token = buildToken(size);
+    await (token as unknown as { _preCreate: (...args: unknown[]) => Promise<void> })._preCreate({}, {}, {});
+
+    expect(token.updateSource).toHaveBeenCalledWith({ width: expectedDimension, height: expectedDimension });
+  });
+
+  it('does not set dimensions when the token has no linked actor', async () => {
+    const token = buildToken(null);
+    await (token as unknown as { _preCreate: (...args: unknown[]) => Promise<void> })._preCreate({}, {}, {});
+
+    expect(token.updateSource).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Implements Story 1 of Phase 9 - Basic Tokens (docs/migration-plan/poc/phase-09-basic-tokens.md): tokens are created linked to their actor, sized from the actor's `system.size`, and given sensible prototype defaults (disposition, HP bar, basic vision).

## Changes
- **Sizing**: `SIZE_TOKEN_DIMENSIONS` maps all 9 size categories (fine -> colossal) to grid-square dimensions.
- **`TokenDocumentDnd35e`**: converted from a type alias to a real class; `_preCreate()` derives token width/height from the linked actor's size.
- **Architecture change**: moved `size` from `CreatureSystemModel`/`CreatureSystemData` up to the base `ActorSystemModel`/`ActorSystemData` - every actor type gets a size (not just creatures), so token sizing works for future non-creature actor types too.
- **`Creature._preCreate()`**: sets prototype token defaults (actor-linked, friendly disposition, owner-hover HP bar, basic vision) via a new pure helper `buildPrototypeTokenDefaults()`. Lives on `Creature` (not `ActorDnd35e`) so it applies to all creature-type actors without a type-string check.
- **CONFIG registration**: `CONFIG.Token.objectClass` / `documentClass` registered alongside the existing `CONFIG.Actor.documentClass`.
- **Misc fix**: `TokenDnd35e` now extends `foundry.canvas.placeables.Token` (the `fc.placeables` shortcut no longer resolves).
- **Misc fix**: `equip-toggle` e2e spec - replaced a no-op `expect(...).toBeDefined()` with a real assertion (`toHaveCount(1)`).

## Tests
- `tests/unit/models/tokenDocument.model.test.mts` - all 9 size categories map to correct token dimensions.
- `tests/unit/models/buildPrototypeTokenDefaults.test.mts` - actorLink, disposition, display modes, HP bar, vision.
- `tests/setup.mts` - added `TokenDocument` and `CONST` global stubs.
- Full suite green: 383 passed / 12 todo.

## Docs
`phase-09-basic-tokens.md` and `roadmap.md` updated - Story 1 marked complete, phase status -> In Progress, spec's `_preCreate` code sample corrected to match the `Creature`/pure-helper pattern actually used.

## Not in this PR
Story 2 (movement budget/ruler) and Story 3 (vision system: darkvision/low-light/tremorsense) - tracked as remaining Phase 9 work.