### PR TITLE
poc.7: Boolean formulas, \ grammar, AE sheet revamp (Story B)

### DIFF
--- a/.github/agents/silversmith.agent.md
+++ b/.github/agents/silversmith.agent.md
@@ -1,7 +1,7 @@
 ---
 name: silversmith
 description: "Phase implementer for dnd35e — executes one checklist item at a time from phase specs. Discuss-then-build workflow with approval gates, design-focused, D35E/Foundry-aware."
-tools: [search, read, vscode_listCodeUsages, agent, todo, edit, vscode/askQuestions, execute/runInTerminal, vscode_memory]
+tools: [search, read, vscode_listCodeUsages, agent, todo, edit, vscode/askQuestions, execute/runInTerminal, vscode_memory, web]
 ---
 
 # SilverSmith — Phase Implementation Agent
@@ -138,6 +138,11 @@ When the user confirms a section is complete:
 - **Foundry core**: The Foundry application files are a few levels up from the systems directory.
 - **Purpose**: Reference for migration decisions — how did D35E handle this? What worked? What should we do differently?
 - **Token discipline**: Do NOT read the entire D35E codebase. Use targeted searches via `@Explore` subagent. When a pattern is worth reusing, delegate to `@kb-curator` to write a compressed knowledge file so you never need to re-read that D35E source.
+
+### Other Foundry Systems (dnd5e, PF2e, etc.)
+- **Check local install first**: Other systems may already be installed as siblings under the Foundry systems directory (e.g. `dnd5e` is a compiled bundle, not raw source — grep the bundled `.mjs` file directly via `Select-String`/terminal search since it's outside the workspace and not covered by `grep_search`).
+- **Not installed locally? Use `web`**: If a system isn't present locally (e.g. PF2e), use the `web` tool to check its real GitHub source (`foundryvtt/pf2e`, `foundryvtt/dnd5e`) rather than answering from training-data memory alone.
+- **Always disclose provenance**: State plainly whether a claim about another system's implementation is verified against real source (local bundle or fetched GitHub file) versus general/unverified knowledge. Do not present unverified recall with the same confidence as a verified code citation.
 
 ### Existing Codebase
 - **Instruction files**: `.github/instructions/*.instructions.md` — auto-loaded patterns for fields, forms, sheets, architecture

--- a/.github/skills/system-comparison/SKILL.md
+++ b/.github/skills/system-comparison/SKILL.md
@@ -18,6 +18,8 @@ This skill helps you:
 - **Compare Foundry system implementations** across D35E (legacy), dnd5e, and PF2e
 - **Understand migration targets** — what D35E did and how dnd35e (our new system) improves on it
 - **Port mechanics** between Foundry system paradigms
+
+> **Local source availability**: D35E and dnd5e are typically installed locally as sibling systems under the Foundry systems directory (see `/d35e-reference` and `silversmith`'s "Other Foundry Systems" section for lookup instructions) — verify claims against that real source when possible. **PF2e is not available on Foundry v14 at the time of this writing** (not yet ported/compatible), so it cannot be checked locally. Use the `web` tool to check the real PF2e source on GitHub (`foundryvtt/pf2e`) instead of relying on unverified recall, and clearly disclose when a PF2e claim is unverified general knowledge vs. confirmed against fetched source.
 - **Identify D35E patterns** that carry over or need redesign
 - **Plan compatibility** with world data from the old D35E system
 

--- a/docs/migration-plan/poc/phase-07-roll-formulas.md
+++ b/docs/migration-plan/poc/phase-07-roll-formulas.md
@@ -15,7 +15,7 @@
 - **No `@attr` bridging.** The system sends zero `@`-prefixed tokens to Foundry's `Roll`/`_castChangeDelta` pipeline. Every authored formula (weapon damage, DC, AE change value, AE change condition) resolves exclusively through FormulaFamiliar's `#context.property` syntax to a literal value *before* it ever reaches `Roll` or `NumberField._castChangeDelta`. This is already how the shipped code behaves — this phase formalizes it as the permanent design rather than the two-syntax bridge originally sketched below (see §7.2).
 - **Typed resolution.** FormulaFamiliar formulas resolve to one of three output types — `string` (default, name/text interpolation), `number` (already implemented, e.g. Spell Resistance), and `boolean` (new — comparison/logical expressions like `#self.skill.concentration.ranks > 5`). Each `FormulaField`/`FormulaData` declares its `expectedType`, and resolution enforces it instead of only coercing at read time.
 - **First boolean consumer: AE change conditional gate.** A `condition` formula (boolean-typed) on an individual AE change determines whether that change applies at all. This slot already exists as a typed placeholder (`EffectChangeSourceDnd35e.condition`) — this phase implements it for real.
-- **Advanced conditional formula editor.** Every `FormulaFormGroup` gets a button (opt-out via `hideAdvancedEditor` prop) that opens one of two modes depending on the field's `expectedType`: `number`/`string` fields get **Conditional Values** (an ordered list of condition → value rules, first true condition wins, original formula becomes the trailing default); `boolean` fields (e.g. the AE Condition column) get the **Condition Builder** standalone — a single structured condition row, no rule list. Both modes share the same Condition Builder row component (aspect/formula + operator + aspect/formula, AND/OR chaining, "Edit as text" escape hatch) and compile down to a single formula string — no separate structured-data storage format. See §7.10.
+- **Story C rescoped: basic multiline editor + engine consolidation, advanced Condition Builder deferred.** Story C originally planned a full structured Condition Builder / Conditional Values rule-list UI. That's now split in two: (1) consolidate the FormulaFamiliar resolution engine (parsing, `#context.property` substitution, boolean grammar, `$conditional(when()else())`, type validation — currently spread across `utils.mts`, `evaluateBooleanExpression.mts`, `conditionalFormula.mts`) into a single `FormulaResolver` class; (2) every `FormulaFormGroup` gets a button (opt-out via `hideAdvancedEditor` prop) that opens a small modal with a multiline rich-text editor — same `#context.property` rules, highlighting, and validation as the inline field, just with line breaks allowed (line breaks are collapsed/hidden when the formula is displayed back in the single-line field). The structured aspect/operator/value pickers, AND/OR clause builder, and ordered Conditional-Values rule list are deferred to the wishlist (`docs/migration-plan/post-release/WISHLIST.md`) — the `$conditional(when()else())` grammar they'd target already ships today (§7.2a), so the wishlist item is purely front-end sugar on top of existing infra. See §7.10.
 - **Boolean grammar supports arithmetic operands.** Comparison operands in a boolean-typed formula may themselves be arithmetic sub-expressions, e.g. `#actor.hp.current > (#actor.hp.max / 2)`. Required because a `condition` string resolves as one fully-substituted expression handed whole to `evaluateBooleanExpression()` — there is no separate per-operand resolution step, so `+ - * /` (with standard precedence and unary minus) must be part of the same grammar as the comparison/logical operators. **Implemented** — see §7.2a.
 - **AE Sheet Revamp (Story B, redesigned).** Story B's first UI pass (a collapsed toggle row per change) was built, reviewed, and **rejected** — it buried the condition behind an icon and conflated the simple boolean gate with Story C's conditional-value editor. Story B is now scoped as part of a broader Changes-tab redesign, using the AE sheet (General + Material) as the flagship use case for FormulaFamiliar across the system. See §7.7b.
 
@@ -25,10 +25,10 @@
 |---|---|---|
 | **A** | Boolean-typed formulas: schema support, resolution, comparison/logical operators, validation | Existing FormulaFamiliar infra (already built — see note below) |
 | **B** | GM can gate an individual AE change on a boolean formula — change is skipped entirely when false | Story A |
-| **C** | Any formula field can be turned into an ordered list of condition → value rules ("Conditional Values") that compiles to a formula string | Story A (rule conditions are boolean formulas) |
-| **D** | (Existing POC story, §7.9) Clickable defense stat → roll dialog → chat card | §7.1/7.2 (rewritten, no `@` bridge) |
+| **C** | (Rescoped) FormulaFamiliar resolution engine consolidated into one `FormulaResolver` class; every `FormulaFormGroup` gets a basic multiline rich-text modal editor (line breaks allowed, same rules/validation as the inline field). Structured Condition Builder / Conditional Values rule-list UI deferred to `WISHLIST.md` | Story A (boolean grammar); no dependency on the deferred rule-list UI |
+| **D** | (Existing POC story, §7.9) Clickable defense stat → roll dialog → chat card. Also owns §7.7 Group Change Targets (registry mechanism only — filed here for bookkeeping, not a design dependency) | §7.1/7.2 (rewritten, no `@` bridge) |
 
-Stories A→B and A→C are the only hard dependencies; B and C can proceed in parallel once A lands. Story D is unchanged in scope but its roll-building step no longer uses `@` tokens (see §7.2).
+Stories A→B and A→C are the only hard dependencies; B and C can proceed in parallel once A lands. Story D is unchanged in scope but its roll-building step no longer uses `@` tokens (see §7.2). §7.7 (Group Change Targets) is filed under Story D as of this pass — it has no functional relationship to the roll dialog work, it's just the catch-all bucket for phase-7 scope not covered by A/B/C.
 
 > **Status note**: Much of the FormulaFamiliar plumbing this phase originally scoped as net-new (schema walker, `FormulaField`/`FormulaData`, per-context autocomplete, universal `#`-token resolution for AE change values regardless of declared `type`) **already shipped** ahead of this phase, landing alongside Phase 2/5/6 AE work. The Completion Checklist at the bottom of this doc has been updated to reflect what's actually done vs. still pending. D20Roll, DamageRoll, and the roll-dialog/chat-card pipeline (Story D) have **not** started.
 
@@ -111,18 +111,19 @@ Boolean-typed formulas support comparison and logical operators over already-sub
 #actor.hp.current > (#actor.hp.max / 2)
 ```
 
-Supported operators: `>`, `<`, `>=`, `<=`, `==`, `!=`, `&&`, `||`, `!`, `+`, `-`, `*`, `/` (standard arithmetic precedence, unary minus), parentheses for grouping. This is a small, purpose-built evaluator (`evaluateBooleanExpression()`, `src/helpers/formulae/evaluateBooleanExpression.mts`) — not a general JS `eval`, and distinct from `Roll.safeEval`. Grammar:
+Supported operators: `>`, `<`, `>=`, `<=`, `==`, `!=`, `&&`, `||`, `!`, `+`, `-`, `*`, `/` (standard arithmetic precedence, unary minus), parentheses for grouping. This is a small, purpose-built evaluator (`FormulaResolver.evaluateBooleanExpression()`, `src/helpers/formulae/FormulaResolver.mts` — consolidated there per §7.10) — not a general JS `eval`, and distinct from `Roll.safeEval`. Grammar:
 
 ```
 orExpr         := andExpr ( '||' andExpr )*
-andExpr        := notExpr ( '&&' notExpr )*
-notExpr        := '!' notExpr | comparison
+andExpr        := comparison ( '&&' comparison )*
 comparison     := additive ( ('>' | '<' | '>=' | '<=' | '==' | '!=') additive )?
 additive       := multiplicative ( ('+' | '-') multiplicative )*
 multiplicative := unary ( ('*' | '/') unary )*
-unary          := ('-' | '+') unary | primary
+unary          := ('!' | '-' | '+') unary | primary
 primary        := '(' orExpr ')' | NUMBER | STRING | 'true' | 'false' | IDENT
 ```
+
+`!` binds like JS's unary `!` — tighter than comparison, not looser. `!#self.broken > 0` reads as `(!#self.broken) > 0`, not `!(#self.broken > 0)`; wrap the comparison in parens (`!(#self.hp.value > 0)`) to negate the whole thing.
 
 **Status: implemented and tested** (`tests/unit/familiar/evaluate-boolean-expression.test.mts`).
 
@@ -237,7 +238,7 @@ this._preparationWarnings.push({
 });
 ```
 
-## 7.7 Group Change Targets
+## 7.7 Group Change Targets (Story D)
 
 ### Problem
 
@@ -466,10 +467,9 @@ No new component. The Condition column is a plain `FormulaFormGroup` with `expec
 | Create | `src/helpers/rollData.mts` — minimal `getRollData()` assembly for Foundry-native `@attr` consumers only (§7.1) |
 | Create | `src/constants/rollVariables.mts` — canonical formula path documentation |
 | Create | `src/helpers/changeTargetGroups.mts` — `ChangeTargetGroup` interface, registry, `registerChangeTargetGroup()`, `resolveChangeTargets()` |
-| Create | `src/helpers/formulae/evaluateBooleanExpression.mts` — comparison/logical operator evaluator for boolean-typed formulas (Story A, §7.2a) |
-| Create | `src/helpers/formulae/conditionalFormula.mts` — `#if(cond, then, else)` parser + serializer for the advanced editor (Story C, §7.10) |
-| Create | `src/vue/components/.../ConditionBuilder.vue` — shared condition-builder row (aspect/formula + operator ▾ + aspect/formula, AND/OR chaining, text escape hatch); used standalone for boolean fields and embedded per-rule in Conditional Values (Story C, §7.10) |
-| Create | `src/vue/components/.../ConditionalValuesEditor.vue` — rule-list builder UI embedding `ConditionBuilder` per rule (Story C, §7.10) |
+| Create | `src/helpers/formulae/FormulaResolver.mts` — consolidated resolution engine (tokenizing, substitution, boolean grammar, `$conditional(...)`, type validation) — Story C, §7.10 |
+| Delete | `src/helpers/formulae/evaluateBooleanExpression.mts`, `src/helpers/formulae/conditionalFormula.mts` — content absorbed into `FormulaResolver.mts` (Story C, §7.10) |
+| Create | Basic multiline formula editor modal (opt out via `hideAdvancedEditor`) — Story C, §7.10. `ConditionBuilder.vue`/`ConditionalValuesEditor.vue` deferred — see `docs/migration-plan/post-release/WISHLIST.md` |
 | Create | `src/documents/activeEffects/general/sheet/GeneralSheet.mts` / `.vue`, `GeneralStore.mts`, `sheet/tabs/index.mts`, `GeneralDetails.vue` — General AE custom sheet mirroring Material's pattern, bare `EffectDetails`-only Details tab (§7.7b) |
 | Create | `src/documents/activeEffects/baseActiveEffect/logic/evaluateChangeCondition.mts` — AE change conditional gate (Story B, §7.7a) |
 | Expand | Actor `getRollData()` — minimal, Foundry-native mechanics only (not our authored-formula resolution path) |
@@ -578,99 +578,54 @@ A matching `rollAC(acVariant, options)` method follows the same pipeline with AC
 
 ---
 
-## 7.10 Conditional Values & Condition Builder (Story C)
+## 7.10 Basic Formula Editor & Engine Consolidation (Story C)
 
 **User**: Anyone authoring a formula (GM or player, depending on field permissions).
-**Delivers**: An advanced-editor button appears on every `FormulaFormGroup` (opt out via a `hideAdvancedEditor` prop). What it opens depends on the field's `expectedType`:
-- **`number` / `string` fields → Conditional Values**: turns the field into an ordered list of condition → value rules. Rules evaluate top-to-bottom; the first whose condition is true supplies the result. The field's original formula becomes the trailing default, always evaluated last if no rule matches. A preview at the bottom shows the live-evaluated result and the fully compiled formula string.
-- **`boolean` fields (e.g. the AE Condition column, §7.7b) → Condition Builder, standalone**: a single structured condition row (no rule list, no value column — the field *is* the condition), same builder described below minus the per-rule wrapping.
 
-Both modes share the same **Condition Builder** component (aspect + operator + value pickers, described below) — embedded per-rule in Conditional Values, or standalone for a boolean field.
-**Depends on**: Story A (aspect type-awareness drives which operators are offered; boolean grammar is the compiled target).
+Story C is now split into two independent halves.
 
-### Layout — Conditional Values mode (`number`/`string` fields)
+### Half 1 — Consolidate the resolution engine into `FormulaResolver`
 
-Top to bottom in the editor window:
-1. **Header** — field label / context
-2. **"Add Condition" button** (relabels to **"+ Add Rule"** once at least one rule exists) — inserts a new rule row
-3. **Rule rows**, evaluated top-to-bottom. Each newly added rule is appended directly above the default — so the first rule you add is checked first, and each later addition is checked after all earlier ones, right before falling through to the default:
-   - Each row: `[Condition builder]` → `[Value formula (FormulaFormGroup, same expectedType as the field)]` → `[✕ remove row]`
-4. **Default formula** — the field's original plain `FormulaFormGroup`, now labeled as the fallback ("Otherwise…"). Always evaluated last, always present — removing all rules just leaves the plain formula field behaved exactly as it did before Conditional Values was turned on.
-5. **Preview** — live-evaluated result (when a preview context is available) plus the fully compiled formula string, read-only.
+Everything involved in parsing/resolving/validating a `#context.property` formula — tokenizing (`parseFormula`), variable substitution (`resolveFormula`), the boolean comparison/logical grammar (formerly `evaluateBooleanExpression.mts`), the `$conditional(when()else())` parser/evaluator (formerly `conditionalFormula.mts`), and type validation (`validateFormula`/`validateFormulaType`) — consolidate into a single `FormulaResolver` class (`src/helpers/formulae/FormulaResolver.mts`). `FormulaData` delegates to it instead of importing loose functions from three separate files.
 
-### Layout — Condition Builder standalone mode (`boolean` fields)
+Editor-only concerns stay separate and unmoved: `schemaWalker.mts` (schema → `AspectGroup` derivation), `registry.mts` (context/document assembly), and `utils.mts`'s HTML-highlighting/autocomplete/localization-display functions (`renderFormulaHTML`, `getAutocompleteOptions`, `localizeFormula`/`canonicalizeFormula`, etc.) — those serve the live-typing editor UI, not resolution, and folding them in would mix data-resolution concerns with HTML-rendering concerns in one file.
 
-Same editor window, drastically simpler — there's no rule list and no separate value column, since the field itself already *is* the condition:
-1. **Header** — field label / context
-2. A single **Condition Builder** row (see below)
-3. **Preview** — live-evaluated true/false result plus the compiled boolean string, read-only
+#### Compiled Syntax Reference (already implemented)
 
-No "Add Rule" button, no default formula slot — closing the editor just writes the compiled condition string back into the field, same as it would for a plain formula.
+`$conditional(when(cond₁, val₁) when(cond₂, val₂) ... else(default))` — a single inline token (like any `#context.property` reference) that resolves to whichever branch wins, with surrounding literal text/tokens untouched. Implemented and tested today in `FormulaResolver` (formerly `conditionalFormula.mts`); kept here for reference since Half 2's wishlist follow-up (structured Condition Builder) will target this same grammar.
 
-### Condition Builder (shared row component)
-
-Structured, dropdown-driven — no raw text required for the common case:
-
-```
-[ Aspect picker ▾ ]  [ Operator ▾ ]  [ Value: literal input | Aspect picker ▾ ]   ( + AND/OR another clause )
-```
-
-- **Aspect picker**: same autocomplete data source as every other `#`-token picker (schema walker's `AspectGroup` tree) — pick e.g. `#self.skill.concentration.ranks`.
-- **Operator dropdown**: options are filtered by the picked aspect's resolved type (Story A's `FieldAspect.type`):
-  - `number` → `>`, `<`, `>=`, `<=`, `==`, `!=`
-  - `string` → `==`, `!=`
-  - `boolean` → no operator needed; the row becomes a plain "is true" / "is false" toggle
-- **Right-hand value**: a literal input (number/string, matching the aspect's type) **or** a toggle to compare against another aspect instead (e.g. `#self.hp.value < #self.hp.max`).
-- **+ AND / OR**: appends another clause to the same rule's condition, joined by the selected logical operator; renders as a stacked additional `[Aspect] [Operator] [Value]` group with an "AND"/"OR" connector label.
-
-The picker compiles to the exact same boolean-formula text from §7.2a (e.g. `#self.abilities.str.mod >= 2 && #self.bab > 0`) — it's a friendlier front-end onto that grammar, not a separate one. Consequences:
-- The stored/compiled formula stays plain text; existing validation/warning/resolution code needs no changes to support it.
-- **Escape hatch**: an "Edit as text" toggle per condition row falls back to a plain boolean `FormulaFormGroup` for anyone who wants a compound expression the picker can't represent (nested parens, unusual operators). A row left in text mode simply doesn't re-parse into pickers on reopen — no forced conversion.
-
-### Compiled Syntax
-
-Grammar: `#conditional( when(cond₁, val₁) when(cond₂, val₂) ... else(default) )` — a single inline token (like any `#context.property` reference) that resolves to whichever branch wins, with surrounding literal text/tokens untouched.
-
-- **`when(condition, value)`** — zero or more, evaluated in left-to-right source order via the existing boolean grammar (§7.2a); first true `condition` wins and its `value` is resolved (recursively — a `value` may itself contain another `#conditional(...)`).
+- **`when(condition, value)`** — zero or more, evaluated in left-to-right source order via the boolean grammar (§7.2a); first true `condition` wins and its `value` is resolved (recursively — a `value` may itself contain another `$conditional(...)`).
 - **`else(value)`** — required exactly once, may appear anywhere among the clauses; supplies the result when no `when()` matches.
 - **Clause separator is don't-care**: `when(...)`/`else(...)` are self-delimiting via their own balanced parens, so a comma, whitespace, or nothing at all between clauses is equivalent — the parser just scans forward for the next `when(`/`else(` keyword.
-- **Backward compatible**: zero `#conditional(...)` blocks in a formula = today's plain-formula behavior, unchanged.
+- **Backward compatible**: zero `$conditional(...)` blocks in a formula = plain-formula behavior, unchanged.
 - **Non-selected branches are never evaluated** — avoids errors from untaken branches (e.g. a divide-by-zero in a branch that never gets picked).
-- **Matching is lenient**: `#conditional`/`when`/`else` keywords are case-insensitive, optional whitespace before `(`.
+- **Matching is lenient**: `$conditional`/`when`/`else` keywords are case-insensitive, optional whitespace before `(`.
 - **Malformed input** (unbalanced parens, missing `else()`, bad arg count) is a validation error; resolution leaves the formula raw/unresolved rather than guessing.
-- **Token/literal-text adjacency requires parens to disambiguate**: a `#context.property` token immediately followed by more literal text with no separator (e.g. `#self.sneakAttackDice` directly followed by `d6`) greedily merges into one invalid path segment, since a property path segment matches any run of letters/digits/underscores — `sneakAttackDiced6` isn't a real property, so it fails validation. This is a general, pre-existing `VARIABLE_REGEX` characteristic (not specific to `#conditional(...)`), and it's the expected/required pattern going forward: wrap the token in parens to disambiguate, e.g. `(#self.sneakAttackDice)d6`.
-- **Escaping**: `\#`, `\(`, `\)`, and `\,` escape a literal `#`/`(`/`)`/`,` character (same backslash convention throughout the formula grammar). An escaped paren doesn't count toward balanced-paren depth tracking, so a branch value can contain literal/unbalanced parens (e.g. `else(\(unbalanced\))`). Escaping the paren immediately after `when`/`else` (e.g. `when\(`) also prevents that occurrence from being parsed as a clause at all, and escaping `#conditional(`'s own `#` (`\#conditional(`) prevents the whole construct from being recognized as a block. The comma escape matters when a condition's string literal itself contains a comma — e.g. `when(#self.name == "\,", 500)` — since an unescaped comma there would be mistaken for the top-level separator between the clause's own `condition`/`value` arguments.
-- **Condition grammar reminders (from §7.2a)**: string literals accept single **or** double quotes interchangeably; equality is `==` (loose/truthy comparison, coerces number↔string as needed) — there is no single `=` (reserved, unused) and no `===` (not needed at this time). A condition that resolves to a non-boolean value is coerced truthy: numbers are truthy unless `0`, strings are truthy unless empty — e.g. `when(#self.name, 1)` is true whenever the name isn't an empty string.
+- **Token/literal-text adjacency requires parens to disambiguate**: a `#context.property` token immediately followed by more literal text with no separator (e.g. `#self.sneakAttackDice` directly followed by `d6`) greedily merges into one invalid path segment — wrap the token in parens to disambiguate, e.g. `(#self.sneakAttackDice)d6`.
+- **Escaping**: `\#`, `\(`, `\)`, and `\,` escape a literal `#`/`(`/`)`/`,` character. An escaped paren doesn't count toward balanced-paren depth tracking, so a branch value can contain literal/unbalanced parens (e.g. `else(\(unbalanced\))`).
+- **Condition grammar reminders (from §7.2a)**: string literals accept single **or** double quotes interchangeably; equality is `==` (loose/truthy comparison) — no single `=`, no `===`. A condition resolving to a non-boolean value is coerced truthy (numbers truthy unless `0`, strings truthy unless empty). `$and`/`$or` are case-insensitive keyword aliases for `&&`/`||`, fully interchangeable with the symbol form.
 
 ```
-#conditional(when(#self.hp.value <= 0, 0) when(#target.isFlanked, 1d6+(#self.sneakAttackDice)d6) else(2d6))
+$conditional(when(#self.hp.value <= 0, 0) when(#target.isFlanked, 1d6+(#self.sneakAttackDice)d6) else(2d6))
 ```
-Reads: "2d6, unless HP ≤ 0 (then 0), unless flanked (then 1d6 + sneak attack dice)." (`(#self.sneakAttackDice)d6` wraps the token in parens per the adjacency rule above — without the parens, `d6` would merge into the token's path segment and fail validation.)
+Reads: "2d6, unless HP ≤ 0 (then 0), unless flanked (then 1d6 + sneak attack dice)."
 
-Supersedes the earlier `#if(condition, value, elseExpr)` right-nested-chain proposal — same problem (first-match-wins rule list with a mandatory default), but expressed as a flat rule list rather than nested ternaries, matching how "Conditional Values" actually presents to the user (a list of rules + a fallback, not a chain).
+### Half 2 — Basic multiline formula editor
 
-### Opening on an Existing Formula (Round-Trip)
+**Delivers**: An editor button appears on every `FormulaFormGroup` (opt out via a `hideAdvancedEditor` prop). Clicking it opens a small modal containing a multiline rich-text editor for the same formula — identical `#context.property` rules, autocomplete, validation, and highlighting as the inline single-line field, but line breaks are allowed. Line breaks are collapsed/hidden when the value is displayed back in the normal single-line `FormulaFormGroup` field (a display-only transform — the stored formula keeps its real newlines).
 
-Because storage is text-only, opening the editor on an existing value requires parsing it back into rule rows:
+No variable/logic insertion helpers (aspect-picker buttons, operator buttons, snippet insertion) ship in this pass — the modal is a plain rich-text box using the exact same editing rules as today's inline field, just bigger and multiline.
 
-- If the formula contains a `#conditional(...)` block → parse its `when()` clauses into rule rows (in source order) and its `else()` into the default.
-- If it doesn't (a plain value, a hand-typed expression, or anything not expressible in this grammar) → the whole string becomes the default value; the rule list starts empty (best-effort: never silently discard the user's existing formula).
-- Each parsed rule's *condition* is additionally checked against the "simple comparison (+ AND/OR chain)" shape to decide whether it opens in structured-picker mode or falls back to "Edit as text" mode for that one row.
-
-> **Open decision** (explore at implementation start): whether partial/best-effort parsing (recovering a rule list from loosely-formed input) is worth the complexity vs. the simpler "exact grammar or start fresh" rule above. Default: exact-grammar-only — if it doesn't parse cleanly, treat the whole existing string as the default value.
+**Deferred to wishlist** (`docs/migration-plan/post-release/WISHLIST.md`): the structured Condition Builder (aspect + operator + value pickers, AND/OR clause chaining, "Edit as text" escape hatch) and the Conditional Values ordered rule-list editor (add/remove rule rows, live preview, round-trip parsing of an existing `$conditional(...)` block back into rule rows). The `$conditional(when()else())` grammar those would target is already fully implemented and tested (§7.2a) — the wishlist item is purely a friendlier front-end onto that existing grammar, not new resolution logic.
 
 ### Tests
 
-- [ ] Adding a rule inserts a condition+value row above the default; default remains last
-- [ ] Adding a second rule appends it above the default but below the first rule (first-added = evaluated first)
-- [ ] Structured condition compiles to correct boolean text for `number`, `string`, and `boolean` aspect types
-- [ ] AND/OR clause chaining compiles correctly and matches §7.2a's grammar
-- [ ] Comparing against another aspect (not just a literal) compiles correctly
-- [ ] "Edit as text" escape hatch accepts arbitrary boolean formulas and round-trips them as raw text on reopen
-- [ ] Removing a rule re-flattens the chain correctly (no orphaned nesting)
-- [ ] Preview shows correct live result and correct compiled string for a 3+ rule chain
-- [ ] Opening the editor on an existing plain (non-conditional) formula shows it as the default, no rules
-- [ ] Opening the editor on an existing compiled `#conditional(...)` block reconstructs the rule list correctly
+- [ ] `FormulaResolver` consolidation: existing test suites for the boolean grammar, `$conditional(...)` parsing/resolution, `resolveFormula`, and `validateFormula`/`validateFormulaType` all pass unchanged (import path updated to `FormulaResolver.mjs`, behavior identical)
+- [ ] Basic multiline modal: opening the editor shows the current formula with real line breaks
+- [ ] Basic multiline modal: typing/pasting a newline is preserved in the stored formula
+- [ ] Inline `FormulaFormGroup` display collapses/hides line breaks from a formula that contains them
+- [ ] Basic multiline modal: `#context.property` highlighting/validation/autocomplete behave identically to the inline field
+- [ ] `hideAdvancedEditor` prop suppresses the editor button
 
 ---
 
@@ -749,25 +704,28 @@ The FormulaFamiliar core plumbing shipped ahead of this phase, landing alongside
 - [x] Remove the rejected branch-toggle button + collapsible condition row
 - [x] Derive Value column's `expected-type` from the picked aspect (`findAspectByAccessPath()`)
 - [x] Add Condition column: plain `FormulaFormGroup` (`expectedType: 'boolean'`), no new compound component
-- [ ] Extend formula syntax highlighting to tag comparison/logical operators (`>`, `<`, `==`, `&&`, `||`, etc.), not just `#tokens`
-- [ ] Add `hideAdvancedEditor` opt-out prop to `FormulaFormGroup.vue`
-- [ ] Create General AE custom sheet (`GeneralSheet.mts`/`.vue`, `GeneralStore.mts`, `sheet/tabs/index.mts`) mirroring Material's pattern
-- [ ] Test: Condition column accepts and evaluates a boolean formula with operator highlighting
-- [ ] Test: Value column rejects/flags a formula that doesn't match the picked aspect's type
-- [ ] Test: General AE sheet renders Changes/Duration tabs with parity to Material
+- [x] Extend formula syntax highlighting to tag comparison/logical operators (`>`, `<`, `>=`, `<=`, `==`, `!=`, `&&`, `||`), not just `#tokens` — same blue/valid, yellow/still-typing, red/invalid-operand contract as `!` and `()`, reusing shared `classifyOperandForward()`/`classifyOperandBackward()`/`classifyBinaryOperator()` classifiers in `utils.mts`; `&&`/`||` cascade validity through their parenthesized operands via the existing paren-matched-state check (no deep sub-expression validation needed). Added real DOM-focus-based severity escalation (`isFocused` param on `renderFormulaHTML()`, `escalateOnBlur()`): a still-typing operand renders yellow while the field is focused, and escalates to red once the field blurs — applied uniformly to `!`, `()`, comparisons, `&&`/`||`, and the two variable-token "still typing"/"fallback" branches. `useFormulaEditor.mts`'s focus tracking was converted from a non-reactive closure flag to a reactive `isFocused` ref feeding this. AND/OR word-keyword syntax was initially deferred by the user for future consideration (`&&`/`||` symbols only); later implemented as `$and`/`$or` keyword aliases (not `#and`/`#or` — see the sigil rescope note below) once the `#` vs `$` sigil split was settled. See `tests/unit/familiar/render-formula-html-comparison-operators.test.mts`.
+- [x] Highlight `$conditional`/`when(`/`else(` as their own keyword class (new `.formula-keyword`, purple — distinct from data-bound `#context.property` tokens): `$conditional` tracks its block's own well-formedness (purple when clean; yellow-while-focused/red-once-blurred for still-typing states `unbalancedParens`/`missingElse`; always-red for genuinely malformed states `multipleElse`/`whenArgCount`/`elseArgCount` — see `conditionalErrorState()` in `utils.mts`), with the specific localized error as a tooltip. `when(`/`else(` are always plain purple (validity tracked only at the `$conditional` token). Nested `#context.property` tokens and operators inside `when()`/`else()` clauses continue to highlight normally, unaffected. See `tests/unit/familiar/render-formula-html-conditional-keyword.test.mts`.
+- [x] Sigil rescope: the conditional keyword moved from `#conditional(...)` to `$conditional(...)` — `#` is reserved for context/property data references, `$` for control-flow/keyword constructs — eliminating the `isConditionalKeywordToken()` disambiguation hack entirely (a `$`-prefixed token is never extracted as a `#`-style variable in the first place). Also added `$and`/`$or` as case-insensitive keyword aliases for `&&`/`||` in the boolean grammar (`FormulaResolver.booleanGrammar.mts`), rendered as `.formula-operator` like their symbol equivalents. `when`/`else` intentionally kept bare (no `$` prefix) — no disambiguation need, and shorter is better.
+- [x] Create General AE custom sheet (`GeneralSheet.mts`/`.vue`, `GeneralStore.mts`) mirroring Material's pattern — thin pass-through leaf store reusing the base `getDefaultActiveEffectTabs()` directly (no custom tabs needed; General has no fields beyond the base Details/Duration/Changes schema)
+- [x] Test: Condition column accepts and evaluates a boolean formula with operator highlighting
+- [x] Test: Value column rejects/flags a formula that doesn't match the picked aspect's type
+- [x] Test: General AE sheet renders Changes/Duration tabs with parity to Material
 
-**Condition Builder & Conditional Values (Story C, §7.10):**
-- [ ] Build shared **Condition Builder** row component (aspect/formula + operator ▾ + aspect/formula, AND/OR clause chaining, "Edit as text" escape hatch per row)
-- [ ] Wire Condition Builder in **standalone mode** as the advanced-editor target for boolean-typed `FormulaFormGroup`s (Condition column included)
-- [ ] Wire Condition Builder **embedded per-rule** inside Conditional Values for number/string fields
-- [x] Implement `#conditional(when(cond, value) ... else(default))` parser + evaluator (new, `src/helpers/formulae/conditionalFormula.mts`) — flat rule-list shape, `else()` required exactly once, position-independent among clauses; includes `\#`/`\(`/`\)` escaping and parens-required-for-adjacency handling
-- [x] Hook parser into `FormulaData.resolve()`/`resolveSource()` and into `utils.mts`'s `resolveFormula()`/`validateFormula()` so `#conditional(` isn't flagged as an unknown context and malformed blocks surface a structural `ValidationError`
-- [ ] Create `ConditionalValuesEditor.vue` (or equivalent) — rule-list builder UI embedding the Condition Builder per rule
-- [ ] Add "Add Condition" button to `FormulaFormGroup.vue`'s controls; relabels to "+ Add Rule" once a rule exists
-- [ ] Implement live preview (result + compiled formula string) at the bottom of the editor
-- [ ] Save path: serialize rule list → `#conditional(when(...) ... else(...))` block → same `onCommit` the plain text input uses
-- [ ] Non-`#conditional(...)`-parseable existing values: preserve as the default value rather than discarding (see §7.10's round-trip note)
-- [ ] Test: all ten cases listed under §7.10's Tests subsection
+**Basic Formula Editor & Engine Consolidation (Story C, §7.10):**
+- [x] Implement `$conditional(when(cond, value) ... else(default))` parser + evaluator (flat rule-list shape, `else()` required exactly once, position-independent among clauses; includes `\$`/`\(`/`\)` escaping and parens-required-for-adjacency handling) — shipped ahead of this rescope, now living in `FormulaResolver`
+- [x] Hook parser into `FormulaData.resolve()`/`resolveSource()` and into resolution/validation so `$conditional(` isn't flagged as an unknown context and malformed blocks surface a structural `ValidationError` — shipped ahead of this rescope
+- [ ] Create `src/helpers/formulae/FormulaResolver.mts`: consolidate `parseFormula`, `extractVariables`, `resolveFormula`, `getNestedValue`, `fieldAspect`, `getFieldAspect`, `getPropertyValue`, `findAspectByAccessPath`, `mergeAspectGroups`, `filterExcludedFields`, `validateFormula`, `validateFormulaType`, the boolean grammar (formerly `evaluateBooleanExpression.mts`), and the `$conditional(...)` parser (formerly `conditionalFormula.mts`) as static methods on one class
+- [ ] Update `FormulaData.mts` to call `FormulaResolver.*` instead of importing loose functions from three files
+- [ ] Update all cross-file call sites (Vue components, `registry.mts`, tests) to the new import path
+- [ ] Delete `evaluateBooleanExpression.mts` and `conditionalFormula.mts` (content absorbed)
+- [ ] Build clean; all existing familiar/effects unit tests pass unchanged (behavior-preserving refactor)
+- [ ] Add basic multiline editor button to `FormulaFormGroup.vue`'s controls, including its `hideAdvancedEditor` opt-out prop (moved here from §7.7b — can't have an opt-out for a button that doesn't exist yet; this is where the button itself is built)
+- [ ] Create the multiline modal component: rich-text box, same `#context.property` validation/highlighting/autocomplete as the inline field, line breaks allowed
+- [ ] Inline `FormulaFormGroup` display: collapse/hide line breaks when rendering a multiline formula back in the single-line field
+- [ ] Save path: modal writes back through the same `onCommit` the plain text input uses
+- [ ] Test: all cases listed under §7.10's Tests subsection
+- [ ] Wishlist: file the deferred Condition Builder / Conditional Values rule-list editor in `docs/migration-plan/post-release/WISHLIST.md` (done as part of this rescope)
 
 **D20Roll Custom Class** in `src/dice/D20Roll.mts`:
 - [ ] Extend Foundry's `Roll` class
@@ -898,9 +856,9 @@ The FormulaFamiliar core plumbing shipped ahead of this phase, landing alongside
 **POC Story 7.9 — Clickable Defense Stat → Roll → Chat Card:**
 
 *`CreatureDefenseStat.vue`*
-- [ ] Create `src/vue/components/actors/CreatureDefenseStat.vue`
-- [ ] Props: `label: string`, `value: number`, `rollable: boolean` (default `true`)
-- [ ] Edit mode: read-only display, no click handler
+- [x] `src/documents/actors/creature/sheet/components/CreatureDefenseStat.vue` already exists (read-only shield display: `label`/`value`/`sublabel`/tooltips) — different path than originally sketched (`src/vue/components/actors/`), and it is NOT yet interactive. Extend this component rather than creating a new one.
+- [ ] Add `rollable: boolean` prop (default `true`)
+- [ ] Edit mode: read-only display, no click handler (already true today, since there's no click handler at all yet)
 - [ ] Play / True mode: cursor pointer, click emits roll intent
 - [ ] Wire into header stat pills: Fort | Ref | Will | AC (normal)
 - [ ] Wire into Combat tab rows: all three AC variants + fort/ref/will rows

--- a/docs/migration-plan/poc/phase-07-roll-formulas.md
+++ b/docs/migration-plan/poc/phase-07-roll-formulas.md
@@ -1,12 +1,36 @@
 # POC Phase 7: Roll Formulas & Custom Rolls
 
-**Status**: 📋 Outlined (FormulaFamiliar system, action formulas)
+**Status**: 🔶 In Progress (FormulaFamiliar system, action formulas)
 
 > **Milestone**: POC  
 > **Dependencies**: Phase 5  
-> **Goal**: Formalize how roll formulas are constructed, resolved, and how roll data is assembled across the system. Ensure all formulas use FormulaFamiliar `#context.property` syntax with proper context inheritance (actor → item → action). Create D20Roll and DamageRoll custom roll classes used by Phase 8 (Action System).
+> **Goal**: Formalize how roll formulas are constructed, resolved, and how roll data is assembled across the system. Ensure all formulas use FormulaFamiliar `#context.property` syntax with proper context inheritance (actor → item → action). Create D20Roll and DamageRoll custom roll classes used by Phase 10 (Action System).
 
-> **Action System note**: This phase creates all the formula plumbing that Phase 8 consumes. D20Roll handles auto-crit/fumble confirmation. DamageRoll handles critical multipliers and damage type tagging. FormulaFamiliar contexts declared here (`#self.*`, `#item.*`) are extended with `#action.*` and `#target.*` in Phase 8.
+> **Action System note**: This phase creates all the formula plumbing that Phase 10 consumes. D20Roll handles auto-crit/fumble confirmation. DamageRoll handles critical multipliers and damage type tagging. FormulaFamiliar contexts declared here (`#self.*`, `#item.*`) are extended with `#action.*` and `#target.*` in Phase 10.
+
+---
+
+## Design Decisions (this planning pass)
+
+- **No `@attr` bridging.** The system sends zero `@`-prefixed tokens to Foundry's `Roll`/`_castChangeDelta` pipeline. Every authored formula (weapon damage, DC, AE change value, AE change condition) resolves exclusively through FormulaFamiliar's `#context.property` syntax to a literal value *before* it ever reaches `Roll` or `NumberField._castChangeDelta`. This is already how the shipped code behaves — this phase formalizes it as the permanent design rather than the two-syntax bridge originally sketched below (see §7.2).
+- **Typed resolution.** FormulaFamiliar formulas resolve to one of three output types — `string` (default, name/text interpolation), `number` (already implemented, e.g. Spell Resistance), and `boolean` (new — comparison/logical expressions like `#self.skill.concentration.ranks > 5`). Each `FormulaField`/`FormulaData` declares its `expectedType`, and resolution enforces it instead of only coercing at read time.
+- **First boolean consumer: AE change conditional gate.** A `condition` formula (boolean-typed) on an individual AE change determines whether that change applies at all. This slot already exists as a typed placeholder (`EffectChangeSourceDnd35e.condition`) — this phase implements it for real.
+- **Advanced conditional formula editor.** Every `FormulaFormGroup` gets a button (opt-out via `hideAdvancedEditor` prop) that opens one of two modes depending on the field's `expectedType`: `number`/`string` fields get **Conditional Values** (an ordered list of condition → value rules, first true condition wins, original formula becomes the trailing default); `boolean` fields (e.g. the AE Condition column) get the **Condition Builder** standalone — a single structured condition row, no rule list. Both modes share the same Condition Builder row component (aspect/formula + operator + aspect/formula, AND/OR chaining, "Edit as text" escape hatch) and compile down to a single formula string — no separate structured-data storage format. See §7.10.
+- **Boolean grammar supports arithmetic operands.** Comparison operands in a boolean-typed formula may themselves be arithmetic sub-expressions, e.g. `#actor.hp.current > (#actor.hp.max / 2)`. Required because a `condition` string resolves as one fully-substituted expression handed whole to `evaluateBooleanExpression()` — there is no separate per-operand resolution step, so `+ - * /` (with standard precedence and unary minus) must be part of the same grammar as the comparison/logical operators. **Implemented** — see §7.2a.
+- **AE Sheet Revamp (Story B, redesigned).** Story B's first UI pass (a collapsed toggle row per change) was built, reviewed, and **rejected** — it buried the condition behind an icon and conflated the simple boolean gate with Story C's conditional-value editor. Story B is now scoped as part of a broader Changes-tab redesign, using the AE sheet (General + Material) as the flagship use case for FormulaFamiliar across the system. See §7.7b.
+
+## Stories (this decomposition)
+
+| Story | Delivers | Depends on |
+|---|---|---|
+| **A** | Boolean-typed formulas: schema support, resolution, comparison/logical operators, validation | Existing FormulaFamiliar infra (already built — see note below) |
+| **B** | GM can gate an individual AE change on a boolean formula — change is skipped entirely when false | Story A |
+| **C** | Any formula field can be turned into an ordered list of condition → value rules ("Conditional Values") that compiles to a formula string | Story A (rule conditions are boolean formulas) |
+| **D** | (Existing POC story, §7.9) Clickable defense stat → roll dialog → chat card | §7.1/7.2 (rewritten, no `@` bridge) |
+
+Stories A→B and A→C are the only hard dependencies; B and C can proceed in parallel once A lands. Story D is unchanged in scope but its roll-building step no longer uses `@` tokens (see §7.2).
+
+> **Status note**: Much of the FormulaFamiliar plumbing this phase originally scoped as net-new (schema walker, `FormulaField`/`FormulaData`, per-context autocomplete, universal `#`-token resolution for AE change values regardless of declared `type`) **already shipped** ahead of this phase, landing alongside Phase 2/5/6 AE work. The Completion Checklist at the bottom of this doc has been updated to reflect what's actually done vs. still pending. D20Roll, DamageRoll, and the roll-dialog/chat-card pipeline (Story D) have **not** started.
 
 ---
 
@@ -39,55 +63,81 @@ interface ItemRollData extends ActorRollData {
 }
 ```
 
+> **Scope of `getRollData()`**: This shape exists **only** to satisfy Foundry-native `@attr` consumers we don't control — e.g. the Combat Tracker's initiative formula setting (`CONFIG.Combat.initiative.formula`). It is not a resolution path any of our own authored formulas travel (see §7.2). Keep it minimal; do not expand it in lockstep with every FormulaFamiliar aspect.
+
 ## 7.2 Formula Resolution Pipeline
 
-1. **Author time**: User writes formula in a field (e.g., `"#self.abilities.str.mod + #self.bab"`)
-2. **FormulaFamiliar**: Schema walker provides autocomplete for `#context.property` paths
-3. **Prep time**: `prepareDerivedData()` resolves formulas that are needed for derived values via `Dnd35eDocumentMixin._buildFormulaContexts()`
-4. **Roll time**: `Roll.fromTerms()` resolves remaining formulas with full roll data context (including `#target.*` added at execution time)
-5. **Error handling**: Invalid formulas surface warnings via the preparation warning system (not blocking)
+1. **Author time**: User writes a formula in a field (e.g., `"#self.abilities.str.mod + #self.bab"`), or turns it into Conditional Values for branching logic (§7.10).
+2. **FormulaFamiliar**: Schema walker provides autocomplete for `#context.property` paths as the user types.
+3. **Prep time**: `prepareDerivedData()` resolves formulas needed for derived values via the document's familiar context (`buildDocumentFamiliar()` / `buildDocumentDataMap()`).
+4. **Resolution**: `FormulaData.resolve()` / `FormulaData.resolveSource()` substitute every `#context.property` token with its live value, then coerce/validate the result against the field's `expectedType` (`string` / `number` / `boolean` — see §7.2a).
+5. **Roll time**: The fully-resolved formula (a plain dice-notation string with zero `#` or `@` tokens remaining, e.g. `"1d8 + 4"`) is handed directly to `Roll.create()`. There is no second substitution pass.
+6. **Error handling**: Invalid formulas surface warnings via the preparation warning system (§7.6, not blocking).
 
-### FormulaFamiliar ↔ Foundry Roll Data Bridge
+### No `@attr` Bridge
 
-Two formula syntaxes coexist in the system:
-- **`@attr`** — Foundry's native syntax. Evaluated by `Roll.replaceFormulaData()` and `NumberField._castChangeDelta()`. Used in initiative formulas, standard AE change values, inline rolls.
-- **`#context.property`** — FormulaFamiliar syntax. Evaluated by `FormulaFamiliar.resolve()`. Used in the formula editor UI, cross-document references, FormulaField values.
+FormulaFamiliar's `#context.property` syntax is the **only** authoring syntax the system supports. We do not translate to, accept, or emit Foundry's native `@attr` syntax anywhere in an authored formula's resolution path:
 
-Both resolve to the same underlying data. The bridge ensures they never drift:
+- Weapon damage formulas, DC formulas, AE change values, and AE change conditions (§7.7a) resolve exclusively through `FormulaData.resolve()` / `resolveActiveEffectChangeValue()`.
+- The resolved output is always a literal (a number, a boolean, or a plain string/dice-formula) — never a string containing `@` tokens.
+- Foundry itself still calls `getRollData()` for its own native mechanics we don't control (initiative formula, etc. — see the callout at the end of §7.1). That is a narrow accommodation, not a general bridge.
 
-```typescript
-// Resolution pipeline (Phase 7)
-function resolveFormula(formula: string, familiar: FamiliarSchema, rollData: Record<string, any>): string {
-  // Step 1: Resolve #context.property tokens via FormulaFamiliar
-  let resolved = FormulaFamiliar.resolve(formula, familiar);
-  // Step 2: Remaining @attr tokens resolved by Foundry's Roll.replaceFormulaData()
-  resolved = Roll.replaceFormulaData(resolved, rollData);
-  return resolved;
-}
+This is already how the shipped code behaves: `resolveActiveEffectChangeValue()` (`resolveChangeValue.mts`) resolves every AE change's `value` through `FormulaData.resolveSource()` regardless of the change's declared `type`. This section formalizes that as the permanent design — the two-syntax bridge originally sketched for this phase is not being built.
+
+### Custom AE Change Type: `familiar` — Removed
+
+`CONFIG.ActiveEffect.changeTypes.familiar` (`handler: null` placeholder) was registered speculatively and never used. It leaked into the AE sheet's Type dropdown as a nonsensical user-selectable option — since any `CONFIG.ActiveEffect.changeTypes` entry automatically becomes user-selectable via `ActiveEffect.CHANGE_TYPES` in any UI that iterates that getter. **Resolved**: removed entirely (registration, the `CHANGE_TYPE.FAMILIAR` constant, its `SystemActiveEffectChangeTypes` type augmentation in `global.mts`, and its localization key). Do not conflate change *types* (Add/Multiply/Override/etc. — how a value combines onto a field) with the `condition` field (§7.7a) — `condition` gates whether *any* change, of any type, applies at all.
+
+## 7.2a Typed Formula Outputs (Story A)
+
+Every `FormulaField`/`FormulaData` already declares an `expectedType` (`'string' | 'number'`, e.g. Spell Resistance uses `'number'`). This phase adds a third type and makes resolution enforce the declared type rather than only coercing at read time.
+
+### `expectedType: 'string' | 'number' | 'boolean'`
+
+| Type | Use | Example field | Resolution behavior |
+|---|---|---|---|
+| `string` | Text interpolation (names, descriptions) | Item name formula | Substituted tokens joined as-is; no coercion |
+| `number` | Numeric derived values | Spell Resistance, weapon damage bonus | After substitution, evaluate via `Roll.safeEval` (dice-formula arithmetic); non-numeric result is a validation error |
+| `boolean` *(new)* | Gates and conditions | AE change `condition` (§7.7a), rule conditions in Conditional Values (§7.10) | After substitution, evaluate via a new small comparison/logical expression evaluator — `Roll.safeEval` has no `>`/`&&`/etc. |
+
+### Boolean Expression Grammar
+
+Boolean-typed formulas support comparison and logical operators over already-substituted numeric/string literals, and comparison operands may be arithmetic sub-expressions:
+
+```
+#self.skill.concentration.ranks > 5
+#self.abilities.str.mod >= 2 && #self.bab > 0
+!#self.hasCondition
+#actor.hp.current > (#actor.hp.max / 2)
 ```
 
-**`getRollData()` generated from schema metadata**: Phase 5's `getRollData()` and FormulaFamiliar's schema walker should derive their structures from the same source to prevent drift. The schema walker already traverses `defineSchema()` — extend it to generate the `getRollData()` shape as well.
+Supported operators: `>`, `<`, `>=`, `<=`, `==`, `!=`, `&&`, `||`, `!`, `+`, `-`, `*`, `/` (standard arithmetic precedence, unary minus), parentheses for grouping. This is a small, purpose-built evaluator (`evaluateBooleanExpression()`, `src/helpers/formulae/evaluateBooleanExpression.mts`) — not a general JS `eval`, and distinct from `Roll.safeEval`. Grammar:
 
-### Custom AE Change Type: `familiar`
-
-The `familiar` change type (registered in Phase 2, handler implemented here) bridges FormulaFamiliar into AE change values:
-
-```typescript
-// Handler implementation for CONFIG.ActiveEffect.changeTypes.familiar
-CONFIG.ActiveEffect.changeTypes.familiar = {
-  label: 'DND35E.EFFECT.CHANGE_TYPE.familiar',
-  defaultPriority: 25,
-  handler: (targetDoc, change, options) => {
-    const familiar = buildDocumentFamiliar(targetDoc);
-    const resolved = FormulaFamiliar.resolve(change.value, familiar);
-    const delta = Number(resolved) || 0;
-    const current = foundry.utils.getProperty(targetDoc, change.key) ?? 0;
-    foundry.utils.setProperty(targetDoc, change.key, current + delta);
-  }
-};
+```
+orExpr         := andExpr ( '||' andExpr )*
+andExpr        := notExpr ( '&&' notExpr )*
+notExpr        := '!' notExpr | comparison
+comparison     := additive ( ('>' | '<' | '>=' | '<=' | '==' | '!=') additive )?
+additive       := multiplicative ( ('+' | '-') multiplicative )*
+multiplicative := unary ( ('*' | '/') unary )*
+unary          := ('-' | '+') unary | primary
+primary        := '(' orExpr ')' | NUMBER | STRING | 'true' | 'false' | IDENT
 ```
 
-Users authoring AE changes via our Vue sheet can choose `familiar` as the change type and write `#self.abilities.str.mod` in the value field. Standard `add`/`override`/etc. change types continue to use `@attr` syntax — evaluated by Foundry's native `NumberField._castChangeDelta()` for free.
+**Status: implemented and tested** (`tests/unit/familiar/evaluate-boolean-expression.test.mts`).
+
+### Schema Walker & `FieldAspect` Changes
+
+- `schemaWalker.mts`: `inferFieldType()` gains a `BooleanField → 'boolean'` branch (currently only distinguishes `NumberField` from everything else — every other field, including `BooleanField`, falls into `'string'`).
+- `FieldAspect.type` widens from `'string' | 'number'` to `'string' | 'number' | 'boolean'` (`types.mts`).
+- `FormulaFieldMeta.aspectType` override widens to match.
+- Autocomplete/validation in `FormulaFormGroup.vue` / `useFormulaEditor.mts` flags a type mismatch (e.g. a `number`-typed field whose formula resolves to a boolean) as a validation error, not just a silent runtime fallback.
+
+### `FormulaData` / `FormulaField` Changes
+
+- `FormulaData.defineSchema()`: `expectedType` choices become `['string', 'number', 'boolean']`.
+- `FormulaData._finalizeResolvedValue()`: branch on `'boolean'` — run `evaluateBooleanExpression()` instead of `Roll.safeEval`; store `'true'`/`'false'` as the resolved string (consistent with how `resolveActiveEffectChangeValue()` already special-cases `BooleanField` results).
+- `FormulaField` constructor options: `expectedType` widens to include `'boolean'`.
 
 ## 7.3 FormulaFamiliar Context Declarations
 
@@ -130,6 +180,8 @@ Establish and document the canonical `#context.property` paths:
 | `#item.enhancement` | Item's enhancement bonus |
 | `#target.defense.armorClass` | Target's AC (at execution time) |
 | `#action.attackBonus` | Action's computed attack bonus |
+| `#self.skill.concentration.ranks > 5` | Boolean gate example — true when ranks exceed 5 |
+| `#self.abilities.str.mod >= 2 && #self.bab > 0` | Boolean gate example — compound condition |
 
 ## 7.5 Custom Roll Classes
 
@@ -292,6 +344,118 @@ D35E's `getChangeFlat()` + `buffTargets` config served the same purpose but was 
 
 This system is orthogonal to field permission metadata for schema field groups on item sheets (e.g., the `hp` section). Group Change Targets are about AE targeting — expanding a single AE change across multiple fields at runtime. Field permission concerns are handled by schema metadata (`useDnd35eField()` defaults) plus runtime overrides in `flags.dnd35e.fieldOverrides`. Neither system depends on the other.
 
+### Relationship to AE Change Conditional Gate (§7.7a)
+
+Also orthogonal, and easy to conflate since both live on the `changes` array. Group Change Targets expand a change's **key** (one change → many field paths, all values identical). The conditional gate (§7.7a) decides whether a change **applies at all** (one change → applied or entirely skipped). A single change entry can use both: a `group:allSaves` key with a `condition` formula that must be true for the whole group to apply.
+
+## 7.7a AE Change Conditional Gate (Story B)
+
+**User**: GM authoring an Active Effect.
+**Delivers**: An individual change row in the AE sheet's change list gets an optional boolean formula. When present and it resolves to `false` at apply time, that change is skipped entirely — as if it weren't in the `changes` array for this preparation cycle. When absent (`null`), the change always applies (current behavior, unchanged).
+**Depends on**: Story A (boolean-typed formula resolution).
+
+### Schema
+
+`EffectChangeSourceDnd35e.condition` already exists as a typed placeholder (`ActiveEffectSystemData.mts`):
+```ts
+condition?: string | null;
+```
+This phase adds it to the actual Foundry schema — `ActiveEffectSystemModel.defineSchema()`'s `changes` `ArrayField`/`SchemaField` currently has no `condition` field:
+```ts
+condition: new StringField({ required: false, nullable: true, initial: null }),
+```
+String-only, no function form — `condition` is persisted to the database as part of the change entry, and a function could never round-trip through it. Live-computed changes with no backing AE document (`ItemDnd35e.getContributedActorChanges()`, `ActorDnd35e.getSelfContributedChanges()`) use the same string-form grammar if they ever need a condition (none currently do — they're filtered unconditionally in TS before the change entry is even built, e.g. Creature's encumbrance changes only get pushed `when tier > 0`). The one system-computed change that DID need a condition (`buildContainmentChanges.mts`'s weightless-bag-of-holding check) now uses the formula string `'!#item.contentsAreWeightless'` instead of a TS predicate.
+
+### Apply-Loop Integration
+
+Both gathering loops that build the `changes[]` array before stacking need the same check, right alongside the existing `!change.key` / phase / target filters:
+
+- `ActorDnd35e.applyActiveEffects()` — all three gathering loops (AE-backed changes, `item.getContributedActorChanges()`, `this.getSelfContributedChanges()`)
+- `ItemDnd35e.applyActiveEffects()` — its equivalent gathering loop
+
+```typescript
+// Alongside the existing continue-filters in each gathering loop:
+if (change.condition && !evaluateChangeCondition(change, contextMap)) continue;
+```
+
+`evaluateChangeCondition()` (new — `src/documents/activeEffects/baseActiveEffect/logic/`):
+- Resolve via `FormulaData.resolveSource({ formula: change.condition, expectedType: 'boolean', resolvedValue: null }, contextMap)`, reusing the **same** `contextMap` `getEffectContexts()` already builds for value resolution (`resolveChangeValue.mts`) — don't duplicate context assembly.
+- No `contextMap` available (live-contributed changes with no backing AE) → treat as `false` and warn, rather than silently passing.
+- Resolution failure (invalid formula) → treat as `false` and surface a preparation warning (§7.6), never throw.
+
+### UI
+
+Superseded by §7.7b (AE Sheet Revamp) — the condition input is a dedicated **Condition column** in `EffectChangesList.vue`, not a per-row collapsed toggle. See §7.7b for the current design.
+
+### Tests
+
+- [x] Change with `condition: null` applies unconditionally (current behavior unchanged)
+- [x] Change with a `condition` formula that resolves `true` applies
+- [x] Change with a `condition` formula that resolves `false` is skipped — target field unaffected, no `Override` recorded for it
+- [x] Invalid `condition` formula → warning generated, change treated as `false` (skipped), no crash
+- [ ] Condition on a `group:`-targeted change (§7.7) gates the whole expanded group
+
+## 7.7b AE Sheet Revamp — Changes Tab Redesign
+
+**User**: GM authoring an Active Effect (General or Material type).
+**Status**: Design in progress — partially implemented, partially still under discussion. Do not implement further UI beyond what's listed as done below without a fresh go-ahead.
+**Depends on**: Story A, §7.7a's schema/logic (unchanged).
+
+### Motivation
+
+Story B's first UI pass added a condition as a collapsed toggle row hidden behind a branch icon in `FieldControls`. This was reviewed and rejected: it buried a first-class per-change setting, and blurred the line between the simple boolean gate (Story B) and Story C's Conditional Values editor (a different feature entirely — branching the *value*, not gating the *change*). The AE sheet is being treated as the flagship use case for FormulaFamiliar across the system, so this redesign covers the full Changes tab, not just the condition field.
+
+### Changes Tab — Column Layout
+
+Reordered left-to-right (previously Key/Type/Value/Bonus Type/Target/Priority/Controls):
+
+| Order | Column | Notes |
+|---|---|---|
+| 1 | **Target** | Moved first — determines which document's context the Key/Value/Condition pickers resolve against. Was last. |
+| 2 | Key | `AspectPicker`, unchanged. Re-validates against the new target's context when Target changes (see AspectPicker fix below). |
+| 3 | Type | Add/Multiply/etc. dropdown — now excludes `mask` (never user-selectable) and no longer offers the removed `familiar` placeholder. |
+| 4 | Value | `FormulaFormGroup`, now enforces the picked aspect's `expectedType` (derived via `findAspectByAccessPath()`) instead of accepting any type. Gets the advanced-editor entry point (Story C, §7.10) once that's built. |
+| 5 | **Condition** *(new)* | Plain `FormulaFormGroup` (`expectedType: 'boolean'`) — same kind of control as the Value column, just its own field/column. Comparison/logical operators get their own highlight class alongside the existing `#token` highlighting. Advanced-editor button opens the **Condition Builder** (§7.10) in standalone mode. Replaces the removed branch-toggle row. |
+| 6 | Priority | Unchanged. |
+| 7 | Controls | Delete button only — branch-toggle button removed (condition now has its own column). |
+
+Bonus Type (mask variant only) and Target-select stay in their existing relative positions otherwise unaffected by this reorder.
+
+### Value Column — `expectedType` Enforcement
+
+The Value formula's `expectedType` is derived from the picked aspect (`change.key`), not left to default to `'string'`:
+- Look up the aspect via `findAspectByAccessPath(contextForTarget.properties, change.key)`.
+- Pass its resolved `FieldAspect.type` (`'string' | 'number' | 'boolean' | undefined`) as `FormulaFormGroup`'s `expected-type` prop.
+- This logic lives in `EffectChangesList.vue` (the row component) — not `AspectPicker.vue` — since the row is what owns both the Key and Value columns and needs to bridge them. (Open to emitting it from `AspectPicker` instead if that proves easier at implementation time — not a hard requirement either way.)
+
+### Condition Column
+
+No new component. The Condition column is a plain `FormulaFormGroup` with `expectedType: 'boolean'` — identical in kind to the Value column, just its own field/column. Three side-by-side inputs (`[formula] [op ▾] [formula]`) don't fit the column width, so the "structured picker" experience lives entirely in the advanced editor instead (§7.10's Condition Builder); the column itself is always raw-text entry with highlighting.
+
+**Highlighting**: extend formula syntax highlighting to tag comparison/logical operators (`>`, `<`, `>=`, `<=`, `==`, `!=`, `&&`, `||`) with their own highlight class, in addition to the existing `#context.property` token highlighting. Example: in `#self.hp.current > (#self.hp.max / 2)`, both `#self.hp.current` and `#self.hp.max` highlight as tokens, and `>` highlights as an operator. This is a system-wide enhancement to the formula renderer (benefits any boolean-typed `FormulaFormGroup`), not Condition-column-specific.
+
+**Advanced editor entry point**: clicking the advanced-editor button on a boolean-typed `FormulaFormGroup` (Condition column included) opens the Condition Builder (§7.10) in **standalone mode** — a single structured `[aspect/formula] [operator ▾] [aspect/formula]` row with AND/OR chaining and an "Edit as text" escape hatch, no surrounding rule list. This is the *same component* used per-rule inside Conditional Values (§7.10) for number/string fields.
+
+### Bug Fixes (shipped)
+
+- Removed `CONFIG.ActiveEffect.changeTypes.familiar` (registration, the `CHANGE_TYPE.FAMILIAR` constant, its `SystemActiveEffectChangeTypes` type augmentation, and its localization key) — it was an unused placeholder that leaked into the Type dropdown as a nonsensical user-selectable option.
+- `changeTypes.mask` stays registered (Secret AE internals still need it) but is filtered out of the Type dropdown for `variant='default'` rows.
+- `AspectPicker.vue`: a stored key that becomes unresolvable after switching Target (a raw path with no `#` token) previously produced **zero** validation errors — `validateFormula()` only inspects `#context.property` tokens, so an orphaned raw path silently looked valid. Now detected explicitly and surfaced via `has-error` styling + hint text (reusing `dnd35e.Formula.Errors.propertyNotFound`), matching the "leave the raw value in place, flag it as an error" reset behavior (never silently clear or destroy the stored key on a Target switch).
+
+### General AE Custom Sheet
+
+`general` (and `containment`) AE types currently fall back to Foundry's default `ActiveEffectConfig` — only `material` and `secret` have custom Vue sheets. Add a General sheet mirroring Material's minimal pattern (`GeneralSheet.mts`/`.vue`, `GeneralStore.mts`, `sheet/tabs/index.mts`) with a bare `EffectDetails`-only Details tab (no appends) so General AEs get sheet parity (same Changes tab redesign, same Duration tab) without any type-specific fields.
+
+### Design Decisions (resolved)
+
+- **Condition column is not a compound control.** No `ConditionFormGroup.vue`. It's a plain boolean `FormulaFormGroup`, same as any other formula field, just given its own column instead of being hidden behind a toggle.
+- **One shared Condition Builder component** (§7.10), used two ways:
+  - **Standalone** — the advanced-editor entry point for any boolean-typed `FormulaFormGroup` (Condition column included): a single structured condition row with AND/OR chaining and a text escape hatch.
+  - **Embedded per-rule** — inside Conditional Values (number/string fields, §7.10): one Condition Builder per rule, gating that rule's value.
+- **Advanced editor mode depends on the field's `expectedType`**: `boolean` fields open the Condition Builder (helps write a gate/condition expression); `number`/`string` fields open Conditional Values (branches which value is used). Both compile to plain formula text — no new storage format either way.
+- **Advanced editor button is system-wide** on every `FormulaFormGroup`, with a `hideAdvancedEditor` prop for the rare case a consumer needs to opt out.
+- **Operator highlighting** is a system-wide formula-renderer enhancement, not Condition-column-specific — see above.
+
 ## 7.8 Files to Create/Modify
 
 | Action | Path |
@@ -299,16 +463,25 @@ This system is orthogonal to field permission metadata for schema field groups o
 | Create | `src/dice/D20Roll.mts` — d20 roll with crit/fumble detection |
 | Create | `src/dice/DamageRoll.mts` — damage roll with crit multiplier and types |
 | Create | `src/dice/index.mts` — register `CONFIG.Dice.rolls` with `[D20Roll, DamageRoll]` |
-| Create | `src/helpers/rollData.mts` — roll data assembly utilities |
-| Create | `src/helpers/formulaBridge.mts` — `resolveFormula()` pipeline bridging `#context.property` and `@attr` |
+| Create | `src/helpers/rollData.mts` — minimal `getRollData()` assembly for Foundry-native `@attr` consumers only (§7.1) |
 | Create | `src/constants/rollVariables.mts` — canonical formula path documentation |
 | Create | `src/helpers/changeTargetGroups.mts` — `ChangeTargetGroup` interface, registry, `registerChangeTargetGroup()`, `resolveChangeTargets()` |
-| Expand | Actor `getRollData()` — structured roll data assembly (generate from schema walker metadata) |
-| Expand | Item `getRollData()` — inherit actor data + add item fields |
-| Expand | FormulaFamiliar context registrations per document type |
+| Create | `src/helpers/formulae/evaluateBooleanExpression.mts` — comparison/logical operator evaluator for boolean-typed formulas (Story A, §7.2a) |
+| Create | `src/helpers/formulae/conditionalFormula.mts` — `#if(cond, then, else)` parser + serializer for the advanced editor (Story C, §7.10) |
+| Create | `src/vue/components/.../ConditionBuilder.vue` — shared condition-builder row (aspect/formula + operator ▾ + aspect/formula, AND/OR chaining, text escape hatch); used standalone for boolean fields and embedded per-rule in Conditional Values (Story C, §7.10) |
+| Create | `src/vue/components/.../ConditionalValuesEditor.vue` — rule-list builder UI embedding `ConditionBuilder` per rule (Story C, §7.10) |
+| Create | `src/documents/activeEffects/general/sheet/GeneralSheet.mts` / `.vue`, `GeneralStore.mts`, `sheet/tabs/index.mts`, `GeneralDetails.vue` — General AE custom sheet mirroring Material's pattern, bare `EffectDetails`-only Details tab (§7.7b) |
+| Create | `src/documents/activeEffects/baseActiveEffect/logic/evaluateChangeCondition.mts` — AE change conditional gate (Story B, §7.7a) |
+| Expand | Actor `getRollData()` — minimal, Foundry-native mechanics only (not our authored-formula resolution path) |
+| Expand | Item `getRollData()` — inherit actor data + add item fields (same narrow scope) |
+| Expand | `schemaWalker.mts` — `inferFieldType()` gains `BooleanField → 'boolean'` (Story A) |
+| Expand | `FormulaData.mts` / `FormulaField.mts` — `expectedType` widens to include `'boolean'` (Story A) |
+| Expand | `FormulaFormGroup.vue` — advanced-editor button (opens Condition Builder standalone or Conditional Values depending on `expectedType`), plus `hideAdvancedEditor` opt-out prop (Story C) |
+| Expand | `ActiveEffectSystemModel.defineSchema()` — add `condition` field to `changes` schema (Story B) |
+| Expand | `EffectChangesList.vue` — reorder columns (Target first), remove branch-toggle, add plain boolean Condition column, derive Value `expected-type` from picked aspect (Story B/§7.7b) |
+| Expand | Formula syntax highlighter (wherever `renderFormulaHTML`/token highlighting lives today) — tag comparison/logical operators (`>`, `<`, `==`, `&&`, `||`, etc.) with their own highlight class (§7.7b) |
 | Expand | FormulaFamiliar picker — append group targets from registry under category headers |
-| Expand | AE change-application loop — call `resolveChangeTargets()` before applying each change |
-| Implement | `CONFIG.ActiveEffect.changeTypes.familiar.handler` — FormulaFamiliar AE change evaluation |
+| Expand | AE change-application loop — call `resolveChangeTargets()` and `evaluateChangeCondition()` before applying each change |
 | Create | Preparation warnings infrastructure on base document classes |
 | Create | `src/vue/components/actors/CreatureDefenseStat.vue` — clickable stat chip for saves and AC |
 | Create | `src/vue/components/dialogs/D20RollDialog.vue` — roll dialog with situational mod + roll mode |
@@ -395,7 +568,7 @@ async rollSave(
 **Pipeline**:
 1. If `!skipDialog` → render `D20RollDialog`; await user confirmation (situational mod, roll mode)
 2. Assemble modifier list: `[{ label: saveName, value: saveTotal }, { label: 'Situational', value: situationalMod }]`
-3. Build formula string: `"1d20 + @saveTotal + @situational"` with roll data from modifier list
+3. Build the roll formula by interpolating the already-known literal numbers directly, e.g. `` `1d20 + ${saveTotal} + ${situationalMod}` `` — no `@` tokens, no roll-data object needed (see §7.2's "No `@attr` Bridge"); the values are plain JS numbers at this point, not formula references
 4. Create and evaluate `D20Roll` — `situationalModifiers` carries the labeled list
 5. Call `rollMessages.buildSaveCard(roll, modifierList, { dc, saveKey })` → HTML
 6. `ChatMessage.create({ content, roll, rollMode })`
@@ -405,14 +578,121 @@ A matching `rollAC(acVariant, options)` method follows the same pipeline with AC
 
 ---
 
+## 7.10 Conditional Values & Condition Builder (Story C)
+
+**User**: Anyone authoring a formula (GM or player, depending on field permissions).
+**Delivers**: An advanced-editor button appears on every `FormulaFormGroup` (opt out via a `hideAdvancedEditor` prop). What it opens depends on the field's `expectedType`:
+- **`number` / `string` fields → Conditional Values**: turns the field into an ordered list of condition → value rules. Rules evaluate top-to-bottom; the first whose condition is true supplies the result. The field's original formula becomes the trailing default, always evaluated last if no rule matches. A preview at the bottom shows the live-evaluated result and the fully compiled formula string.
+- **`boolean` fields (e.g. the AE Condition column, §7.7b) → Condition Builder, standalone**: a single structured condition row (no rule list, no value column — the field *is* the condition), same builder described below minus the per-rule wrapping.
+
+Both modes share the same **Condition Builder** component (aspect + operator + value pickers, described below) — embedded per-rule in Conditional Values, or standalone for a boolean field.
+**Depends on**: Story A (aspect type-awareness drives which operators are offered; boolean grammar is the compiled target).
+
+### Layout — Conditional Values mode (`number`/`string` fields)
+
+Top to bottom in the editor window:
+1. **Header** — field label / context
+2. **"Add Condition" button** (relabels to **"+ Add Rule"** once at least one rule exists) — inserts a new rule row
+3. **Rule rows**, evaluated top-to-bottom. Each newly added rule is appended directly above the default — so the first rule you add is checked first, and each later addition is checked after all earlier ones, right before falling through to the default:
+   - Each row: `[Condition builder]` → `[Value formula (FormulaFormGroup, same expectedType as the field)]` → `[✕ remove row]`
+4. **Default formula** — the field's original plain `FormulaFormGroup`, now labeled as the fallback ("Otherwise…"). Always evaluated last, always present — removing all rules just leaves the plain formula field behaved exactly as it did before Conditional Values was turned on.
+5. **Preview** — live-evaluated result (when a preview context is available) plus the fully compiled formula string, read-only.
+
+### Layout — Condition Builder standalone mode (`boolean` fields)
+
+Same editor window, drastically simpler — there's no rule list and no separate value column, since the field itself already *is* the condition:
+1. **Header** — field label / context
+2. A single **Condition Builder** row (see below)
+3. **Preview** — live-evaluated true/false result plus the compiled boolean string, read-only
+
+No "Add Rule" button, no default formula slot — closing the editor just writes the compiled condition string back into the field, same as it would for a plain formula.
+
+### Condition Builder (shared row component)
+
+Structured, dropdown-driven — no raw text required for the common case:
+
+```
+[ Aspect picker ▾ ]  [ Operator ▾ ]  [ Value: literal input | Aspect picker ▾ ]   ( + AND/OR another clause )
+```
+
+- **Aspect picker**: same autocomplete data source as every other `#`-token picker (schema walker's `AspectGroup` tree) — pick e.g. `#self.skill.concentration.ranks`.
+- **Operator dropdown**: options are filtered by the picked aspect's resolved type (Story A's `FieldAspect.type`):
+  - `number` → `>`, `<`, `>=`, `<=`, `==`, `!=`
+  - `string` → `==`, `!=`
+  - `boolean` → no operator needed; the row becomes a plain "is true" / "is false" toggle
+- **Right-hand value**: a literal input (number/string, matching the aspect's type) **or** a toggle to compare against another aspect instead (e.g. `#self.hp.value < #self.hp.max`).
+- **+ AND / OR**: appends another clause to the same rule's condition, joined by the selected logical operator; renders as a stacked additional `[Aspect] [Operator] [Value]` group with an "AND"/"OR" connector label.
+
+The picker compiles to the exact same boolean-formula text from §7.2a (e.g. `#self.abilities.str.mod >= 2 && #self.bab > 0`) — it's a friendlier front-end onto that grammar, not a separate one. Consequences:
+- The stored/compiled formula stays plain text; existing validation/warning/resolution code needs no changes to support it.
+- **Escape hatch**: an "Edit as text" toggle per condition row falls back to a plain boolean `FormulaFormGroup` for anyone who wants a compound expression the picker can't represent (nested parens, unusual operators). A row left in text mode simply doesn't re-parse into pickers on reopen — no forced conversion.
+
+### Compiled Syntax
+
+Grammar: `#conditional( when(cond₁, val₁) when(cond₂, val₂) ... else(default) )` — a single inline token (like any `#context.property` reference) that resolves to whichever branch wins, with surrounding literal text/tokens untouched.
+
+- **`when(condition, value)`** — zero or more, evaluated in left-to-right source order via the existing boolean grammar (§7.2a); first true `condition` wins and its `value` is resolved (recursively — a `value` may itself contain another `#conditional(...)`).
+- **`else(value)`** — required exactly once, may appear anywhere among the clauses; supplies the result when no `when()` matches.
+- **Clause separator is don't-care**: `when(...)`/`else(...)` are self-delimiting via their own balanced parens, so a comma, whitespace, or nothing at all between clauses is equivalent — the parser just scans forward for the next `when(`/`else(` keyword.
+- **Backward compatible**: zero `#conditional(...)` blocks in a formula = today's plain-formula behavior, unchanged.
+- **Non-selected branches are never evaluated** — avoids errors from untaken branches (e.g. a divide-by-zero in a branch that never gets picked).
+- **Matching is lenient**: `#conditional`/`when`/`else` keywords are case-insensitive, optional whitespace before `(`.
+- **Malformed input** (unbalanced parens, missing `else()`, bad arg count) is a validation error; resolution leaves the formula raw/unresolved rather than guessing.
+- **Token/literal-text adjacency requires parens to disambiguate**: a `#context.property` token immediately followed by more literal text with no separator (e.g. `#self.sneakAttackDice` directly followed by `d6`) greedily merges into one invalid path segment, since a property path segment matches any run of letters/digits/underscores — `sneakAttackDiced6` isn't a real property, so it fails validation. This is a general, pre-existing `VARIABLE_REGEX` characteristic (not specific to `#conditional(...)`), and it's the expected/required pattern going forward: wrap the token in parens to disambiguate, e.g. `(#self.sneakAttackDice)d6`.
+- **Escaping**: `\#`, `\(`, `\)`, and `\,` escape a literal `#`/`(`/`)`/`,` character (same backslash convention throughout the formula grammar). An escaped paren doesn't count toward balanced-paren depth tracking, so a branch value can contain literal/unbalanced parens (e.g. `else(\(unbalanced\))`). Escaping the paren immediately after `when`/`else` (e.g. `when\(`) also prevents that occurrence from being parsed as a clause at all, and escaping `#conditional(`'s own `#` (`\#conditional(`) prevents the whole construct from being recognized as a block. The comma escape matters when a condition's string literal itself contains a comma — e.g. `when(#self.name == "\,", 500)` — since an unescaped comma there would be mistaken for the top-level separator between the clause's own `condition`/`value` arguments.
+- **Condition grammar reminders (from §7.2a)**: string literals accept single **or** double quotes interchangeably; equality is `==` (loose/truthy comparison, coerces number↔string as needed) — there is no single `=` (reserved, unused) and no `===` (not needed at this time). A condition that resolves to a non-boolean value is coerced truthy: numbers are truthy unless `0`, strings are truthy unless empty — e.g. `when(#self.name, 1)` is true whenever the name isn't an empty string.
+
+```
+#conditional(when(#self.hp.value <= 0, 0) when(#target.isFlanked, 1d6+(#self.sneakAttackDice)d6) else(2d6))
+```
+Reads: "2d6, unless HP ≤ 0 (then 0), unless flanked (then 1d6 + sneak attack dice)." (`(#self.sneakAttackDice)d6` wraps the token in parens per the adjacency rule above — without the parens, `d6` would merge into the token's path segment and fail validation.)
+
+Supersedes the earlier `#if(condition, value, elseExpr)` right-nested-chain proposal — same problem (first-match-wins rule list with a mandatory default), but expressed as a flat rule list rather than nested ternaries, matching how "Conditional Values" actually presents to the user (a list of rules + a fallback, not a chain).
+
+### Opening on an Existing Formula (Round-Trip)
+
+Because storage is text-only, opening the editor on an existing value requires parsing it back into rule rows:
+
+- If the formula contains a `#conditional(...)` block → parse its `when()` clauses into rule rows (in source order) and its `else()` into the default.
+- If it doesn't (a plain value, a hand-typed expression, or anything not expressible in this grammar) → the whole string becomes the default value; the rule list starts empty (best-effort: never silently discard the user's existing formula).
+- Each parsed rule's *condition* is additionally checked against the "simple comparison (+ AND/OR chain)" shape to decide whether it opens in structured-picker mode or falls back to "Edit as text" mode for that one row.
+
+> **Open decision** (explore at implementation start): whether partial/best-effort parsing (recovering a rule list from loosely-formed input) is worth the complexity vs. the simpler "exact grammar or start fresh" rule above. Default: exact-grammar-only — if it doesn't parse cleanly, treat the whole existing string as the default value.
+
+### Tests
+
+- [ ] Adding a rule inserts a condition+value row above the default; default remains last
+- [ ] Adding a second rule appends it above the default but below the first rule (first-added = evaluated first)
+- [ ] Structured condition compiles to correct boolean text for `number`, `string`, and `boolean` aspect types
+- [ ] AND/OR clause chaining compiles correctly and matches §7.2a's grammar
+- [ ] Comparing against another aspect (not just a literal) compiles correctly
+- [ ] "Edit as text" escape hatch accepts arbitrary boolean formulas and round-trips them as raw text on reopen
+- [ ] Removing a rule re-flattens the chain correctly (no orphaned nesting)
+- [ ] Preview shows correct live result and correct compiled string for a 3+ rule chain
+- [ ] Opening the editor on an existing plain (non-conditional) formula shows it as the default, no rules
+- [ ] Opening the editor on an existing compiled `#conditional(...)` block reconstructs the rule list correctly
+
+---
+
 ## Completion Checklist
 
 ### ✅ Complete
-- (None — Phase 7 has not started)
 
-### ❌ Not Started (All Tasks for Phase 7)
+The FormulaFamiliar core plumbing shipped ahead of this phase, landing alongside Phase 2/5/6 AE work. Confirmed in the current codebase:
 
-**Roll Data Structure & Interfaces:**
+- **Schema walker** (`src/helpers/formulae/schemaWalker.mts`) auto-derives `AspectGroup` trees from `defineSchema()` — opt-out model via `formulaVisible: false`, opaque leaves via `isFamiliarLeaf`
+- **`FormulaField`/`FormulaData`** (`src/helpers/formulae/FormulaField.mts`, `FormulaData.mts`) — formula storage + resolution, `expectedType: 'string' | 'number'` already implemented (e.g. `spellResistance` on `CreatureSystemModel` uses `'number'`)
+- **`#context.property` resolution** — `FormulaData.resolve()` / `resolveSource()` / `resolveDisplaySource()`; zero `@attr` tokens anywhere in the pipeline
+- **AE change value resolution** — `resolveActiveEffectChangeValue()` (`resolveChangeValue.mts`) universally resolves every change's `value` through `FormulaData.resolveSource()` regardless of the change's declared `type` — this already validates the "No `@attr` Bridge" design in §7.2 as the shipped reality, not just a plan
+- **Autocomplete + formula editor UI** — `FormulaFormGroup.vue`, `useFormulaEditor.mts`, `useFamiliarOverlayInput.mts`, `#`-token validation/highlighting, per-context aliasing
+- **`condition` type placeholder** — `EffectChangeSourceDnd35e.condition` (`ActiveEffectSystemData.mts`) already typed as `string | null | ((target) => boolean)`, ready for Story B to wire up
+- **Boolean Formula Type (Story A, §7.2a)** — schema walker `BooleanField → 'boolean'` branch, `FieldAspect.type`/`FormulaFieldMeta.aspectType` widened, `FormulaData`/`FormulaField` `expectedType` includes `'boolean'`, `evaluateBooleanExpression()` implemented **including arithmetic operands** (`+ - * /`, unary minus, standard precedence — see §7.2a), `FormulaData._finalizeResolvedValue()` branches on `'boolean'`. All tests passing (`tests/unit/familiar/evaluate-boolean-expression.test.mts`).
+- **AE Change Conditional Gate — schema & logic (Story B, §7.7a)** — `condition` field added to `ActiveEffectSystemModel.defineSchema()`'s `changes` schema; `evaluateChangeCondition()` implemented (string-form only via `FormulaData.resolveSource()`) and wired into `ActorDnd35e.applyActiveEffects()`'s three gathering loops and `ItemDnd35e.applyActiveEffects()`. All five test cases passing (`tests/unit/effects/evaluate-change-condition.test.mts`). A function-form condition type was briefly supported for live-computed changes with no backing AE document, but was removed — conditions are persisted to the database, so a function could never round-trip through it. **UI is not done** — see §7.7b checklist below.
+- **Bug fixes (§7.7b)** — removed the unused `changeTypes.familiar` placeholder (registration, constant, type augmentation, localization key); `AspectPicker.vue` now surfaces a validation error when a stored key becomes unresolvable after a Target switch instead of silently looking valid.
+
+### ❌ Not Started
+
+**Roll Data Structure & Interfaces** *(narrow scope — Foundry-native `@attr` consumers only, see §7.1's callout)*:
 - [ ] Create `src/types/rollData.d.ts` with interfaces:
   - `ActorRollData` (abilities with mod/total/base, attributes, saves, skills, size mods)
   - `ItemRollData extends ActorRollData` (adds item-specific fields)
@@ -421,7 +701,7 @@ A matching `rollAC(acVariant, options)` method follows the same pipeline with AC
 - [ ] Document each field's calculation/source
 - [ ] Test: Interfaces compile without errors
 
-**Actor.getRollData() Implementation:**
+**Actor.getRollData() Implementation** *(minimal — only for Foundry-native mechanics like the Combat Tracker initiative formula; not a resolution path our own formulas use)*:
 - [ ] Override `getRollData()` on `ActorDnd35e`
 - [ ] Populate abilities: for each (str-cha), include base score, derived mod, derived total
 - [ ] Populate attributes: bab, ac (normal/touch/flatFooted), saves (fort/ref/will), init
@@ -431,7 +711,7 @@ A matching `rollAC(acVariant, options)` method follows the same pipeline with AC
 - [ ] Test: `getRollData()` includes all expected fields
 - [ ] Test: Values are correct for a test character
 
-**Item.getRollData() Implementation:**
+**Item.getRollData() Implementation** *(same narrow scope as above)*:
 - [ ] Override `getRollData()` on `ItemDnd35e`
 - [ ] Call parent actor's `getRollData()` to inherit all actor fields
 - [ ] Add item-specific fields:
@@ -440,17 +720,10 @@ A matching `rollAC(acVariant, options)` method follows the same pipeline with AC
 - [ ] Test: `getRollData()` includes both actor + item fields
 - [ ] Test: Item fields override actor fields if names conflict (shouldn't happen, but verify logic)
 
-**FormulaFamiliar Context Registration:**
-- [ ] Create schema walker that traverses DataModel schema to build context autocomplete
-- [ ] Register `#self.*` contexts mapping to actor's `getRollData()` schema
-- [ ] Register `#item.*` contexts mapping to item's system schema
+**FormulaFamiliar Context Registration** *(schema walker + `#self`/`#item` already shipped — remaining work is Phase 8's placeholder contexts + user docs)*:
 - [ ] Register `#action.*` contexts (placeholder, Phase 8 will populate)
 - [ ] Register `#target.*` contexts (placeholder, Phase 8 will populate)
-- [ ] Implement autocomplete in Vue formula input fields:
-  - User types `#self.` → show available abilities, attributes, skills
-  - User types `#item.` → show available item fields
-- [ ] Test: Autocomplete suggestions are accurate
-- [ ] Test: Invalid paths are rejected or warned
+- [ ] Test: Invalid paths are rejected or warned (verify existing behavior covers Phase 8's future contexts too)
 
 **Canonical Formula Paths Documentation:**
 - [ ] Create `src/constants/formulaPaths.mts` documenting all valid `#context.property` paths
@@ -459,19 +732,42 @@ A matching `rollAC(acVariant, options)` method follows the same pipeline with AC
   - Attack bonus: `#self.bab + #self.abilities.str.mod + #self.size.attackMod`
   - AC: `10 + #self.abilities.dex.mod - #item.armorCheckPenalty`
   - Save DC: `10 + #self.details.level + #self.abilities.wis.mod`
+  - Boolean gate: `#self.skill.concentration.ranks > 5`
 - [ ] Document context inheritance hierarchy (actor → item → action)
 - [ ] Update README/docs with formula examples for users
 
-**FormulaFamiliar ↔ Foundry Roll Data Bridge:**
-- [ ] Implement `resolveFormula()` pipeline: Step 1 resolves `#context.property` via FormulaFamiliar, Step 2 resolves `@attr` via `Roll.replaceFormulaData()`
-- [ ] Verify `getRollData()` paths mirror FormulaFamiliar schema paths (e.g., `@abilities.str.mod` ↔ `#self.abilities.str.mod`)
-- [ ] Generate `getRollData()` structure from schema walker metadata (same source as FormulaFamiliar contexts)
-- [ ] Implement `familiar` custom change type handler in `CONFIG.ActiveEffect.changeTypes.familiar` (registration done in Phase 2)
-- [ ] Test: AE change with type `familiar` and value `#self.abilities.str.mod` correctly resolves and applies
-- [ ] Test: AE change with type `add` and value `@abilities.str.mod` correctly resolves via Foundry's native `_castChangeDelta`
-- [ ] Test: Both syntax styles resolve to the same numeric value for the same field
-- [ ] Test: Invalid `#context.property` in familiar change type produces warning, not crash
-- [ ] Document when to use `@attr` vs `#context.property` for system authors
+**Boolean Formula Type (Story A, §7.2a):** — ✅ moved to Complete above.
+
+**AE Change Conditional Gate (Story B, §7.7a):** — schema/logic/wiring ✅ moved to Complete above. Remaining:
+- [ ] UI — see AE Sheet Revamp checklist below (§7.7b)
+
+**AE Sheet Revamp (§7.7b):**
+- [x] Remove `changeTypes.familiar` placeholder (registration, constant, type augmentation, localization key)
+- [x] Filter `changeTypes.mask` out of the Type dropdown for `variant='default'` rows
+- [x] `AspectPicker.vue`: surface a validation error for an unresolvable stored key after a Target switch
+- [x] Reorder `EffectChangesList.vue` columns: Target first
+- [x] Remove the rejected branch-toggle button + collapsible condition row
+- [x] Derive Value column's `expected-type` from the picked aspect (`findAspectByAccessPath()`)
+- [x] Add Condition column: plain `FormulaFormGroup` (`expectedType: 'boolean'`), no new compound component
+- [ ] Extend formula syntax highlighting to tag comparison/logical operators (`>`, `<`, `==`, `&&`, `||`, etc.), not just `#tokens`
+- [ ] Add `hideAdvancedEditor` opt-out prop to `FormulaFormGroup.vue`
+- [ ] Create General AE custom sheet (`GeneralSheet.mts`/`.vue`, `GeneralStore.mts`, `sheet/tabs/index.mts`) mirroring Material's pattern
+- [ ] Test: Condition column accepts and evaluates a boolean formula with operator highlighting
+- [ ] Test: Value column rejects/flags a formula that doesn't match the picked aspect's type
+- [ ] Test: General AE sheet renders Changes/Duration tabs with parity to Material
+
+**Condition Builder & Conditional Values (Story C, §7.10):**
+- [ ] Build shared **Condition Builder** row component (aspect/formula + operator ▾ + aspect/formula, AND/OR clause chaining, "Edit as text" escape hatch per row)
+- [ ] Wire Condition Builder in **standalone mode** as the advanced-editor target for boolean-typed `FormulaFormGroup`s (Condition column included)
+- [ ] Wire Condition Builder **embedded per-rule** inside Conditional Values for number/string fields
+- [x] Implement `#conditional(when(cond, value) ... else(default))` parser + evaluator (new, `src/helpers/formulae/conditionalFormula.mts`) — flat rule-list shape, `else()` required exactly once, position-independent among clauses; includes `\#`/`\(`/`\)` escaping and parens-required-for-adjacency handling
+- [x] Hook parser into `FormulaData.resolve()`/`resolveSource()` and into `utils.mts`'s `resolveFormula()`/`validateFormula()` so `#conditional(` isn't flagged as an unknown context and malformed blocks surface a structural `ValidationError`
+- [ ] Create `ConditionalValuesEditor.vue` (or equivalent) — rule-list builder UI embedding the Condition Builder per rule
+- [ ] Add "Add Condition" button to `FormulaFormGroup.vue`'s controls; relabels to "+ Add Rule" once a rule exists
+- [ ] Implement live preview (result + compiled formula string) at the bottom of the editor
+- [ ] Save path: serialize rule list → `#conditional(when(...) ... else(...))` block → same `onCommit` the plain text input uses
+- [ ] Non-`#conditional(...)`-parseable existing values: preserve as the default value rather than discarding (see §7.10's round-trip note)
+- [ ] Test: all ten cases listed under §7.10's Tests subsection
 
 **D20Roll Custom Class** in `src/dice/D20Roll.mts`:
 - [ ] Extend Foundry's `Roll` class
@@ -531,7 +827,7 @@ A matching `rollAC(acVariant, options)` method follows the same pipeline with AC
 - [ ] Test: Enriched elements render correctly in item descriptions and chat messages
 
 **Codebase TODO Notes (Landing Here):**
-- [ ] **Remove `ActiveEffect._shimChanges` compat shim** (`ItemDnd35e.mts:131`): The `_shimChanges(changes)` call is explicitly marked `// todo remove in v16`. When Phase 7 implements the formula-familiar change type handler and the full AE change pipeline is proven, verify whether the shim is still needed. If v16 migration transforms old AE data, remove the shim call and its TODO comment. If the shim is still required for pre-migration data, keep it but update the comment with the specific migration that will obsolete it.
+- [ ] **Remove `ActiveEffect._shimChanges` compat shim** (`ItemDnd35e.mts:131`): The `_shimChanges(changes)` call is explicitly marked `// todo remove in v16`. Once Story B's conditional gate and the full AE change pipeline are proven, verify whether the shim is still needed. If v16 migration transforms old AE data, remove the shim call and its TODO comment. If the shim is still required for pre-migration data, keep it but update the comment with the specific migration that will obsolete it.
 - [ ] **Integrate Hooks.onError pattern into LogHelper** (`ItemDnd35e.mts:93`): The `applyActiveEffects()` method uses `LogHelper.error()` as a substitute for Foundry's `Hooks.onError()` pattern. Evaluate whether `LogHelper` should wrap `Hooks.onError()` for consistency with Foundry's error surfacing (e.g., error hooks that modules can listen to), or if the current direct logging is sufficient.
 - [ ] **Fix `DnD35eActiveEffect.createDialog` type cast** (`ItemSheetStore.mts:92`): `createDialog` is called via `(DnD35eActiveEffect as any).createDialog(...)` because the type definitions don't expose it. Add proper type declaration for `createDialog` on `DnD35eActiveEffect` (either via interface merge or by adding the static method signature to the class).
 
@@ -556,16 +852,10 @@ A matching `rollAC(acVariant, options)` method follows the same pipeline with AC
 - [ ] Test: User sees warning message
 - [ ] Test: Field shows fallback value
 
-**Vue Form Component - Formula Input:**
-- [ ] Create `FormulaFormGroup.vue` component for formula fields
-- [ ] Show formula input field
-- [ ] Show autocomplete dropdown on `#` key press
-- [ ] Show validation status (green = valid, red = invalid)
+**Vue Form Component - Formula Input** *(`FormulaFormGroup.vue` already exists and ships autocomplete + validation; remaining items are new here)*:
 - [ ] Show contextual help: "Formula must start with #self, #item, #action, or #target"
 - [ ] Evaluate `HeaderNameField.vue` refactor (`HeaderNameField.vue:25`): Component uses its own display mode to hide formula hints when not editing. Assess whether this should be folded into `FormulaFormGroup` as a `displayMode` prop or slot, or kept as a separate wrapper. The TODO also notes styling concerns with a read-only slot that were deferred.
-- [ ] Test: Autocomplete works
-- [ ] Test: Validation works
-- [ ] Test: Complex formulas with operators work
+- [ ] Test: Complex boolean expressions with operators work (Story A)
 
 **Group Change Targets (§7.7):**
 - [ ] Create `src/helpers/changeTargetGroups.mts`:

--- a/docs/migration-plan/post-release/WISHLIST.md
+++ b/docs/migration-plan/post-release/WISHLIST.md
@@ -67,3 +67,20 @@ Foundry core ships generic `blink` and `displace` teleport-style movement action
 Placed tokens copy `sight`/`detectionModes` from the actor's `prototypeToken` once, at creation — Foundry never re-derives those fields from the actor afterward (confirmed by reading `TokenDocument#prepareBaseData`/`prepareDerivedData` in Foundry core; no auto-sync exists). Standard Foundry behavior is that an actor edit doesn't retroactively update already-placed tokens for fields like this — the GM deletes and re-drags the token (or uses `updateVisionMode()`/manual token edits) to pick up changes. poc.9 accepts this standard behavior rather than building a bespoke live-sync hook (`updateActor` → `updateEmbeddedDocuments('Token', ...)`).
 
 Revisit if this friction proves painful in practice — a hook could push `buildTokenVisionFromSenses()` output onto linked placed tokens on `system.bio.senses` changes, surgically merging `detectionModes` (preserving unrelated GM-added entries like `seeInvisibility`).
+
+---
+
+## Formula System
+
+### Structured Condition Builder & Conditional Values rule-list editor
+Phase 7 (poc.7) Story C originally planned a full structured editor for formula fields: a **Condition Builder** row (aspect picker + operator dropdown, filtered by the picked aspect's type, + a literal-or-aspect value + AND/OR clause chaining + an "Edit as text" escape hatch), used two ways:
+- **Standalone**, as the advanced-editor target for boolean-typed fields (e.g. the AE Condition column)
+- **Embedded per-rule** inside a **Conditional Values** editor for `number`/`string` fields — an ordered list of condition → value rules (first true condition wins), with the field's original formula as the trailing default, a "+ Add Rule" button, and a live preview of the result and compiled formula string
+
+Both compile down to the same `$conditional(when(cond, value) ... else(default))` grammar that already ships and is fully tested today (`FormulaResolver`, see `docs/migration-plan/poc/phase-07-roll-formulas.md` §7.10) — this wishlist item is purely a friendlier front-end onto existing infrastructure, not new resolution logic.
+
+Also deferred: **round-trip parsing** — opening the editor on an existing formula needs to parse a `$conditional(...)` block back into rule rows (in source order), falling back to "whole string becomes the default, rule list starts empty" for anything not expressible in the grammar. Whether to attempt best-effort/partial parsing of loosely-formed input, or require an exact-grammar match before offering structured rows (falling back to raw text otherwise), is still an open question — default toward exact-grammar-only for simplicity.
+
+Also deferred: helper buttons on the new basic multiline modal editor (§7.10 Half 2) to insert `#context.property` variables or `$conditional(...)` scaffolding without hand-typing — the modal shipped as a plain rich-text box for the initial pass.
+
+Affects: `src/helpers/formulae/FormulaFormGroup.vue`, a new `ConditionBuilder.vue` / `ConditionalValuesEditor.vue` (not yet created), the AE Condition column (`EffectChangesList.vue`).

--- a/docs/migration-plan/roadmap.md
+++ b/docs/migration-plan/roadmap.md
@@ -178,7 +178,7 @@ Dependencies use `wave.N` notation (e.g. `poc.1`, `alpha.3`, `beta.2`).
 | 4 | [Testing Infrastructure](poc/phase-04-testing-infrastructure.md) | ✅ Complete | poc.1, poc.2, poc.3 | Vitest, Foundry mocks, coverage tooling — establishes test patterns; back-fills poc.1–3 tests |
 | 5 | [Compendium Foundation](poc/phase-05-compendium-foundation.md) | 🔶 In Progress | poc.1, poc.2, poc.3 | Pack pipeline, origin tracking, UUID helpers, migration version field |
 | 6 | [Actor Foundation](poc/phase-06-actor-foundation.md) | 🔶 In Progress | poc.1, poc.3 | Character actor: abilities, AC shell, HP, saves, inventory, tokens, equipment slots |
-| 7 | [Roll Formulas & Custom Rolls](poc/phase-07-roll-formulas.md) | 📋 Outlined | poc.6 | D20Roll, DamageRoll, FormulaFamiliar roll data, formula paths |
+| 7 | [Roll Formulas & Custom Rolls](poc/phase-07-roll-formulas.md) | � In Progress | poc.6 | D20Roll, DamageRoll, FormulaFamiliar roll data, formula paths |
 | 8 | [Pipeline & Branching](poc/phase-08-pipeline-and-branching.md) | 🔶 In Progress | — | Branching model, PR gate (`test.yml`), release pipeline (`build.yml`), `phases.json` sync. Independent of POC content; can land any time before POC closes. |
 | 9 | [Basic Tokens](poc/phase-09-basic-tokens.md) | ✅ Complete | poc.6 | Token placed on scene with correct size and HP bar, actor linkage wired; movement budget display on ruler; vision system (darkvision, low-light, tremorsense) automatically maps to canvas. Ruler/movement E2E deferred to poc.10 by design. |
 | 10 | [Basic Combat](poc/phase-10-basic-combat.md) | 📝 Planned | poc.6, poc.7, poc.9 | Combat tracker functional; detects basic move, double move, and main-hand attack. Seeds alpha.3 Action System. |

--- a/docs/migration-plan/roadmap.md
+++ b/docs/migration-plan/roadmap.md
@@ -178,7 +178,7 @@ Dependencies use `wave.N` notation (e.g. `poc.1`, `alpha.3`, `beta.2`).
 | 4 | [Testing Infrastructure](poc/phase-04-testing-infrastructure.md) | ✅ Complete | poc.1, poc.2, poc.3 | Vitest, Foundry mocks, coverage tooling — establishes test patterns; back-fills poc.1–3 tests |
 | 5 | [Compendium Foundation](poc/phase-05-compendium-foundation.md) | 🔶 In Progress | poc.1, poc.2, poc.3 | Pack pipeline, origin tracking, UUID helpers, migration version field |
 | 6 | [Actor Foundation](poc/phase-06-actor-foundation.md) | 🔶 In Progress | poc.1, poc.3 | Character actor: abilities, AC shell, HP, saves, inventory, tokens, equipment slots |
-| 7 | [Roll Formulas & Custom Rolls](poc/phase-07-roll-formulas.md) | � In Progress | poc.6 | D20Roll, DamageRoll, FormulaFamiliar roll data, formula paths |
+| 7 | [Roll Formulas & Custom Rolls](poc/phase-07-roll-formulas.md) | 🔶 In Progress | poc.6 | D20Roll, DamageRoll, FormulaFamiliar roll data, formula paths |
 | 8 | [Pipeline & Branching](poc/phase-08-pipeline-and-branching.md) | 🔶 In Progress | — | Branching model, PR gate (`test.yml`), release pipeline (`build.yml`), `phases.json` sync. Independent of POC content; can land any time before POC closes. |
 | 9 | [Basic Tokens](poc/phase-09-basic-tokens.md) | ✅ Complete | poc.6 | Token placed on scene with correct size and HP bar, actor linkage wired; movement budget display on ruler; vision system (darkvision, low-light, tremorsense) automatically maps to canvas. Ruler/movement E2E deferred to poc.10 by design. |
 | 10 | [Basic Combat](poc/phase-10-basic-combat.md) | 📝 Planned | poc.6, poc.7, poc.9 | Combat tracker functional; detects basic move, double move, and main-hand attack. Seeds alpha.3 Action System. |

--- a/src/documents/activeEffects/baseActiveEffect/data/ActiveEffectSystemData.mts
+++ b/src/documents/activeEffects/baseActiveEffect/data/ActiveEffectSystemData.mts
@@ -2,7 +2,6 @@ import type { ActorDnd35e } from '@actors/baseActor/index.mjs';
 import type { ActiveEffectSystemSource, EffectChangeData } from '@common/documents/active-effect.mjs';
 import type { BonusType } from '@constants/bonusTypes.mjs';
 import type { DocumentSystemData } from '@documents/document/index.mjs';
-import type { Dnd35eDocType } from '@documents/types.mjs';
 import type { EffectChangeTarget } from '@effects/baseActiveEffect/data/constants.mjs';
 import type { ItemDnd35e } from '@items/baseItem/index.mjs';
 
@@ -27,10 +26,8 @@ interface EffectChangeSourceDnd35e extends Omit<EffectChangeData, 'effect'> {
   label?: string;
   /** Optional bonus type for stacking resolution. Only set when stacking applies (Phase 2+). */
   bonusType?: BonusType | null;
-  /** Optional formula-familiar condition for action-phase changes. Phase 8+. */
-  condition?: string 
-    | null 
-    | ((target: Dnd35eDocType) => boolean);
+  /** Optional formula-familiar condition for action-phase changes. Phase 8+. Must round-trip through the database, so string-form (FormulaFamiliar boolean grammar) only — no function form. */
+  condition?: string | null;
 }
 
 interface ActiveEffectSystemSourceDnd35e extends DocumentSystemData, Omit<ActiveEffectSystemSource, 'changes'> {

--- a/src/documents/activeEffects/baseActiveEffect/data/constants.mts
+++ b/src/documents/activeEffects/baseActiveEffect/data/constants.mts
@@ -44,8 +44,6 @@ const EFFECT_CHANGE_TYPE = {
  * These are registered in CONFIG.ActiveEffect.changeTypes at init.
  */
 const CHANGE_TYPE = {
-  /** FormulaFamiliar change type — provides autocomplete context, not value changes. */
-  FAMILIAR: 'familiar',
   /** MASK change type — defines masked (fake) values for Secret AEs. Not applied via stacking. */
   MASK: 'mask',
 } as const;

--- a/src/documents/activeEffects/baseActiveEffect/logic/evaluateChangeCondition.mts
+++ b/src/documents/activeEffects/baseActiveEffect/logic/evaluateChangeCondition.mts
@@ -1,0 +1,45 @@
+/**
+ * AE Change Conditional Gate
+ *
+ * Evaluates a single change's optional `condition` — a string-form formula resolved
+ * through FormulaFamiliar's boolean grammar. Conditions must be strings: they're
+ * persisted to the database, so a function form could never round-trip.
+ *
+ * A missing/null condition always passes (current behavior, unchanged).
+ */
+import type { EffectChangeDataDnd35e } from '@effects/baseActiveEffect/data/ActiveEffectSystemData.mjs';
+import { FormulaData } from '@helpers/formulae/FormulaData.mjs';
+
+/**
+ * @param change The change whose `condition` should be evaluated.
+ * @param contextMap Pre-built context map for resolution (from `getEffectContexts()`).
+ *   Omit for changes with no backing AE document (e.g. live-contributed changes) — a
+ *   condition with no contextMap surfaces a warning and is treated as `false`.
+ * @returns `true` when the change should apply, `false` when it should be skipped.
+ */
+function evaluateChangeCondition(
+  change: EffectChangeDataDnd35e,
+  contextMap?: Record<string, unknown>
+): boolean {
+  const condition = change.condition;
+  if (!condition) return true;
+
+  if (!contextMap) {
+    console.warn(`evaluateChangeCondition: no context map available to resolve condition "${condition}" for change targeting "${change.key}"`);
+    return false;
+  }
+
+  const resolved = FormulaData.resolveSource(
+    { formula: condition, resolvedValue: null, expectedType: 'boolean' },
+    contextMap
+  );
+
+  if (resolved !== 'true' && resolved !== 'false') {
+    console.error(`evaluateChangeCondition: condition "${condition}" did not resolve to a valid boolean expression (got "${resolved}") for change targeting "${change.key}"`);
+    return false;
+  }
+
+  return resolved === 'true';
+}
+
+export { evaluateChangeCondition };

--- a/src/documents/activeEffects/baseActiveEffect/logic/index.mts
+++ b/src/documents/activeEffects/baseActiveEffect/logic/index.mts
@@ -6,6 +6,9 @@ export {
   applyStackedActiveEffectChanges,
 } from './applyStackedChanges.mjs';
 export {
+  evaluateChangeCondition,
+} from './evaluateChangeCondition.mjs';
+export {
   formatChangeTypeSymbol,
 } from './formatChangeTypeSymbol.mjs';
 export {

--- a/src/documents/activeEffects/baseActiveEffect/logic/resolveChangeValue.mts
+++ b/src/documents/activeEffects/baseActiveEffect/logic/resolveChangeValue.mts
@@ -66,16 +66,13 @@ function tryEvaluateNumber(expression: string): number | null {
   if (!Number.isNaN(numericValue)) return numericValue;
 
   try {
-    const safeEval = (Roll as unknown as { safeEval?: (formula: string) => number }).safeEval;
-    if (safeEval) {
-      const evaluated = safeEval(trimmed);
-      return Number.isNaN(evaluated) ? null : evaluated;
-    }
+    const evaluated = Roll.safeEval(trimmed);
+    return Number.isNaN(evaluated)
+      ? null
+      : evaluated;
   } catch {
     return null;
   }
-
-  return null;
 }
 
 function resolveActiveEffectChangeValue(

--- a/src/documents/activeEffects/baseActiveEffect/sheet/components/EffectChangesList.vue
+++ b/src/documents/activeEffects/baseActiveEffect/sheet/components/EffectChangesList.vue
@@ -15,23 +15,56 @@
       {{ resolvedEmptyLabel }}
     </p>
 
-    <ol v-else class="changes-list" data-changes>
+    <ol
+      v-else
+      class="changes-list"
+      :class="`changes-list--${props.variant}`"
+      :style="{ gridTemplateColumns: gridColumns }"
+      data-changes
+    >
+      <li class="changes-table-header">
+        <span v-if="props.variant === 'default'" class="col-header">{{ targetLabel }}</span>
+        <span class="col-header">{{ keyHeaderLabel }}</span>
+        <span v-if="props.variant === 'mask'" class="col-header" />
+        <span v-if="props.variant === 'default'" class="col-header">{{ typeHeaderLabel }}</span>
+        <span class="col-header">{{ valueHeaderLabel }}</span>
+        <span v-if="props.variant === 'default' && props.showBonusType" class="col-header">{{ bonusTypeLabel }}</span>
+        <span v-if="props.variant === 'default'" class="col-header">{{ conditionHeaderLabel }}</span>
+        <span class="col-header">{{ priorityHeaderLabel }}</span>
+        <span v-if="props.showChangeFieldControls" class="col-header">{{ controlsHeaderLabel }}</span>
+      </li>
+
       <li
         v-for="(change, index) in visibleChanges"
         v-show="isChangeVisible(index)"
         :key="index"
         class="change-row"
-        :class="`change-row--${props.variant}`"
         :data-index="index"
       >
         <div class="form-fields">
+          <select
+            v-if="props.variant === 'default'"
+            :name="`system.changes.${index}.target`"
+            :value="change.target ?? 'item'"
+            :disabled="!isChangeEditable(index) || change.isSystem"
+            class="target-select"
+            :title="targetLabel"
+            @change="(e: Event) => updateChangeField(index, 'target', (e.target as HTMLSelectElement).value)"
+          >
+            <option v-for="(label, target) in changeTargets" :key="target" :value="target">
+              {{ label }}
+            </option>
+          </select>
+
           <AspectPicker
             :model-value="change.key"
             :placeholder="resolvedKeyPlaceholder"
             :disabled="!isChangeEditable(index) || change.isSystem"
             :familiar-context="store.documentGetters.getTargetFamiliarContext(change.target ?? 'item')"
             :context-name="store.documentGetters.getTargetFamiliarContextName(change.target ?? 'item')"
+            hide-context-hint
             @update:model-value="(val: string) => updateChangeKey(index, val)"
+            @update:error="(err: string | null) => setRowError(index, 'field', err)"
           />
 
           <span v-if="props.variant === 'mask'" class="mask-arrow">
@@ -57,7 +90,10 @@
             :on-update="(val: string) => updateChangeField(index, 'value', val)"
             :disabled="!isChangeEditable(index) || change.isSystem"
             :contexts="getContextsForTarget(change.target ?? 'item')"
+            :expected-type="getExpectedTypeForChange(change)"
             hide-field-controls
+            hide-context-hint
+            @update:error="(err: string | null) => setRowError(index, 'value', err)"
           />
 
           <select
@@ -75,19 +111,20 @@
             </option>
           </select>
 
-          <select
+          <FormulaFormGroup
             v-if="props.variant === 'default'"
-            :name="`system.changes.${index}.target`"
-            :value="change.target ?? 'item'"
+            class="change-condition"
+            :value="String(change.condition ?? '')"
+            expected-type="boolean"
+            :field-path="`system.changes.${index}.condition`"
+            :on-update="(val: string) => updateChangeField(index, 'condition', val || null)"
             :disabled="!isChangeEditable(index) || change.isSystem"
-            class="target-select"
-            :title="targetLabel"
-            @change="(e: Event) => updateChangeField(index, 'target', (e.target as HTMLSelectElement).value)"
-          >
-            <option v-for="(label, target) in changeTargets" :key="target" :value="target">
-              {{ label }}
-            </option>
-          </select>
+            :contexts="getContextsForTarget(change.target ?? 'item')"
+            hide-field-controls
+            hide-label
+            hide-context-hint
+            @update:error="(err: string | null) => setRowError(index, 'condition', err)"
+          />
 
           <input
             type="number"
@@ -110,6 +147,10 @@
             </button>
           </FieldControls>
         </div>
+
+        <div v-if="getRowContextText(index, change)" class="row-context" :class="{ 'has-error': hasRowError(index) }">
+          {{ getRowContextText(index, change) }}
+        </div>
       </li>
     </ol>
   </div>
@@ -120,13 +161,14 @@
   import type { RenderModeStore } from '@documents/document/index.mjs';
   import { DocumentSheetStoreSymbol, RenderModeStoreSymbol } from '@documents/document/index.mjs';
   import type { EffectChangeDataDnd35e } from '@effects/baseActiveEffect/data/ActiveEffectSystemData.mjs';
-  import { EFFECT_CHANGE_TARGET, EFFECT_CHANGE_TARGETS, EFFECT_CHANGE_TYPE } from '@effects/baseActiveEffect/data/constants.mjs';
+  import { EFFECT_CHANGE_TARGET, EFFECT_CHANGE_TARGETS, EFFECT_CHANGE_TYPE, SYSTEM_CHANGE_TYPE } from '@effects/baseActiveEffect/data/constants.mjs';
   import type { ActiveEffectConfigStore } from '@effects/baseActiveEffect/sheet/ActiveEffectConfigStore.mjs';
   import FormulaFormGroup from '@helpers/formulae/FormulaFormGroup.vue';
   import type { FamiliarSchema } from '@helpers/formulae/types.mts';
+  import { findAspectByAccessPath } from '@helpers/formulae/utils.mjs';
   import AspectPicker from '@vc/fields/formGroups/AspectPicker.vue';
   import FieldControls from '@vc/fields/formGroups/FieldControls.vue';
-  import { computed, inject } from 'vue';
+  import { computed, inject, reactive } from 'vue';
 
   const props = withDefaults(defineProps<{
     title?: string;
@@ -166,6 +208,30 @@
   const targetLabel = game.i18n.localize('dnd35e.EFFECT.ChangeTarget.Target');
   const bonusTypeLabel = game.i18n.localize('dnd35e.EFFECT.BonusType.Label');
   const noneLabel = game.i18n.localize('dnd35e.EFFECT.BonusType.None');
+  const keyHeaderLabel = game.i18n.localize('dnd35e.EFFECT.Headers.Field');
+  const typeHeaderLabel = game.i18n.localize('dnd35e.EFFECT.Headers.Type');
+  const valueHeaderLabel = game.i18n.localize('dnd35e.EFFECT.Headers.Value');
+  const conditionHeaderLabel = game.i18n.localize('dnd35e.EFFECT.Headers.Condition');
+  const priorityHeaderLabel = game.i18n.localize('dnd35e.EFFECT.Headers.Priority');
+  const controlsHeaderLabel = game.i18n.localize('dnd35e.EFFECT.Headers.Actions');
+
+  // The Changes list renders as a single shared CSS grid (header row + each
+  // change row are `display: contents`, see <style>) so columns stay aligned
+  // like a real table. The column count/order must exactly match what's
+  // rendered per-row for the current variant/props — kept in sync here.
+  const gridColumns = computed(() => {
+    if (props.variant === 'mask') {
+      const cols = ['1fr', 'max-content', '1fr', 'max-content']; // Key, arrow, Value, Priority
+      if (props.showChangeFieldControls) cols.push('max-content');
+      return cols.join(' ');
+    }
+    const cols = ['max-content', '1fr', 'max-content', '1fr']; // Target, Key, Type, Value
+    if (props.showBonusType) cols.push('max-content'); // BonusType
+    cols.push('1fr'); // Condition
+    cols.push('max-content'); // Priority
+    if (props.showChangeFieldControls) cols.push('max-content'); // Controls
+    return cols.join(' ');
+  });
   const resolvedTitle = computed(() => props.title ?? game.i18n.localize('EFFECT.TABS.changes'));
   const resolvedAddLabel = computed(() => props.addLabel ?? game.i18n.localize('EFFECT.AddChange'));
   const resolvedEmptyLabel = computed(() => props.emptyLabel ?? '');
@@ -175,15 +241,74 @@
   const isChangeVisible = (index: number): boolean => getIsFieldVisible(changeFieldPath(index)).value;
   const isChangeEditable = (index: number): boolean => getIsFieldEditable(changeFieldPath(index)).value;
 
+  // Value/Condition formulas may reference both the change's target (item/actor)
+  // AND the effect document itself ("Self") — e.g. a Material AE's Value formula
+  // referencing its own #Self.MagicEquivalency. The Field column (AspectPicker)
+  // intentionally does NOT get Self — change.key must resolve to a path on the
+  // target document, since that's what Foundry actually applies the change to.
   function getContextsForTarget (target: string): FamiliarSchema | undefined {
-    const ctx = store.documentGetters.getTargetFamiliarContext(target);
+    const schema: FamiliarSchema = {};
+
+    const selfContext = store.documentGetters.familiarSchema.value.self;
+    if (selfContext) schema.self = selfContext;
+
+    const targetContext = store.documentGetters.getTargetFamiliarContext(target);
+    if (targetContext) schema[store.documentGetters.getTargetFamiliarContextName(target)] = targetContext;
+
+    return Object.keys(schema).length ? schema : undefined;
+  }
+
+  // Per-row validation errors surfaced by the Field/Value/Condition formula editors
+  // (`update:error`), combined into the row's shared context line instead of each
+  // editor showing its own separate hint/error text. Keyed by row index — self-heals
+  // when rows shift, since each editor re-emits its current error on every update.
+  type RowFieldKey = 'field' | 'value' | 'condition';
+  const rowFieldErrors = reactive<Record<number, Partial<Record<RowFieldKey, string | null>>>>({});
+
+  function setRowError (index: number, field: RowFieldKey, error: string | null): void {
+    rowFieldErrors[index] = { ...rowFieldErrors[index], [field]: error };
+  }
+
+  function hasRowError (index: number): boolean {
+    const errors = rowFieldErrors[index];
+    return !!errors && Object.values(errors).some(Boolean);
+  }
+
+  // Combined display text for the row's shared context line: validation errors
+  // (prefixed by which column they came from) take priority over the plain
+  // "Available Contexts: [...]" hint, since all three fields share one context.
+  function getRowContextText (index: number, change: EffectChangeDataDnd35e): string {
+    const errors = rowFieldErrors[index];
+    if (errors) {
+      const parts: string[] = [];
+      if (errors.field) parts.push(`${keyHeaderLabel}: ${errors.field}`);
+      if (errors.value) parts.push(`${valueHeaderLabel}: ${errors.value}`);
+      if (errors.condition) parts.push(`${conditionHeaderLabel}: ${errors.condition}`);
+      if (parts.length) return parts.join(' \u00b7 ');
+    }
+
+    const schema = getContextsForTarget(change.target ?? 'item');
+    if (!schema) return '';
+    const names = Object.entries(schema).map(([k, ctx]) => ctx.display ?? (k.charAt(0).toUpperCase() + k.slice(1)));
+    if (!names.length) return '';
+    const localizedPrefix = game.i18n.localize('dnd35e.Formula.availableContexts');
+    return `${localizedPrefix}: [${names.join(', ')}]`;
+  }
+
+  // The Value column's expectedType is derived from the picked aspect (change.key),
+  // not left to default to 'string' — enforces the aspect's real type in the formula input.
+  function getExpectedTypeForChange (change: EffectChangeDataDnd35e): 'string' | 'number' | 'boolean' | undefined {
+    if (!change.key) return undefined;
+    const ctx = store.documentGetters.getTargetFamiliarContext(change.target ?? 'item');
     if (!ctx) return undefined;
-    return { [store.documentGetters.getTargetFamiliarContextName(target)]: ctx };
+    return findAspectByAccessPath(ctx.properties, change.key)?.aspect.type;
   }
 
   const changeTypes = computed(() => {
     const types: Record<string, string> = {};
     for (const [type, config] of Object.entries(ActiveEffect.CHANGE_TYPES)) {
+      // mask is a system-registered internal type (Secret AE masking) — never user-selectable here.
+      if (type === SYSTEM_CHANGE_TYPE.MASK) continue;
       types[type] = game.i18n.localize((config as { label: string }).label);
     }
     return types;
@@ -259,9 +384,10 @@
     list-style: none;
     padding: 0;
     margin: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
+    display: grid;
+    column-gap: 0.5rem;
+    row-gap: 0.15rem;
+    align-items: center;
   }
 
   .changes-empty {
@@ -271,7 +397,49 @@
     text-align: center;
   }
 
+  // The header row is `display: contents` so its cells become direct items
+  // of the `.changes-list` grid, sharing the exact same column tracks as
+  // every data row below.
+  .changes-table-header {
+    display: contents;
+
+    .col-header {
+      font-weight: 600;
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      opacity: 0.7;
+      padding-bottom: 0.35rem;
+      border-bottom: 1px solid var(--color-border);
+    }
+  }
+
+  // Each change row is a real grid box (not `display: contents`) using
+  // `grid-template-columns: subgrid` so it inherits the parent's column
+  // tracks exactly — this keeps columns aligned with the header AND lets
+  // the row have its own background/padding/hover state, unlike a bare
+  // `display: contents` row which can't paint a box at all.
   .change-row {
+    display: grid;
+    grid-column: 1 / -1;
+    grid-template-columns: subgrid;
+    align-items: start;
+    row-gap: 0.2rem;
+    padding: 0.4rem 0.25rem 0;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.02);
+    transition: background-color 0.15s ease;
+    border-bottom: 1px solid var(--color-border);
+    margin: 0;
+
+    &:nth-of-type(even) {
+      background: rgba(255, 255, 255, 0.05);
+    }
+
+    &:hover {
+      background: rgba(102, 166, 255, 0.07);
+    }
+
     input[type="text"] {
       flex: 1;
     }
@@ -279,41 +447,52 @@
     select {
       width: 120px;
     }
-    
-    :deep(.change-value.form-group) {
+
+    :deep(.change-value.form-group),
+    :deep(.change-condition.form-group) {
       display: flex;
+      border: none;
+      padding: 0;
     }
 
-    &--default {
-      .form-fields {
-        display: grid;
-        grid-template-columns: 1fr max-content max-content max-content auto 100px;
-        gap: 0.25rem;
-        align-items: center;
-      }
-
-      &:has(.bonus-type-select) {
-        .form-fields {
-          grid-template-columns: 1fr max-content max-content max-content max-content auto 100px;
-        }
-      }
-
+    // Harmonize the Value/Condition formula editors (rendered by the shared,
+    // globally-styled FormulaFormGroup/FamiliarOverlayInput) with the more
+    // compact Field/AspectPicker input so all row cells read as one uniform
+    // table row, instead of two oversized boxed cells next to plain selects.
+    // Scoped to `.change-value`/`.change-condition` only — the global
+    // `.formula-input`/`.highlight-layer`/`.formula-display` styles used
+    // elsewhere (e.g. FormulaSettingsGroup) are left untouched.
+    :deep(.change-value .formula-input),
+    :deep(.change-condition .formula-input),
+    :deep(.change-value .highlight-layer),
+    :deep(.change-condition .highlight-layer) {
+      min-height: unset;
+      padding: 0.35rem 0.5rem;
+      font-size: 0.85rem;
+      border-radius: 3px;
     }
 
-    &--mask {
-      .form-fields {
-        display: grid;
-        grid-template-columns: 1fr auto 1fr 60px auto;
-        gap: 0.5rem;
-        align-items: center;
-        padding: 0.25rem 0;
-      }
+    :deep(.change-value .formula-display),
+    :deep(.change-condition .formula-display) {
+      min-height: unset;
+      padding: 0.35rem 0.5rem;
+      font-size: 0.85rem;
+      border-radius: 3px;
+    }
+  }
 
-      &:not(:last-child) {
-        .form-fields {
-          border-bottom: 1px solid var(--color-border);
-        }
-      }
+  .form-fields {
+    display: contents;
+  }
+
+  .row-context {
+    grid-column: 1 / -1;
+    font-size: var(--font-size-11);
+    color: var(--color-text-secondary);
+    padding: 0.35rem 0.5rem;
+
+    &.has-error {
+      color: rgba(255, 100, 100, 0.85);
     }
   }
 

--- a/src/documents/activeEffects/baseActiveEffect/sheet/components/EffectChangesList.vue
+++ b/src/documents/activeEffects/baseActiveEffect/sheet/components/EffectChangesList.vue
@@ -164,8 +164,8 @@
   import { EFFECT_CHANGE_TARGET, EFFECT_CHANGE_TARGETS, EFFECT_CHANGE_TYPE, SYSTEM_CHANGE_TYPE } from '@effects/baseActiveEffect/data/constants.mjs';
   import type { ActiveEffectConfigStore } from '@effects/baseActiveEffect/sheet/ActiveEffectConfigStore.mjs';
   import FormulaFormGroup from '@helpers/formulae/FormulaFormGroup.vue';
+  import { FormulaResolver } from '@helpers/formulae/FormulaResolver.mjs';
   import type { FamiliarSchema } from '@helpers/formulae/types.mts';
-  import { findAspectByAccessPath } from '@helpers/formulae/utils.mjs';
   import AspectPicker from '@vc/fields/formGroups/AspectPicker.vue';
   import FieldControls from '@vc/fields/formGroups/FieldControls.vue';
   import { computed, inject, reactive } from 'vue';
@@ -301,7 +301,7 @@
     if (!change.key) return undefined;
     const ctx = store.documentGetters.getTargetFamiliarContext(change.target ?? 'item');
     if (!ctx) return undefined;
-    return findAspectByAccessPath(ctx.properties, change.key)?.aspect.type;
+    return FormulaResolver.findAspectByAccessPath(ctx.properties, change.key)?.aspect.type;
   }
 
   const changeTypes = computed(() => {

--- a/src/documents/activeEffects/containment/data/ContainmentSystemModel.mts
+++ b/src/documents/activeEffects/containment/data/ContainmentSystemModel.mts
@@ -2,6 +2,7 @@ import { ActiveEffectSystemModel } from '@effects/baseActiveEffect/data/ActiveEf
 import type { EffectChangeDataDnd35e } from '@effects/baseActiveEffect/index.mjs';
 import { CurrencyField } from '@fields/currency/CurrencyField.mjs';
 import { requiredNumberField } from '@fields/fieldBuilders.mjs';
+import type { FormulaField } from '@helpers/formulae/FormulaField.mjs';
 
 import { buildContainmentChanges } from './buildContainmentChanges.mjs';
 import type { ContainmentSystemData } from './ContainmentSystemData.mjs';
@@ -19,6 +20,11 @@ class ContainmentSystemModel extends ActiveEffectSystemModel {
 
   static override defineSchema (): Record<string, any> {
     const schema = super.defineSchema();
+
+    // Always placed on the container item it contributes to.
+    (schema.nameFormula as FormulaField).formulaContexts = [
+      { contextName: 'Container', resolvePath: 'parent', documentType: 'Item', fallbackSubtypes: ['container'], aliases: ['Owner', 'Parent'] },
+    ];
 
     schema.sourceItemUuid = new StringField({ required: true, nullable: true, initial: null });
     schema.contributedWeight = requiredNumberField(0);

--- a/src/documents/activeEffects/containment/data/buildContainmentChanges.mts
+++ b/src/documents/activeEffects/containment/data/buildContainmentChanges.mts
@@ -1,7 +1,5 @@
-import type { Dnd35eDocType } from '@documents/types.mjs';
 import type { EffectChangeDataDnd35e } from '@effects/baseActiveEffect/index.mjs';
 import type { CurrencyData } from '@fields/index.mjs';
-import { Container } from '@items/physical/container/Container.mjs';
 
 type BuildContainmentChangesInput = {
   existingChanges: EffectChangeDataDnd35e[];
@@ -13,7 +11,7 @@ type BuildContainmentChangesInput = {
 const buildChange = (
   key: string,
   value: number | CurrencyData,
-  condition?: (target: Dnd35eDocType) => boolean
+  condition?: string
 ): EffectChangeDataDnd35e => ({
   key,
   type: 'add',
@@ -41,9 +39,7 @@ const buildContainmentChanges = ({
   changes.push(buildChange(
     'system.weight',
     contributedWeight,
-    (target): target is Container => 
-      target instanceof Container
-      && !((target as Container).system.contentsAreWeightless)
+    '!#item.contentsAreWeightless'
   ));
   changes.push(buildChange(
     'system.contentsCount',

--- a/src/documents/activeEffects/general/data/GeneralEffectSystemModel.mts
+++ b/src/documents/activeEffects/general/data/GeneralEffectSystemModel.mts
@@ -1,13 +1,39 @@
+import { ACTOR_TYPES } from '@actors/actorTypes.mjs';
 import { ActiveEffectSystemModel } from '@effects/baseActiveEffect/data/ActiveEffectSystemModel.mjs';
+import type { FormulaField } from '@helpers/formulae/FormulaField.mjs';
+import type { TargetContexts } from '@helpers/formulae/registry.mjs';
+import { PHYSICAL_ITEM_TYPES } from '@items/itemTypes.mjs';
 
 import type { GeneralEffectSystemData } from './GeneralEffectSystemData.mjs';
 
 /**
  * General active effect system model — the standard effect type for dnd35e.
- * No additional fields beyond the base schema.
+ *
+ * Unlike Material (weapon-only) or Secret (always has a live parent), General
+ * AEs are meant to target ANY item or actor subtype — including when edited
+ * standalone (no live parent of the target kind to narrow the schema). So its
+ * `targetContexts` is sourced from the full type registries rather than a
+ * hardcoded list, and grows automatically as new item/actor subtypes register.
  */
 class GeneralEffectSystemModel extends ActiveEffectSystemModel {
   static override LOCALIZATION_PREFIXES = [...super.LOCALIZATION_PREFIXES, 'dnd35e.EFFECT.General'];
+  static override targetContexts: TargetContexts = {
+    item: [...PHYSICAL_ITEM_TYPES],
+    actor: [...ACTOR_TYPES],
+  };
+
+  static override defineSchema (): Record<string, any> {
+    const schema = super.defineSchema();
+
+    // Parent could be an Item or an Actor (or neither, when edited standalone) —
+    // no single fallback subtype makes sense, so schema-only editing without a
+    // live parent just shows Self.
+    (schema.nameFormula as FormulaField).formulaContexts = [
+      { contextName: 'Parent', resolvePath: 'parent', documentType: 'Item', fallbackSubtypes: [] },
+    ];
+
+    return schema;
+  }
 }
 
 interface GeneralEffectSystemModel extends GeneralEffectSystemData {}

--- a/src/documents/activeEffects/general/sheet/GeneralSheet.mts
+++ b/src/documents/activeEffects/general/sheet/GeneralSheet.mts
@@ -1,0 +1,25 @@
+import type { DocumentSheetConfiguration } from '@client/applications/api/document-sheet.mjs';
+import { ActiveEffectConfigDnd35e } from '@effects/baseActiveEffect/sheet/ActiveEffectConfigDnd35e.mjs';
+import type { General } from '@effects/general/General.mjs';
+
+import GeneralSheetVue from './GeneralSheet.vue';
+
+type GeneralSheetConfig = DocumentSheetConfiguration<General>;
+type GeneralSheetRenderContext = {
+  document: General;
+};
+
+class GeneralSheet extends ActiveEffectConfigDnd35e {
+  get vueComponent () {
+    return GeneralSheetVue;
+  }
+}
+
+export {
+  GeneralSheet,
+};
+
+export type {
+  GeneralSheetConfig,
+  GeneralSheetRenderContext,
+};

--- a/src/documents/activeEffects/general/sheet/GeneralSheet.vue
+++ b/src/documents/activeEffects/general/sheet/GeneralSheet.vue
@@ -1,0 +1,24 @@
+<template>
+  <DocumentSheetBody>
+    <template #header-summary>
+      <DisableEffect />
+    </template>
+  </DocumentSheetBody>
+</template>
+<script lang="ts" setup>
+  import { DocumentSheetStoreSymbol } from '@documents/document/index.mjs';
+  import { DocumentSheetBody } from '@documents/document/index.mjs';
+  import DisableEffect from '@effects/baseActiveEffect/sheet/components/DisableEffect.vue';
+  import type { VueApplicationContext } from '@vueApps/VueAppTypes.mjs';
+  import { provide } from 'vue';
+
+  import type { General } from '../General.mjs';
+  import { useGeneralStore } from './GeneralStore.mjs';
+
+  const props = defineProps<{
+    context: VueApplicationContext<General>;
+  }>();
+
+  const store = useGeneralStore(props.context);
+  provide(DocumentSheetStoreSymbol, store);
+</script>

--- a/src/documents/activeEffects/general/sheet/GeneralStore.mts
+++ b/src/documents/activeEffects/general/sheet/GeneralStore.mts
@@ -1,0 +1,22 @@
+import type { ActiveEffectConfigStore } from '@effects/baseActiveEffect/sheet/ActiveEffectConfigStore.mjs';
+import { useActiveEffectConfigStore } from '@effects/baseActiveEffect/sheet/ActiveEffectConfigStore.mjs';
+import type { General } from '@effects/general/General.mjs';
+import type { VueApplicationContext } from '@vueApps/VueAppTypes.mjs';
+
+/**
+ * General AE has no fields or tabs beyond the base ActiveEffect schema
+ * (Details/Duration/Changes) — this is a thin pass-through leaf store, kept
+ * as its own file for structural parity with Material/Secret.
+ */
+const useGeneralStore = (context: VueApplicationContext<General>): GeneralStore => {
+  const baseStore = useActiveEffectConfigStore<General>(context);
+
+  return {
+    ...baseStore,
+  };
+};
+
+type GeneralStore = ActiveEffectConfigStore<General>;
+
+export { useGeneralStore };
+export type { GeneralStore };

--- a/src/documents/activeEffects/general/sheet/index.mts
+++ b/src/documents/activeEffects/general/sheet/index.mts
@@ -1,0 +1,15 @@
+import type { GeneralSheetConfig, GeneralSheetRenderContext } from './GeneralSheet.mjs';
+import { GeneralSheet } from './GeneralSheet.mjs';
+import type { GeneralStore } from './GeneralStore.mjs';
+import { useGeneralStore } from './GeneralStore.mjs';
+
+export {
+  GeneralSheet,
+  useGeneralStore,
+};
+
+export type {
+  GeneralSheetConfig,
+  GeneralSheetRenderContext,
+  GeneralStore,
+};

--- a/src/documents/activeEffects/registration.mts
+++ b/src/documents/activeEffects/registration.mts
@@ -3,6 +3,7 @@ import { EFFECT_CHANGE_PHASES } from '@effects/baseActiveEffect/data/index.mjs';
 import { containmentEffectType } from '@effects/containment/containmentEffectType.mjs';
 import { Containment, ContainmentSystemModel } from '@effects/containment/index.mjs';
 import { GENERAL_EFFECT_TYPE, GeneralEffectSystemModel } from '@effects/general/index.mjs';
+import { GeneralSheet } from '@effects/general/sheet/GeneralSheet.mjs';
 import { MaterialSystemModel } from '@effects/material/data/MaterialSystemModel.mjs';
 import { Material } from '@effects/material/Material.mjs';
 import { materialEffectType } from '@effects/material/materialEffectType.mjs';
@@ -16,6 +17,7 @@ import { SYSTEM_ID } from '@settings/shared.mjs';
 import { Secret } from './secret/index.mjs';
 const registerEffectSheets = () => {
   const effectSheets = [
+    [GENERAL_EFFECT_TYPE, GeneralSheet],
     [materialEffectType, MaterialSheet],
     [secretEffectType, SecretSheet],
   ] as const;
@@ -55,14 +57,10 @@ export const registerEffects = () => {
     // Default new AEs to 'general' type instead of 'base'
     CONFIG.ActiveEffect.defaultType = GENERAL_EFFECT_TYPE;
 
-    // Register FormulaFamiliar change type (handler deferred to Phase 7)
+    // MASK change type — Secret AEs use this to define masked values. Not applied via
+    // applyChange() (filtered out of the stacking loops) and not user-selectable — the
+    // "type" dropdown in EffectChangesList.vue excludes it for regular (non-mask) rows.
     const changeTypes = ((CONFIG.ActiveEffect as Record<string, unknown>).changeTypes ??= {}) as Record<string, unknown>;
-    changeTypes.familiar = {
-      label: 'dnd35e.EFFECT.ChangeMode.Familiar',
-      defaultPriority: 50,
-      handler: null,
-    };
-    // MASK change type — Secret AEs use this to define masked values. Not applied via applyChange().
     changeTypes.mask = {
       label: 'dnd35e.EFFECT.ChangeMode.Mask',
       defaultPriority: 10,

--- a/src/documents/activeEffects/secret/data/SecretSystemModel.mts
+++ b/src/documents/activeEffects/secret/data/SecretSystemModel.mts
@@ -1,5 +1,6 @@
 import { ActiveEffectSystemModel } from '@effects/baseActiveEffect/data/ActiveEffectSystemModel.mjs';
 import { requiredBooleanField } from '@fields/fieldBuilders.mjs';
+import type { FormulaField } from '@helpers/formulae/FormulaField.mjs';
 
 import type { SecretSystemData } from './SecretSystemData.mjs';
 
@@ -21,6 +22,12 @@ class SecretSystemModel extends ActiveEffectSystemModel {
 
   static override defineSchema (): Record<string, any> {
     const superSchema = super.defineSchema();
+
+    // Secrets always have a live parent (Item or Actor) — no fallback needed.
+    (superSchema.nameFormula as FormulaField).formulaContexts = [
+      { contextName: 'Parent', resolvePath: 'parent', documentType: 'Item', fallbackSubtypes: [] },
+    ];
+
     return foundry.utils.mergeObject(superSchema, {
       isPlayerEditSecret: requiredBooleanField(false),
     });

--- a/src/documents/actors/baseActor/ActorDnd35e.mts
+++ b/src/documents/actors/baseActor/ActorDnd35e.mts
@@ -10,8 +10,10 @@ import type { ActiveEffectDnd35e } from '@effects/baseActiveEffect/ActiveEffectD
 import type { EffectChangeDataDnd35e } from '@effects/baseActiveEffect/data/ActiveEffectSystemData.mjs';
 import { EFFECT_CHANGE_TARGET, EFFECT_CHANGE_TYPE, SYSTEM_CHANGE_TYPE } from '@effects/baseActiveEffect/data/constants.mjs';
 import { applyStackedActiveEffectChanges, type ResolvedEffectChange } from '@effects/baseActiveEffect/logic/applyStackedChanges.mjs';
-import { resolveActiveEffectChange } from '@effects/baseActiveEffect/logic/resolveChangeValue.mjs';
+import { evaluateChangeCondition } from '@effects/baseActiveEffect/logic/evaluateChangeCondition.mjs';
+import { getEffectContexts, resolveActiveEffectChange } from '@effects/baseActiveEffect/logic/resolveChangeValue.mjs';
 import { DocumentEventEmitter } from '@helpers/documentEvents/DocumentEventEmitter.mjs';
+import { buildDocumentDataMap } from '@helpers/formulae/index.mjs';
 import { LogHelper } from '@helpers/LogHelper.mjs';
 import type { Override } from '@helpers/stacking.mjs';
 import type { ItemDnd35e } from '@items/baseItem/index.mjs';
@@ -90,6 +92,10 @@ class ActorDnd35e<
           // read directly by maskMap.mts to build the actor's masks dictionary.
           || (change.type === SYSTEM_CHANGE_TYPE.MASK)
         ) continue;
+        if (change.condition) {
+          const { contextMap } = getEffectContexts(effect, change);
+          if (!evaluateChangeCondition(change, contextMap)) continue;
+        }
         const copy = foundry.utils.deepClone(resolveActiveEffectChange(effect, change)) as AppliedActorEffectChange;
         copy.effect = effect as ActiveEffectDnd35e;
         copy.type ??= EFFECT_CHANGE_TYPE.ADD;
@@ -101,19 +107,34 @@ class ActorDnd35e<
       }
     }
 
-    // Items can also contribute actor-targeted changes with no backing AE document at
-    // all (e.g. carried-weight, equipped-status) - see `ItemDnd35e.getContributedActorChanges()`.
-    // Already phase-filtered by the item; no `resolveActiveEffectChange()` needed since
-    // these values are computed live, not read from a stored AE.
-    for ( const item of this.items ) {
-      for ( const change of item.getContributedActorChanges(phase) ) {
-        if ( !change.key ) continue;
+    const processChanges = (
+      changesToProcess: EffectChangeDataDnd35e[],
+      contextMap?: Record<string, unknown>,
+      source: ActiveEffectDnd35e | ItemDnd35e | ActorDnd35e = this
+    ) => {
+      for (const change of changesToProcess) {
+        if (!change.key) continue;
+        if (change.condition && !evaluateChangeCondition(change, contextMap)) continue;
         const copy = foundry.utils.deepClone(change) as AppliedActorEffectChange;
-        copy.effect = item;
+        copy.effect = source;
         copy.type ??= EFFECT_CHANGE_TYPE.ADD;
         copy.priority ??= 0;
         changes.push(copy);
       }
+    };
+
+    // Items can also contribute actor-targeted changes with no backing AE document at
+    // all (e.g. carried-weight, equipped-status) - see `ItemDnd35e.getContributedActorChanges()`.
+    // Already phase-filtered by the item; no `resolveActiveEffectChange()` needed since
+    // these values are computed live, not read from a stored AE. Build a contextMap so a
+    // `condition` on one of these live changes can resolve `#item.___`/`#actor.___` just
+    // like AE-backed changes do (via `getEffectContexts()`).
+    for ( const item of this.items ) {
+      const contextMap = buildDocumentDataMap(this, {
+        item, Item: item, [item.type]: item,
+        actor: this, Actor: this, Owner: this, [this.type]: this,
+      });
+      processChanges(item?.getContributedActorChanges(phase) ?? [], contextMap, item);
     }
 
     // The actor can also contribute changes derived from its own data with no backing
@@ -121,14 +142,11 @@ class ActorDnd35e<
     // `getSelfContributedChanges()`. Already phase-filtered by the override; no
     // `resolveActiveEffectChange()` needed since these values are computed live, not
     // read from a stored AE.
-    for ( const change of this.getSelfContributedChanges(phase) ) {
-      if ( !change.key ) continue;
-      const copy = foundry.utils.deepClone(change) as AppliedActorEffectChange;
-      copy.effect = this;
-      copy.type ??= EFFECT_CHANGE_TYPE.ADD;
-      copy.priority ??= 0;
-      changes.push(copy);
-    }
+    processChanges(
+      this.getSelfContributedChanges(phase),
+      buildDocumentDataMap(this, { actor: this, Actor: this, [this.type]: this })
+    );
+    
     changes.sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
 
     // Resolve bonus-type stacking and apply the winners, recording Override

--- a/src/documents/document/data/DocumentSystemModel.mts
+++ b/src/documents/document/data/DocumentSystemModel.mts
@@ -79,7 +79,7 @@ abstract class DocumentSystemModel<TDocType extends foundry.abstract.DataModel |
         const excluded = field.excludedFields ?? [];
         const formulaSource = currentValue as unknown as {
           formula: string;
-          expectedType: 'string' | 'number';
+          expectedType: 'string' | 'number' | 'boolean';
           resolvedValue: string | null;
         };
         formulaSource.resolvedValue = formulaSource.formula

--- a/src/documents/items/baseItem/ItemDnd35e.mts
+++ b/src/documents/items/baseItem/ItemDnd35e.mts
@@ -18,9 +18,11 @@ import {
 } from '@effects/baseActiveEffect/data/constants.mjs';
 import type { ResolvedEffectChange } from '@effects/baseActiveEffect/logic/applyStackedChanges.mjs';
 import { applyStackedActiveEffectChanges } from '@effects/baseActiveEffect/logic/applyStackedChanges.mjs';
-import { resolveActiveEffectChange, resolveMaskedActiveEffectChangeValue } from '@effects/baseActiveEffect/logic/resolveChangeValue.mjs';
+import { evaluateChangeCondition } from '@effects/baseActiveEffect/logic/evaluateChangeCondition.mjs';
+import { getEffectContexts, resolveActiveEffectChange, resolveMaskedActiveEffectChangeValue } from '@effects/baseActiveEffect/logic/resolveChangeValue.mjs';
 import type { ACTIVE_EFFECTS_DND35E } from '@effects/effectTypes.mjs';
 import { secretEffectType } from '@effects/secret/secretEffectType.mjs';
+import type { FormulaDataSource } from '@helpers/formulae/FormulaData.mjs';
 import { FormulaData } from '@helpers/formulae/FormulaData.mjs';
 import { LogHelper } from '@helpers/LogHelper.mjs';
 import type { Override } from '@helpers/stacking.mjs';
@@ -119,7 +121,7 @@ class ItemDnd35e<TItemType extends ItemType = ItemType, TParent extends ActorDnd
   /** Runtime masks dictionary built from active Secret AE MASK changes. Keyed by field path. */
   _masks: Record<string, unknown> = {};
 
-  private get _maskedNameFormula (): { formula: string; resolvedValue: string | number | null; expectedType: 'string' | 'number' } | null {
+  private get _maskedNameFormula (): FormulaDataSource | null {
     const directMask = this._masks['system.nameFormula'] as FormulaLikeSource | undefined;
     if (directMask && typeof directMask === 'object') {
       const formula = typeof directMask.formula === 'string' ? directMask.formula : null;
@@ -307,21 +309,11 @@ class ItemDnd35e<TItemType extends ItemType = ItemType, TParent extends ActorDnd
           )
           // MASK changes are not applied via stacking — they define masked values read at prep time
           || (change.type === SYSTEM_CHANGE_TYPE.MASK)
-          || (
-            change.condition
-            && (
-              (
-                typeof change.condition === 'function'
-                && !change.condition(this)
-              )
-              //TODO implement after the fomrula deep dive
-              // || (
-              //   typeof change.condition === 'string'
-              //   && !FormulaData.evaluateFormula(change.condition, this.getRollData())
-              // )
-            )
-          )
         ) continue;
+        if ( change.condition ) {
+          const { contextMap } = getEffectContexts(effect, change);
+          if ( !evaluateChangeCondition(change, contextMap) ) continue;
+        }
         const copy = foundry.utils.deepClone(resolveActiveEffectChange(effect, change)) as unknown as AppliedItemEffectChange;
         copy.effect = effect;
         copy.type ??= EFFECT_CHANGE_TYPE.ADD;

--- a/src/documents/items/physical/container/data/ContainerSystemModel.mts
+++ b/src/documents/items/physical/container/data/ContainerSystemModel.mts
@@ -4,6 +4,7 @@ import {
   requiredBooleanField,
   useDnd35eField,
 } from '@fields/fieldBuilders.mjs';
+import type { FormulaField } from '@helpers/formulae/FormulaField.mjs';
 import { PhysicalItemSystemModel } from '@items/physical/physicalItem/data/PhysicalItemSystemModel.mjs';
 
 import type { ContainerSystemData } from './ContainerSystemData.mjs';
@@ -25,6 +26,11 @@ class ContainerSystemModel extends PhysicalItemSystemModel {
 
   static override defineSchema (): Record<string, any> {
     const schema = super.defineSchema();
+
+    // Declare Owner context on inherited nameFormula (matches Weapon's pattern)
+    (schema.nameFormula as FormulaField).formulaContexts = [
+      { contextName: 'Owner', resolvePath: 'parent', documentType: 'Actor', fallbackSubtypes: ['character'], aliases: ['Parent'] },
+    ];
 
     schema.maxContentWeight = useDnd35eField(new NumberField({ required: true, nullable: true, initial: null, min: 0 }));
     schema.contentsAreWeightless = useDnd35eField(requiredBooleanField(false));

--- a/src/global.mts
+++ b/src/global.mts
@@ -104,7 +104,6 @@ declare global {
 /** Augment Foundry's change type registry with system-registered change types. */
 declare module '@common/constants.mjs' {
   interface SystemActiveEffectChangeTypes {
-    FAMILIAR: 'familiar';
     MASK: 'mask';
   }
 }

--- a/src/helpers/formulae/FormulaData.mts
+++ b/src/helpers/formulae/FormulaData.mts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import { evaluateBooleanExpression } from './evaluateBooleanExpression.mjs';
 import type { DocumentContext } from './registry.mjs';
 import { buildDocumentFamiliar } from './registry.mjs';
 import type { FamiliarSchema } from './types.mjs';
@@ -23,20 +24,20 @@ const {
 interface FormulaDataSource {
   formula: string;
   resolvedValue: string | number | null;
-  expectedType: 'string' | 'number';
+  expectedType: 'string' | 'number' | 'boolean';
 }
 
 class FormulaData extends foundry.abstract.DataModel {
   // Declare model properties for TypeScript
   declare formula: string;
   declare resolvedValue: string | null;
-  declare expectedType: 'string' | 'number';
+  declare expectedType: 'string' | 'number' | 'boolean';
 
   static override defineSchema() {
     return {
       formula: new StringField({ blank: true, initial: '' }),
       resolvedValue: new StringField({ nullable: true, initial: null }),
-      expectedType: new StringField({ choices: ['string', 'number'], initial: 'string' }),
+      expectedType: new StringField({ choices: ['string', 'number', 'boolean'], initial: 'string' }),
     };
   }
 
@@ -155,7 +156,16 @@ class FormulaData extends foundry.abstract.DataModel {
     return schema;
   }
 
-  private static _finalizeResolvedValue(resolved: string, expectedType: 'string' | 'number'): string {
+  private static _finalizeResolvedValue(resolved: string, expectedType: 'string' | 'number' | 'boolean'): string {
+    if (expectedType === 'boolean') {
+      if (extractVariables(resolved).length > 0) return resolved;
+      try {
+        return evaluateBooleanExpression(resolved) ? 'true' : 'false';
+      } catch {
+        return resolved;
+      }
+    }
+
     if (expectedType !== 'number') return resolved;
     if (extractVariables(resolved).length > 0) return resolved;
 
@@ -166,9 +176,7 @@ class FormulaData extends foundry.abstract.DataModel {
     if (!Number.isNaN(numericValue)) return String(numericValue);
 
     try {
-      const safeEval = (Roll as unknown as { safeEval?: (formula: string) => number }).safeEval;
-      if (!safeEval) return resolved;
-      const evaluated = safeEval(trimmed);
+      const evaluated = Roll.safeEval(trimmed);
       return Number.isNaN(evaluated) ? resolved : String(evaluated);
     } catch {
       return resolved;

--- a/src/helpers/formulae/FormulaData.mts
+++ b/src/helpers/formulae/FormulaData.mts
@@ -8,11 +8,10 @@
  * @module
  */
 
-import { evaluateBooleanExpression } from './evaluateBooleanExpression.mjs';
+import { FormulaResolver } from './FormulaResolver.mjs';
 import type { DocumentContext } from './registry.mjs';
 import { buildDocumentFamiliar } from './registry.mjs';
 import type { FamiliarSchema } from './types.mjs';
-import { extractVariables, resolveFormula } from './utils.mjs';
 
 const {
   StringField,
@@ -57,7 +56,7 @@ class FormulaData extends foundry.abstract.DataModel {
   resolve(documentDataMap: Record<string, DocumentContext>, fallback: string = '', excludedFields: string[] = []): string {
     if (!this.formula) return fallback;
     const familiarSchema = FormulaData._buildFamiliarFromDocumentMap(documentDataMap, excludedFields);
-    const partiallyResolved = resolveFormula(this.formula, familiarSchema, documentDataMap);
+    const partiallyResolved = FormulaResolver.resolveFormula(this.formula, familiarSchema, documentDataMap);
     return FormulaData._finalizeResolvedValue(partiallyResolved, this.expectedType);
   }
 
@@ -77,7 +76,7 @@ class FormulaData extends foundry.abstract.DataModel {
   ): string {
     if (!source.formula) return fallback;
     const familiarSchema = FormulaData._buildFamiliarFromDocumentMap(documentDataMap as Record<string, DocumentContext>, excludedFields);
-    const partiallyResolved = resolveFormula(source.formula, familiarSchema, documentDataMap as Record<string, DocumentContext>);
+    const partiallyResolved = FormulaResolver.resolveFormula(source.formula, familiarSchema, documentDataMap as Record<string, DocumentContext>);
     return FormulaData._finalizeResolvedValue(partiallyResolved, source.expectedType);
   }
 
@@ -89,7 +88,7 @@ class FormulaData extends foundry.abstract.DataModel {
   ): string {
     if (!source.formula) return fallback;
     const familiarSchema = FormulaData._buildFamiliarFromDocumentMap(documentDataMap as Record<string, DocumentContext>, excludedFields);
-    return resolveFormula(source.formula, familiarSchema, documentDataMap as Record<string, DocumentContext>);
+    return FormulaResolver.resolveFormula(source.formula, familiarSchema, documentDataMap as Record<string, DocumentContext>);
   }
 
   // ---------------------------------------------------------------------------
@@ -158,16 +157,16 @@ class FormulaData extends foundry.abstract.DataModel {
 
   private static _finalizeResolvedValue(resolved: string, expectedType: 'string' | 'number' | 'boolean'): string {
     if (expectedType === 'boolean') {
-      if (extractVariables(resolved).length > 0) return resolved;
+      if (FormulaResolver.extractVariables(resolved).length > 0) return resolved;
       try {
-        return evaluateBooleanExpression(resolved) ? 'true' : 'false';
+        return FormulaResolver.evaluateBooleanExpression(resolved) ? 'true' : 'false';
       } catch {
         return resolved;
       }
     }
 
     if (expectedType !== 'number') return resolved;
-    if (extractVariables(resolved).length > 0) return resolved;
+    if (FormulaResolver.extractVariables(resolved).length > 0) return resolved;
 
     const trimmed = resolved.trim();
     if (!trimmed) return resolved;

--- a/src/helpers/formulae/FormulaField.mts
+++ b/src/helpers/formulae/FormulaField.mts
@@ -23,7 +23,7 @@ const { EmbeddedDataField } = foundry.data.fields;
 
 type BaseFormulaFieldOptions = {
   /** Expected result type when resolving the formula. Default: 'string'. */
-  expectedType?: 'string' | 'number';
+  expectedType?: 'string' | 'number' | 'boolean';
   /** Default visibility when no GM override is saved. Default: 'everyone'. */
   defaultVisibility?: FieldVisibility;
   /** Default editability when no GM override is saved. Default: 'normal'. */
@@ -140,6 +140,15 @@ class FormulaField extends EmbeddedDataField<FormulaData, false, true, true> {
 
   set excludedFields (value: string[]) {
     (this.options as Record<string, unknown>).excludedFields = value;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Expected type
+  // ---------------------------------------------------------------------------
+
+  /** Expected result type when resolving the formula (used for type-mismatch validation). */
+  get expectedType (): 'string' | 'number' | 'boolean' {
+    return (this.options as Record<string, unknown>).expectedType as 'string' | 'number' | 'boolean' ?? 'string';
   }
 
   // ---------------------------------------------------------------------------

--- a/src/helpers/formulae/FormulaFormGroup.vue
+++ b/src/helpers/formulae/FormulaFormGroup.vue
@@ -50,7 +50,7 @@
   import FamiliarOverlayInput from '@vc/fields/formGroups/FamiliarOverlayInput.vue';
   import FormGroup from '@vc/fields/formGroups/FormGroup.vue';
   import type { PropType } from 'vue';
-  import { computed, inject, ref, useSlots } from 'vue';
+  import { computed, inject, ref, useSlots, watch } from 'vue';
 
   import type { FormulaData } from './FormulaData.mjs';
   import { FormulaField } from './FormulaField.mjs';
@@ -83,7 +83,26 @@
     formulaData: { type: Object as PropType<FormulaData | null>, default: undefined },
     /** Whether to focus the input on mount. Used by the name field to focus on edit. */
     focusOnMount: { type: Boolean, default: false },
+    /**
+     * Explicit expectedType override. Takes priority over formulaData/schema inference —
+     * needed for fields whose schema type isn't a FormulaField (e.g. a plain StringField
+     * that is always semantically boolean, such as an AE change's `condition`).
+     */
+    expectedType: { type: String as PropType<'string' | 'number' | 'boolean'>, default: undefined },
+    /**
+     * Suppress the auto-generated "Available Contexts: [...]" hint text.
+     * Used when a consumer renders that hint itself once, shared across
+     * several sibling fields (e.g. the AE Changes table's row-context line).
+     * Validation errors still surface via `update:error` regardless.
+     */
+    hideContextHint: { type: Boolean, default: false },
   });
+
+  const emit = defineEmits<{
+    /** Current validation/type-mismatch error message for this field, or null when valid. */
+    'update:error': [error: string | null];
+  }>();
+
   const { isEditMode } = inject(RenderModeStoreSymbol) as RenderModeStore;
 
   // Effective formula — from FormulaData, or legacy value prop
@@ -97,6 +116,12 @@
   // Resolve the FormulaField schema entry for this field path to read excludedFields
   const formulaField = computed((): FormulaField | undefined => {
     return sheetStore?._storeUtils?.getSchemaField?.(props.fieldPath) as FormulaField | undefined;
+  });
+
+  // Expected type — explicit prop override > FormulaData > the schema's FormulaField,
+  // used for type-mismatch validation
+  const resolvedExpectedType = computed((): 'string' | 'number' | 'boolean' | undefined => {
+    return props.expectedType ?? props.formulaData?.expectedType ?? formulaField.value?.expectedType;
   });
 
   // If no explicit updater is provided, infer write path from fieldPath:
@@ -154,14 +179,13 @@
   /** Auto-generate hint from context keys, e.g. "Available Contexts: [Self, Owner]" */
   const dynamicHint = computed(() => {
     if (props.hint) return props.hint;
+    if (props.hideContextHint) return '';
     const keys = Object.keys(contexts.value);
     if (keys.length === 0) return '';
     const names = Object.entries(contexts.value).map(([k, ctx]) => ctx.display ?? (k.charAt(0).toUpperCase() + k.slice(1)));
     const localizedPrefix = game.i18n.localize('dnd35e.Formula.availableContexts');
     return `${localizedPrefix}: [${names.join(', ')}]`;
   });
-
-  const displayHint = computed(() => isEditMode.value ? dynamicHint.value : (props.hint ?? ''));
 
   const readonlyDisplayHtml = computed(() => {
     if (!effectiveFormula.value) {
@@ -204,9 +228,29 @@
       console.warn(`[FormulaFormGroup] No updater available for ${props.fieldPath}. Provide onUpdate or ensure DocumentSheetStore is injected.`);
     },
     focusOnMount: () => isEditable.value && props.focusOnMount,
+    expectedType: resolvedExpectedType,
   });
-</script>
 
+  // Type-mismatch errors carry an empty context (they aren't tied to a specific variable) —
+  // exposed separately so consumers can surface it (e.g. combined into a shared row-context
+  // error line) even when the dynamic context hint itself is suppressed via `hideContextHint`.
+  const currentError = computed((): string | null => {
+    const typeError = formulaErrors.value.find(e => e.context === '' && e.severity === 'error');
+    return typeError?.error ?? null;
+  });
+
+  const displayHint = computed(() => {
+    if (!isEditMode.value) return props.hint ?? '';
+    // Type-mismatch errors take priority over the dynamic context hint — surface
+    // them to the user instead of silently falling back. Suppressed when the
+    // context hint is hidden — the consumer (e.g. the AE Changes table row) is
+    // already showing this error via the `update:error` emit in a shared line.
+    if (currentError.value && !props.hideContextHint) return currentError.value;
+    return dynamicHint.value;
+  });
+
+  watch(currentError, (error) => emit('update:error', error), { immediate: true });
+</script>
 <style scoped lang="scss">
 // Readonly slot content (sibling of .formula-form-group)
 .formula-display {

--- a/src/helpers/formulae/FormulaFormGroup.vue
+++ b/src/helpers/formulae/FormulaFormGroup.vue
@@ -54,12 +54,10 @@
 
   import type { FormulaData } from './FormulaData.mjs';
   import { FormulaField } from './FormulaField.mjs';
+  import { FormulaResolver } from './FormulaResolver.mjs';
   import type { FamiliarSchema } from './types.mts';
   import { useFormulaEditor } from './useFormulaEditor.mjs';
-  import {
-    filterExcludedFields,
-    renderFormulaDisplayHTML,
-  } from './utils.mjs';
+  import { renderFormulaDisplayHTML } from './utils.mjs';
 
   const slots = useSlots();
 
@@ -159,7 +157,7 @@
     }
 
     const excluded = formulaField.value?.excludedFields ?? [];
-    return filterExcludedFields(schema, excluded);
+    return FormulaResolver.filterExcludedFields(schema, excluded);
   });
 
   // Refs

--- a/src/helpers/formulae/FormulaResolver.aspectResolution.mts
+++ b/src/helpers/formulae/FormulaResolver.aspectResolution.mts
@@ -1,0 +1,456 @@
+/**
+ * FormulaResolver — core parsing, variable substitution, and aspect lookup.
+ *
+ * Tokenizes `#context.property` formulas, extracts/resolves variables against
+ * a FamiliarSchema + live document data, and provides aspect-tree lookup
+ * helpers (`getFieldAspect`, `findAspectByAccessPath`, `mergeAspectGroups`).
+ *
+ * Split out from FormulaResolver.mts to keep this file focused. Consumed by
+ * FormulaResolver.mts as static methods.
+ *
+ * @module
+ */
+import { evaluateBooleanExpression } from './FormulaResolver.booleanGrammar.mjs';
+import { resolveConditionalFormula } from './FormulaResolver.conditionalGrammar.mjs';
+import type { AspectLookupResult } from './FormulaResolver.types.mjs';
+import type { DocumentContext } from './registry.mjs';
+import { normalizeLabel } from './schemaWalker.mjs';
+import type {
+  AspectGroup,
+  FamiliarSchema,
+  FieldAspect,
+  FormulaToken,
+  FormulaVariable,
+} from './types.mjs';
+import { isFieldAspect } from './types.mjs';
+
+/**
+ * Regex matching formula variables:
+ *   #context.property.nested       — standard familiar path
+ *   #context.'raw.dotted.path'     — custom / arbitrary document path (closed quote)
+ *   #context.'partial.text         — unclosed quote, no spaces (still typing)
+ *
+ * The optional quoted segment (single-quotes) lets users reference any
+ * document path that isn't exposed through the familiar shortcuts.
+ *
+ * Uses a negative lookbehind so `\#` is treated as a literal `#`, not a variable.
+ *
+ * A `#token` immediately followed by more identifier characters with no
+ * separator (e.g. `#self.sneakAttackDiced6`) greedily matches as a single
+ * (invalid) path segment rather than `#self.sneakAttackDice` + literal `d6` —
+ * wrap the token in parens to disambiguate: `(#self.sneakAttackDice)d6`.
+ *
+ * `\#`, `\(`, `\)`, and `\,` all escape to their literal character (see the
+ * final unescape step in `resolveFormula()`) — the comma escape matters for
+ * `$conditional(...)` so a literal comma inside a quoted string value (e.g.
+ * `when(#self.name == "\,", 500)`) isn't mistaken for the top-level comma
+ * separating a clause's own arguments.
+ */
+// Unicode-aware: \p{L} = any letter, \p{N} = any digit — allows Polish/Czech/etc variable names
+const VARIABLE_REGEX = /(?<!\\)#[\p{L}\p{N}_]+(?:\.(?:'[^']*'|'[^ ']*|[\p{L}\p{N}_]+))*/gu;
+
+/**
+ * Return a copy of `schema` with the given top-level aspect keys removed from
+ * every context's properties.  Used to prevent circular references (e.g.
+ * nameFormula must not reference `name`).
+ *
+ * Only strips keys at the root of each context's `properties` — nested paths
+ * are not affected.
+ */
+export function filterExcludedFields(schema: FamiliarSchema, excludedFields: string[]): FamiliarSchema {
+  if (!excludedFields.length) return schema;
+
+  const filtered: FamiliarSchema = {};
+  for (const [ctxName, ctx] of Object.entries(schema)) {
+    const props = { ...ctx.properties };
+    for (const key of excludedFields) {
+      delete props[key];
+      // Also delete the PascalCase-normalized form in case keys have been localized
+      const normalized = normalizeLabel(key);
+      if (normalized && normalized !== key) delete props[normalized];
+    }
+    filtered[ctxName] = { ...ctx, properties: props };
+  }
+  return filtered;
+}
+
+/**
+ * Parse a formula into tokens (text and variables)
+ * Handles #contextName.property.nested.path, #context.'raw.path' and partial syntax
+ */
+export function parseFormula(formula: string): FormulaToken[] {
+  const tokens: FormulaToken[] = [];
+  const regex = new RegExp(VARIABLE_REGEX.source, 'gu');
+  let lastIndex = 0;
+  let match;
+
+  while ((match = regex.exec(formula)) !== null) {
+    // Add text token before the variable
+    if (match.index > lastIndex) {
+      tokens.push({
+        type: 'text',
+        value: formula.substring(lastIndex, match.index),
+        startIndex: lastIndex,
+        endIndex: match.index,
+      });
+    }
+
+    const raw = match[0];
+    // Detect unclosed quote — the match grabbed to EOL without a closing '
+    const quoteCount = (raw.match(/'/g) || []).length;
+    const isPartial = quoteCount % 2 !== 0;
+
+    tokens.push({
+      type: 'variable',
+      value: raw,
+      startIndex: match.index,
+      endIndex: match.index + raw.length,
+      ...(isPartial && { partial: true }),
+    });
+
+    lastIndex = match.index + raw.length;
+  }
+
+  // Add remaining text
+  if (lastIndex < formula.length) {
+    tokens.push({
+      type: 'text',
+      value: formula.substring(lastIndex),
+      startIndex: lastIndex,
+      endIndex: formula.length,
+    });
+  }
+
+  return tokens.length > 0 ? tokens : [{ type: 'text', value: formula, startIndex: 0, endIndex: formula.length }];
+}
+
+/**
+ * Split a variable body (after the leading #) into segments,
+ * respecting single-quoted segments which represent raw paths.
+ * Returns { context, path, customAccessPath? }.
+ *
+ *   "self.hardness"               → { context: "self", path: ["hardness"] }
+ *   "self.'system.isIdentified'"  → { context: "self", path: [], customAccessPath: "system.isIdentified" }
+ */
+export function parseVariableSegments(body: string): { context: string; path: string[]; customAccessPath?: string } {
+  const segments: string[] = [];
+  let current = '';
+  let inQuote = false;
+  let customAccessPath: string | undefined;
+
+  for (const ch of body) {
+    if (ch === '\'' && !inQuote) {
+      inQuote = true;
+    } else if (ch === '\'' && inQuote) {
+      // The content inside quotes is the raw access path
+      customAccessPath = current;
+      current = '';
+      inQuote = false;
+    } else if (ch === '.' && !inQuote) {
+      if (current) segments.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  if (current) {
+    if (inQuote) {
+      // Unclosed quote — treat accumulated text as a partial custom path
+      customAccessPath = current;
+    } else {
+      segments.push(current);
+    }
+  }
+
+  const context = segments[0] ?? '';
+  const path = customAccessPath !== undefined ? [] : segments.slice(1);
+  return { context, path, customAccessPath };
+}
+
+/**
+ * Extract all variables from a formula
+ * @param formula The formula string
+ * @returns Array of found variables
+ */
+export function extractVariables(formula: string): FormulaVariable[] {
+  const regex = new RegExp(VARIABLE_REGEX.source, 'gu');
+  const variables: FormulaVariable[] = [];
+  let match;
+
+  while ((match = regex.exec(formula)) !== null) {
+    const variable = match[0];
+    const body = variable.substring(1); // Remove leading #
+    const { context, path, customAccessPath } = parseVariableSegments(body);
+
+    variables.push({
+      variable,
+      context,
+      path,
+      startIndex: match.index,
+      endIndex: match.index + variable.length,
+      isValid: true,
+      ...(customAccessPath !== undefined && { customAccessPath }),
+    });
+  }
+
+  return variables;
+}
+
+/**
+ * Resolve all variables in a formula against document data using familiar accessPaths.
+ *
+ * For each #context.path variable, looks up the FieldAspect in the schema
+ * to find its accessPath, then reads that path from the document data.
+ *
+ * @param formula The formula string with #context.path variables
+ * @param familiarSchema The familiar schema (defines accessPaths)
+ * @param documentDataMap Maps context names to their document data objects
+ * @returns Formula with variables replaced by their resolved values
+ */
+export function resolveFormula(
+  formula: string,
+  familiarSchema: FamiliarSchema,
+  documentDataMap: Record<string, DocumentContext>
+): string {
+  // Pre-resolve $conditional(when(...) ... else(...)) blocks into their winning
+  // branch's (still-unresolved) text before the generic token substitution below
+  // runs — $conditional/when/else are not #context.property tokens themselves.
+  const withConditionalsResolved = resolveConditionalFormula(
+    formula,
+    sub => resolveFormula(sub, familiarSchema, documentDataMap),
+    resolvedCondition => evaluateBooleanExpression(resolvedCondition)
+  );
+
+  let result = withConditionalsResolved;
+  const variables = extractVariables(withConditionalsResolved);
+
+  // Process in reverse order to maintain string indices
+  for (let i = variables.length - 1; i >= 0; i--) {
+    const variable = variables[i];
+
+    // Resolve context data: direct lookup first, then via familiarSchema alias
+    let docData = documentDataMap[variable.context];
+    if (!docData) {
+      // variable.context may be a localized alias (e.g. 'Self') while documentDataMap
+      // uses the internal key ('self'). Use the familiarSchema to bridge them.
+      const ctxEntry = familiarSchema[variable.context]
+        ? { key: variable.context, ctx: familiarSchema[variable.context] }
+        : (() => {
+          const found = Object.entries(familiarSchema).find(([, ctx]) =>
+            ctx.aliases?.includes(variable.context)
+          );
+          return found ? { key: found[0], ctx: found[1] } : null;
+        })();
+      if (ctxEntry) {
+        // Try the primary FamiliarSchema key in documentDataMap
+        docData = documentDataMap[ctxEntry.key];
+        if (!docData) {
+          // Try each alias of that context in documentDataMap
+          for (const alias of (ctxEntry.ctx.aliases ?? [])) {
+            if (documentDataMap[alias]) { docData = documentDataMap[alias]; break; }
+          }
+        }
+      }
+    }
+    if (!docData) continue;
+
+    // Custom quoted path — use the raw path directly as the accessPath
+    if (variable.customAccessPath) {
+      const value = getNestedValue(docData, variable.customAccessPath);
+      if (value !== undefined && value !== null) {
+        result =
+          result.substring(0, variable.startIndex) +
+          String(value) +
+          result.substring(variable.endIndex);
+      }
+      continue;
+    }
+
+    // Find the FieldAspect to get the accessPath
+    const prop = getFieldAspect(familiarSchema, variable.context, variable.path);
+    if (!prop) continue;
+
+    const value = getNestedValue(docData, prop.accessPath);
+
+    if (value !== undefined && value !== null) {
+      result =
+        result.substring(0, variable.startIndex) +
+        String(value) +
+        result.substring(variable.endIndex);
+    }
+  }
+
+  // Unescape literal \# → #, \( → (, \) → ), \, → ,
+  result = result.replace(/\\([#(),])/g, '$1');
+
+  return result;
+}
+
+/**
+ * Walk a dotted path on any object to retrieve a nested value.
+ * Works with live Foundry documents (getter access) and plain objects alike.
+ */
+export function getNestedValue(obj: object, dottedPath: string): unknown {
+  let current: unknown = obj;
+  for (const key of dottedPath.split('.')) {
+    if (current === null || current === undefined || typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
+/**
+ * Factory for FieldAspect that optionally resolves the value
+ * from a context object (live document or plain object) using the accessPath.
+ *
+ * When `context` is provided, the value at `accessPath` is read (including
+ * any custom getters) and coerced to the property's type. Without context,
+ * only the schema shape is returned (value remains undefined).
+ */
+export function fieldAspect<TContext extends DocumentContext>(
+  display: string,
+  type: 'string' | 'number' | 'boolean',
+  accessPath: string,
+  context?: TContext
+): FieldAspect {
+  const prop: FieldAspect = { display, type, accessPath };
+  if (context) {
+    const raw = getNestedValue(context, accessPath);
+    if (raw !== undefined && raw !== null) {
+      prop.value = type === 'number'
+        ? Number(raw)
+        : type === 'boolean'
+          ? (raw ? 'true' : 'false')
+          : String(raw);
+    }
+  }
+  return prop;
+}
+
+/**
+ * Walk the familiar tree to find the FieldAspect at a given path.
+ */
+export function getFieldAspect(context: FamiliarSchema, contextName: string, path: string[]): FieldAspect | null {
+  let contextSchema = context[contextName];
+
+  if (!contextSchema) {
+    const foundKey = Object.keys(context).find(k => context[k].aliases?.includes(contextName));
+    if (foundKey) contextSchema = context[foundKey];
+  }
+
+  if (!contextSchema?.properties) return null;
+
+  let current: unknown = contextSchema.properties;
+  for (const key of path) {
+    if (typeof current !== 'object' || current === null) return null;
+    const obj = current as Record<string, unknown>;
+    if (key in obj) {
+      current = obj[key];
+    } else {
+      // Leaf alias fallback (FieldAspect.aliases)
+      const leafAlias = Object.entries(obj).find(([, v]) =>
+        isFieldAspect(v) && v.aliases?.includes(key)
+      );
+      if (leafAlias) {
+        current = leafAlias[1];
+        continue;
+      }
+      // Branch alias fallback (AspectGroup._aliases)
+      const branchAlias = Object.entries(obj).find(([, v]) =>
+        typeof v === 'object' && v !== null && !isFieldAspect(v)
+        && (v as { _aliases?: string[] })._aliases?.includes(key)
+      );
+      if (branchAlias) {
+        current = branchAlias[1];
+        continue;
+      }
+      // Localized display name fallback
+      const localDisplay = Object.entries(obj).find(([k, v]) => {
+        if (k.startsWith('_')) return false;
+        const localKey = isFieldAspect(v)
+          ? normalizeLabel((v as FieldAspect).display)
+          : normalizeLabel((v as AspectGroup)._display);
+        return localKey === key;
+      });
+      if (localDisplay) {
+        current = localDisplay[1];
+      } else {
+        return null;
+      }
+    }
+  }
+
+  return isFieldAspect(current) ? current : null;
+}
+
+/**
+ * Get the value of a property from the familiar context.
+ * Uses accessPath to read the value from the document data if available.
+ * Falls back to the static value on the FieldAspect.
+ */
+export function getPropertyValue(context: FamiliarSchema, contextName: string, path: string[]): string | number | null {
+  const prop = getFieldAspect(context, contextName, path);
+  if (!prop) return null;
+  return prop.value ?? null;
+}
+
+/**
+ * Reverse-lookup: given a raw document `accessPath` (e.g. `system.hardness.value`),
+ * find the FieldAspect and its familiar tree key path within an AspectGroup.
+ *
+ * Performs a depth-first search of the group tree, comparing each leaf's
+ * `accessPath` against the target.
+ */
+export function findAspectByAccessPath(group: AspectGroup, accessPath: string): AspectLookupResult | null {
+  for (const [key, value] of Object.entries(group)) {
+    if (isFieldAspect(value)) {
+      if (value.accessPath === accessPath) {
+        return { aspect: value, treePath: [key] };
+      }
+    } else if (typeof value === 'object' && value !== null) {
+      const nested = findAspectByAccessPath(value as AspectGroup, accessPath);
+      if (nested) {
+        return { aspect: nested.aspect, treePath: [key, ...nested.treePath] };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Deep-merge multiple AspectGroups into one.
+ *
+ * - Nested groups merge recursively.
+ * - Leaf conflicts (same key in multiple groups): first group wins.
+ * - A leaf in one group and a branch in another: first group wins (no mixing).
+ * - Branch metadata (`_display`/`_aliases`, set by the schema walker) is copied
+ *   as-is from the first group that declares it — never recursed into. These are
+ *   plain strings/string-arrays, not FieldAspect/AspectGroup nodes, so treating
+ *   them as branches (as a naive `!isFieldAspect` check would) sends
+ *   `Object.entries()` down a string's character indices, which — when two
+ *   groups both declare the same metadata on the same branch (e.g. every
+ *   ACTOR_TYPES subtype sharing one builder) — degenerates into merging
+ *   single-character strings with themselves forever (infinite recursion).
+ */
+export function mergeAspectGroups(...groups: AspectGroup[]): AspectGroup {
+  const result: AspectGroup = {};
+  for (const group of groups) {
+    for (const [key, value] of Object.entries(group)) {
+      if (key.startsWith('_')) {
+        // Branch metadata — first group wins, never merged/recursed into.
+        if (result[key] === undefined) result[key] = value;
+        continue;
+      }
+      const existing = result[key];
+      if (existing === undefined) {
+        // New key — take it
+        result[key] = value;
+      } else if (!isFieldAspect(existing) && !isFieldAspect(value)) {
+        // Both are branches — recurse
+        result[key] = mergeAspectGroups(existing as AspectGroup, value as AspectGroup);
+      }
+      // else: conflict (leaf vs leaf, or leaf vs branch) — first wins, skip
+    }
+  }
+  return result;
+}

--- a/src/helpers/formulae/FormulaResolver.booleanGrammar.mts
+++ b/src/helpers/formulae/FormulaResolver.booleanGrammar.mts
@@ -1,60 +1,21 @@
 /**
- * evaluateBooleanExpression — small, purpose-built comparison/logical expression
- * evaluator for boolean-typed formulas (§7.2a of Phase 7).
+ * FormulaResolver — boolean comparison/logical expression grammar.
  *
- * Operates on an already-substituted formula string (all `#context.property`
- * tokens have been replaced with their literal values by `resolveFormula()`).
- * This is NOT a general JS `eval` and is distinct from `Roll.safeEval` (which
- * only handles dice-formula arithmetic, no comparison/logical operators).
+ * Small, purpose-built evaluator for boolean-typed formulas. Operates on an
+ * already-substituted formula string (all `#context.property` tokens have
+ * been replaced with their literal values by `resolveFormula()`). This is NOT
+ * a general JS `eval` and is distinct from `Roll.safeEval` (which only
+ * handles dice-formula arithmetic, no comparison/logical operators).
  *
- * Supported grammar (standard precedence, lowest to highest):
- *   orExpr         := andExpr ( '||' andExpr )*
- *   andExpr        := notExpr ( '&&' notExpr )*
- *   notExpr        := '!' notExpr | comparison
- *   comparison     := additive ( ('>' | '<' | '>=' | '<=' | '==' | '!=') additive )?
- *   additive       := multiplicative ( ('+' | '-') multiplicative )*
- *   multiplicative := unary ( ('*' | '/') unary )*
- *   unary          := ('-' | '+') unary | primary
- *   primary        := '(' orExpr ')' | NUMBER | STRING | 'true' | 'false' | IDENT
- *
- * `IDENT` covers bareword literals — after substitution, a resolved string
- * value (e.g. a weapon name) appears unquoted in the formula text, so any
- * token that isn't a recognized literal/operator is treated as a string literal.
- *
- * Comparison operands may be arithmetic sub-expressions (e.g.
- * `#actor.hp.max / 2`) — `+`/`-`/`*`/`/` are evaluated with standard
- * precedence before the surrounding comparison is applied.
+ * Split out from FormulaResolver.mts to keep each grammar's tokenizer/parser
+ * self-contained. Consumed by FormulaResolver.mts as a static method.
  *
  * @module
  */
+import type { LiteralValue, Token, TokenType } from './FormulaResolver.types.mjs';
 
-type TokenType =
-  | 'number'
-  | 'string'
-  | 'boolean'
-  | 'ident'
-  | '('
-  | ')'
-  | '&&'
-  | '||'
-  | '!'
-  | '>'
-  | '<'
-  | '>='
-  | '<='
-  | '=='
-  | '!='
-  | '+'
-  | '-'
-  | '*'
-  | '/';
-
-interface Token {
-  type: TokenType;
-  value: string;
-}
-
-const TOKEN_REGEX = /\s*(?:(>=|<=|==|!=|&&|\|\||[()!<>+*/-])|('[^']*'|"[^"]*")|(\d+(?:\.\d+)?)|([^\s()!<>=&|]+))/g;
+const TOKEN_REGEX =
+  /\s*(?:(>=|<=|==|!=|&&|\|\||[()!<>+*/-])|(\$and\b|\$or\b)|('[^']*'|"[^"]*")|(\d+(?:\.\d+)?)|([^\s()!<>=&|]+))/gi;
 
 function tokenize(expression: string): Token[] {
   const tokens: Token[] = [];
@@ -62,9 +23,14 @@ function tokenize(expression: string): Token[] {
   TOKEN_REGEX.lastIndex = 0;
 
   while ((match = TOKEN_REGEX.exec(expression)) !== null) {
-    const [, operator, quoted, number, word] = match;
+    const [, operator, andOr, quoted, number, word] = match;
     if (operator) {
       tokens.push({ type: operator as TokenType, value: operator });
+    } else if (andOr) {
+      // `$and`/`$or` are keyword aliases for `&&`/`||` — same token type, so
+      // the parser below needs no separate handling for them.
+      const mapped: TokenType = andOr.toLowerCase() === '$and' ? '&&' : '||';
+      tokens.push({ type: mapped, value: mapped });
     } else if (quoted) {
       tokens.push({ type: 'string', value: quoted.slice(1, -1) });
     } else if (number) {
@@ -83,8 +49,6 @@ function tokenize(expression: string): Token[] {
 
   return tokens;
 }
-
-type LiteralValue = number | string | boolean;
 
 class ExpressionParser {
   private readonly tokens: Token[];
@@ -127,21 +91,13 @@ class ExpressionParser {
   }
 
   private parseAnd(): LiteralValue {
-    let left = this.parseNot();
+    let left = this.parseComparison();
     while (this.peek()?.type === '&&') {
       this.consume('&&');
-      const right = this.parseNot();
+      const right = this.parseComparison();
       left = this.toBoolean(left) && this.toBoolean(right);
     }
     return left;
-  }
-
-  private parseNot(): LiteralValue {
-    if (this.peek()?.type === '!') {
-      this.consume('!');
-      return !this.toBoolean(this.parseNot());
-    }
-    return this.parseComparison();
   }
 
   private parseComparison(): LiteralValue {
@@ -176,6 +132,10 @@ class ExpressionParser {
   }
 
   private parseUnary(): LiteralValue {
+    if (this.peek()?.type === '!') {
+      this.consume('!');
+      return !this.toBoolean(this.parseUnary());
+    }
     if (this.peek()?.type === '-') {
       this.consume('-');
       const value = this.parseUnary();
@@ -215,9 +175,6 @@ class ExpressionParser {
       const value = this.parseOr();
       this.consume(')');
       return value;
-    }
-    if (token.type === '!') {
-      return this.parseNot();
     }
     if (token.type === 'number') {
       this.consume();
@@ -265,6 +222,34 @@ class ExpressionParser {
 
 /**
  * Evaluate a boolean expression over already-substituted literals.
+ *
+ * Supported grammar (standard precedence, lowest to highest):
+ *   orExpr         := andExpr ( '||' andExpr )*
+ *   andExpr        := comparison ( '&&' comparison )*
+ *   comparison     := additive ( ('>' | '<' | '>=' | '<=' | '==' | '!=') additive )?
+ *   additive       := multiplicative ( ('+' | '-') multiplicative )*
+ *   multiplicative := unary ( ('*' | '/') unary )*
+ *   unary          := ('!' | '-' | '+') unary | primary
+ *   primary        := '(' orExpr ')' | NUMBER | STRING | 'true' | 'false' | IDENT
+ *
+ * `$and`/`$or` are case-insensitive keyword aliases for `&&`/`||` — useful
+ * inside a `$conditional(when(...))` condition where a bare `&&`/`||` can
+ * read awkwardly next to the surrounding keyword syntax. Both spellings
+ * tokenize to the exact same operator, so they're fully interchangeable.
+ *
+ * `!` binds like JS's unary `!` (tighter than comparison, not looser) — it
+ * negates only its immediate operand, so `!#self.broken > 0` reads as
+ * `(!#self.broken) > 0`, not `!(#self.broken > 0)`. Wrap the comparison in
+ * parens if you want to negate the whole thing: `!(#self.hp.value > 0)`.
+ *
+ * `IDENT` covers bareword literals — after substitution, a resolved string
+ * value (e.g. a weapon name) appears unquoted in the formula text, so any
+ * token that isn't a recognized literal/operator is treated as a string literal.
+ *
+ * Comparison operands may be arithmetic sub-expressions (e.g.
+ * `#actor.hp.max / 2`) — `+`/`-`/`*`/`/` are evaluated with standard
+ * precedence before the surrounding comparison is applied.
+ *
  * Throws a descriptive Error on invalid syntax — callers should catch and
  * fall back / surface a validation error rather than letting this throw
  * during derived-data preparation.

--- a/src/helpers/formulae/FormulaResolver.conditionalGrammar.mts
+++ b/src/helpers/formulae/FormulaResolver.conditionalGrammar.mts
@@ -1,63 +1,25 @@
 /**
- * Conditional Formula Syntax — `#conditional(when(cond, value) ... else(default))`
+ * FormulaResolver — `$conditional(when()else())` grammar.
  *
- * A flat rule-list conditional embedded directly in formula text, e.g.:
+ * Parses and resolves `$conditional(when(cond, value) ... else(default))`
+ * blocks: a flat rule-list conditional syntax layered on top of the plain
+ * `#context.property` substitution grammar. `$` is a distinct sigil from
+ * `#` on purpose — `#` always means "context/property data reference";
+ * `$` marks a control-flow/keyword construct, so `$conditional(...)` is
+ * never mistaken for (or extracted as) a `#`-style variable token in the
+ * first place. `resolveConditionalFormula` takes its sub-formula resolver
+ * and condition evaluator as parameters (rather than importing them) to
+ * keep this module fully decoupled from both the aspect-resolution and
+ * boolean-grammar modules.
  *
- *   #conditional(when(#self.hp.value <= 0, 0) when(#self.isFlanked, 1d6+#self.sneakAttackDice) else(2))d6
- *
- * - `when(condition, value)` — zero or more, evaluated in left-to-right source order;
- *   the first clause whose condition is true supplies the result.
- * - `else(value)` — required exactly once, may appear anywhere among the clauses;
- *   supplies the result when no `when()` matches.
- * - Clause separators are don't-care — `when(...)`/`else(...)` are self-delimiting via
- *   their own balanced parens, so commas, whitespace, or nothing between clauses are
- *   all equivalent.
- * - `#conditional(...)` behaves as a single inline token — surrounding literal text
- *   and other `#context.property` tokens are untouched.
- * - Matching is lenient: `#conditional`/`when`/`else` keywords are case-insensitive,
- *   with optional whitespace before `(`.
- * - `\(` and `\)` escape a literal parenthesis (same backslash convention as `\#`
- *   for a literal `#`) — an escaped paren doesn't count toward balanced-paren
- *   depth tracking, so a value can contain unbalanced literal parens, and
- *   `\#conditional(`/escaping the paren right after `when`/`else` prevents that
- *   occurrence from being parsed as the syntax construct at all.
- * - `\,` escapes a literal comma inside a `when(...)`/`else(...)` argument (e.g.
- *   a quoted string being compared against, `when(#self.name == "\,", 500)`) —
- *   without it, the comma would be mistaken for the top-level separator between
- *   that clause's own arguments (e.g. condition vs. value).
- *
- * See `docs/migration-plan/poc/phase-07-roll-formulas.md` §7.10 for the full design.
+ * Split out from FormulaResolver.mts to keep each grammar self-contained.
+ * Consumed by FormulaResolver.mts as static methods.
  *
  * @module
  */
+import type { ConditionalBlock, ConditionalBlockError, ConditionalWhenClause } from './FormulaResolver.types.mjs';
 
-/** A single `when(condition, value)` clause. */
-export interface ConditionalWhenClause {
-  condition: string;
-  value: string;
-}
-
-/** A reason a `#conditional(...)` block failed to parse cleanly. */
-export type ConditionalBlockError =
-  | 'unbalancedParens'
-  | 'missingElse'
-  | 'multipleElse'
-  | 'whenArgCount'
-  | 'elseArgCount';
-
-/** A single `#conditional(...)` block found within a formula string. */
-export interface ConditionalBlock {
-  /** Full "#conditional(...)" span exactly as it appeared in the source. */
-  raw: string;
-  startIndex: number;
-  endIndex: number;
-  whenClauses: ConditionalWhenClause[];
-  elseValue: string | null;
-  /** Present when the block is malformed — resolution leaves it raw/unresolved. */
-  error?: ConditionalBlockError;
-}
-
-const CONDITIONAL_OPEN_REGEX = /(?<!\\)#conditional\s*\(/gi;
+const CONDITIONAL_OPEN_REGEX = /(?<!\\)\$conditional\s*\(/gi;
 const CLAUSE_KEYWORD_REGEX = /(?<![\p{L}\p{N}_])(when|else)\s*\(/giu;
 
 /**
@@ -125,9 +87,9 @@ interface RawClause {
 }
 
 /**
- * Scan `innerText` (the content between `#conditional(`'s parens) for
+ * Scan `innerText` (the content between `$conditional(`'s parens) for
  * `when(...)`/`else(...)` clauses. Nested clauses (e.g. inside a value that
- * contains its own `#conditional(...)`) are skipped over automatically since
+ * contains its own `$conditional(...)`) are skipped over automatically since
  * each match consumes through its own balanced closing paren before resuming
  * the search.
  */
@@ -153,7 +115,7 @@ function findClauses(innerText: string): { clauses: RawClause[]; error?: Conditi
 }
 
 /**
- * Find all `#conditional(...)` blocks in a formula string, parsing each into
+ * Find all `$conditional(...)` blocks in a formula string, parsing each into
  * its `when`/`else` clauses. Malformed blocks are still returned (with
  * `.error` set) so validation and resolution can handle them explicitly
  * rather than throwing.
@@ -226,7 +188,7 @@ export function findConditionalBlocks(formula: string): ConditionalBlock[] {
 }
 
 /**
- * Resolve all `#conditional(...)` blocks in `formula`, replacing each with
+ * Resolve all `$conditional(...)` blocks in `formula`, replacing each with
  * its winning branch's (still-unresolved) text. Ordinary `#context.property`
  * tokens are left untouched — the caller is expected to run its own
  * substitution pass over the result afterward.
@@ -267,25 +229,16 @@ export function resolveConditionalFormula(
       }
     }
 
-    // Recursively resolve any nested #conditional(...) block within the winning
+    // Recursively resolve any nested $conditional(...) block within the winning
     // branch — ordinary tokens are left for the caller's own substitution pass.
-    const resolvedWinningValue = resolveConditionalFormula(winningValue, resolveSubFormula, evaluateCondition);
+    const resolvedWinningValue = resolveConditionalFormula(
+      winningValue,
+      resolveSubFormula,
+      evaluateCondition
+    );
 
     result = result.substring(0, block.startIndex) + resolvedWinningValue + result.substring(block.endIndex);
   }
 
   return result;
-}
-
-/**
- * True when `variable` (as produced by `extractVariables`) is the bare
- * `#conditional` keyword token immediately followed by `(` — i.e. it's being
- * used as this syntax construct, not as an actual (invalid) context reference.
- */
-export function isConditionalKeywordToken(
-  formula: string,
-  variable: { context: string; path: string[]; endIndex: number }
-): boolean {
-  if (variable.context.toLowerCase() !== 'conditional' || variable.path.length !== 0) return false;
-  return /^\s*\(/.test(formula.slice(variable.endIndex));
 }

--- a/src/helpers/formulae/FormulaResolver.mts
+++ b/src/helpers/formulae/FormulaResolver.mts
@@ -1,0 +1,73 @@
+/**
+ * FormulaResolver — consolidated FormulaFamiliar resolution engine.
+ *
+ * Public facade over the split grammar/resolution modules — each static
+ * method here is a direct reference to a plain function in one of:
+ * - `FormulaResolver.aspectResolution.mts` — parsing, variable substitution, aspect lookup
+ * - `FormulaResolver.validation.mts` — formula & type validation
+ * - `FormulaResolver.booleanGrammar.mts` — boolean comparison/logical grammar
+ * - `FormulaResolver.conditionalGrammar.mts` — `$conditional(when()else())` grammar
+ *
+ * None of the underlying functions use `this`, so every static method here
+ * remains safe to destructure and call standalone (e.g.
+ * `const { evaluateBooleanExpression } = FormulaResolver;`).
+ *
+ * Editor-only concerns (HTML highlighting, autocomplete, localized display,
+ * schema→AspectGroup derivation, context/document assembly) live elsewhere —
+ * see `utils.mts`, `schemaWalker.mts`, `registry.mts` — and consume this
+ * class's static methods rather than duplicating resolution logic.
+ *
+ * @module
+ */
+import {
+  extractVariables,
+  fieldAspect,
+  filterExcludedFields,
+  findAspectByAccessPath,
+  getFieldAspect,
+  getNestedValue,
+  getPropertyValue,
+  mergeAspectGroups,
+  parseFormula,
+  parseVariableSegments,
+  resolveFormula,
+} from './FormulaResolver.aspectResolution.mjs';
+import { evaluateBooleanExpression } from './FormulaResolver.booleanGrammar.mjs';
+import {
+  findConditionalBlocks,
+  resolveConditionalFormula,
+} from './FormulaResolver.conditionalGrammar.mjs';
+import { validateFormula, validateFormulaType } from './FormulaResolver.validation.mjs';
+
+export class FormulaResolver {
+  // Aspect resolution — parsing, variable substitution, aspect lookup
+  static filterExcludedFields = filterExcludedFields;
+  static parseFormula = parseFormula;
+  static parseVariableSegments = parseVariableSegments;
+  static extractVariables = extractVariables;
+  static resolveFormula = resolveFormula;
+  static getNestedValue = getNestedValue;
+  static fieldAspect = fieldAspect;
+  static getFieldAspect = getFieldAspect;
+  static getPropertyValue = getPropertyValue;
+  static findAspectByAccessPath = findAspectByAccessPath;
+  static mergeAspectGroups = mergeAspectGroups;
+
+  // Validation
+  static validateFormula = validateFormula;
+  static validateFormulaType = validateFormulaType;
+
+  // Boolean comparison/logical grammar
+  static evaluateBooleanExpression = evaluateBooleanExpression;
+
+  // $conditional(when()else()) grammar
+  static findConditionalBlocks = findConditionalBlocks;
+  static resolveConditionalFormula = resolveConditionalFormula;
+}
+
+export type {
+  AspectLookupResult,
+  ConditionalBlock,
+  ConditionalBlockError,
+  ConditionalWhenClause,
+} from './FormulaResolver.types.mjs';

--- a/src/helpers/formulae/FormulaResolver.types.mts
+++ b/src/helpers/formulae/FormulaResolver.types.mts
@@ -1,0 +1,81 @@
+/**
+ * FormulaResolver — shared type/interface declarations.
+ *
+ * Split out from FormulaResolver.mts to keep the resolver implementation file
+ * focused on logic. Pure type declarations only — no runtime code.
+ *
+ * @module
+ */
+import type { FieldAspect } from './types.mjs';
+
+/** Result of a reverse-lookup from a raw document path to the familiar tree. */
+export interface AspectLookupResult {
+  /** The FieldAspect that matched. */
+  aspect: FieldAspect;
+  /** The familiar tree path segments (e.g., ['hp', 'max']). */
+  treePath: string[];
+}
+
+// ============================================================================
+// Boolean grammar token types — used only by the private tokenizer/parser
+// backing `FormulaResolver.evaluateBooleanExpression`.
+// ============================================================================
+
+export type TokenType =
+  | 'number'
+  | 'string'
+  | 'boolean'
+  | 'ident'
+  | '('
+  | ')'
+  | '&&'
+  | '||'
+  | '!'
+  | '>'
+  | '<'
+  | '>='
+  | '<='
+  | '=='
+  | '!='
+  | '+'
+  | '-'
+  | '*'
+  | '/';
+
+export interface Token {
+  type: TokenType;
+  value: string;
+}
+
+/** A resolved literal value produced while evaluating a boolean expression. */
+export type LiteralValue = number | string | boolean;
+
+// ============================================================================
+// $conditional(when()else()) grammar types
+// ============================================================================
+
+/** A single `when(condition, value)` clause. */
+export interface ConditionalWhenClause {
+  condition: string;
+  value: string;
+}
+
+/** A reason a `$conditional(...)` block failed to parse cleanly. */
+export type ConditionalBlockError =
+  | 'unbalancedParens'
+  | 'missingElse'
+  | 'multipleElse'
+  | 'whenArgCount'
+  | 'elseArgCount';
+
+/** A single `$conditional(...)` block found within a formula string. */
+export interface ConditionalBlock {
+  /** Full "$conditional(...)" span exactly as it appeared in the source. */
+  raw: string;
+  startIndex: number;
+  endIndex: number;
+  whenClauses: ConditionalWhenClause[];
+  elseValue: string | null;
+  /** Present when the block is malformed — resolution leaves it raw/unresolved. */
+  error?: ConditionalBlockError;
+}

--- a/src/helpers/formulae/FormulaResolver.validation.mts
+++ b/src/helpers/formulae/FormulaResolver.validation.mts
@@ -1,0 +1,303 @@
+/**
+ * FormulaResolver — formula & type validation.
+ *
+ * Validates `#context.property` variables against a FamiliarSchema and checks
+ * whether a formula's resolved value matches its field's expected type.
+ *
+ * Split out from FormulaResolver.mts to keep this file focused. Consumed by
+ * FormulaResolver.mts as static methods.
+ *
+ * @module
+ */
+import { extractVariables, getFieldAspect } from './FormulaResolver.aspectResolution.mjs';
+import { evaluateBooleanExpression } from './FormulaResolver.booleanGrammar.mjs';
+import { findConditionalBlocks } from './FormulaResolver.conditionalGrammar.mjs';
+import { normalizeLabel } from './schemaWalker.mjs';
+import type {
+  AspectGroup,
+  FamiliarSchema,
+  FieldAspect,
+  FormulaVariable,
+  ValidationError,
+} from './types.mjs';
+import { isFieldAspect } from './types.mjs';
+
+/**
+ * Validate all variables in a formula
+ * @param formula The formula string
+ * @param context The familiar context
+ * @returns Array of validation errors (empty if valid)
+ */
+export function validateFormula(formula: string, context: FamiliarSchema): ValidationError[] {
+  if (!context) return [];
+  const errors: ValidationError[] = [];
+  const variables = extractVariables(formula);
+
+  for (const variable of variables) {
+    const error = validateVariable(variable, context);
+    if (error) {
+      errors.push(error);
+    }
+  }
+
+  for (const block of findConditionalBlocks(formula)) {
+    if (!block.error) continue;
+    errors.push({
+      variable: block.raw,
+      context: 'conditional',
+      path: [],
+      error: game.i18n.localize(`dnd35e.Formula.Errors.conditional.${block.error}`),
+      severity: 'error',
+      index: block.startIndex,
+    });
+  }
+
+  return errors;
+}
+
+/**
+ * Substitute #context.property variables using the *schema's cached values*
+ * (`FieldAspect.value`) rather than a live document data map. Used for
+ * lightweight type-mismatch checks in the editor, where only a FamiliarSchema
+ * (not a full documentDataMap) is available.
+ *
+ * When a variable resolves to a known FieldAspect but has no cached `.value`
+ * (e.g. no live parent document — a merged fallback schema built without
+ * context, as when editing an orphaned/standalone effect), a type-appropriate
+ * placeholder ('0' / 'false' / '""') is substituted instead of leaving the
+ * variable unresolved. This still lets grammar/type validation run — e.g.
+ * catching `!#item.broken 0` (two adjacent expressions, no operator) — without
+ * needing real live data, since the *shape* of a formula doesn't depend on the
+ * variable's actual runtime value. Variables with no matching aspect at all
+ * (invalid/unresolvable path — already flagged separately by `validateFormula`)
+ * or custom quoted paths are left as-is.
+ */
+function resolveFormulaFromSchemaValues(formula: string, schema: FamiliarSchema): string {
+  let result = formula;
+  const variables = extractVariables(formula);
+
+  for (let i = variables.length - 1; i >= 0; i--) {
+    const variable = variables[i];
+    if (variable.customAccessPath !== undefined) continue;
+
+    const aspect = getFieldAspect(schema, variable.context, variable.path);
+    if (!aspect) continue;
+
+    const placeholder = aspect.type === 'number'
+      ? '0'
+      : aspect.type === 'boolean'
+        ? 'false'
+        : '""';
+    const value = aspect.value ?? placeholder;
+
+    result =
+      result.substring(0, variable.startIndex) +
+      String(value) +
+      result.substring(variable.endIndex);
+  }
+
+  return result;
+}
+
+/**
+ * Check whether a formula's resolved value matches its field's `expectedType`.
+ * Surfaces a validation error instead of silently falling back — a `number`-typed
+ * field whose formula resolves to a boolean/non-numeric string, or a
+ * `boolean`-typed field whose formula isn't a valid comparison/logical
+ * expression, both produce an error here.
+ *
+ * Known variables are substituted with either their live/cached value or a
+ * type-appropriate placeholder (see `resolveFormulaFromSchemaValues`), so
+ * grammar errors (e.g. `!#item.broken 0`) are still caught even without a live
+ * document to resolve real values from.
+ *
+ * Returns `null` when the type is `'string'` (no coercion possible to fail),
+ * the formula is empty, or any variable couldn't be resolved to a known
+ * schema aspect at all (invalid/unresolvable path — flagged separately by
+ * `validateFormula`).
+ */
+export function validateFormulaType(
+  formula: string,
+  context: FamiliarSchema,
+  expectedType: 'string' | 'number' | 'boolean'
+): ValidationError | null {
+  if (!formula || expectedType === 'string') return null;
+
+  const resolved = resolveFormulaFromSchemaValues(formula, context);
+  if (extractVariables(resolved).length > 0) return null;
+
+  if (expectedType === 'number') {
+    const trimmed = resolved.trim();
+    if (!trimmed) return null;
+    if (!Number.isNaN(Number(trimmed))) return null;
+    try {
+      if (!Number.isNaN(Roll.safeEval(trimmed))) return null;
+    } catch {
+      // fall through to error
+    }
+    return {
+      variable: formula,
+      context: '',
+      path: [],
+      error: game.i18n.format('dnd35e.Formula.Errors.notANumber', { resolved }),
+      severity: 'error',
+      index: 0,
+    };
+  }
+
+  // expectedType === 'boolean'
+  try {
+    evaluateBooleanExpression(resolved);
+    return null;
+  } catch {
+    return {
+      variable: formula,
+      context: '',
+      path: [],
+      error: game.i18n.localize('dnd35e.Formula.Errors.notABoolean'),
+      severity: 'error',
+      index: 0,
+    };
+  }
+}
+
+/**
+ * Validate a single variable
+ * @param variable The FormulaVariable to validate
+ * @param context The familiar context
+ * @returns ValidationError or null if valid
+ */
+function validateVariable(variable: FormulaVariable, context: FamiliarSchema): ValidationError | null {
+  // Custom quoted path — trusted, skip all validation, just flag as warning
+  if (variable.customAccessPath !== undefined) {
+    variable.isValid = true;
+    return {
+      variable: variable.variable,
+      context: variable.context,
+      path: variable.path,
+      error: variable.customAccessPath,
+      severity: 'warning',
+      index: variable.startIndex,
+    };
+  }
+
+  let contextSchema = context[variable.context];
+
+  if (!contextSchema) {
+    // Try to find by alias or localized display name
+    const foundKey = Object.keys(context).find(k =>
+      context[k].aliases?.includes(variable.context)
+      || (normalizeLabel(context[k].display) ?? '') === variable.context
+    );
+    if (foundKey) {
+      contextSchema = context[foundKey];
+    }
+  }
+
+  if (!contextSchema || typeof contextSchema !== 'object' || !('properties' in contextSchema)) {
+    return {
+      variable: variable.variable,
+      context: variable.context,
+      path: variable.path,
+      error: game.i18n.format('dnd35e.Formula.Errors.contextNotFound', { context: variable.context }),
+      severity: 'error',
+      index: variable.startIndex,
+    };
+  }
+
+  // Bare context reference without a property path (e.g. #owner) is incomplete
+  if (variable.path.length === 0) {
+    return {
+      variable: variable.variable,
+      context: variable.context,
+      path: variable.path,
+      error: game.i18n.format('dnd35e.Formula.Errors.incompleteReference', { context: variable.context }),
+      severity: 'warning',
+      index: variable.startIndex,
+    };
+  }
+
+  let current: unknown = (contextSchema as { properties: AspectGroup }).properties;
+  let pathTraversed: string[] = [];
+
+  for (const key of variable.path) {
+    if (typeof current !== 'object' || current === null) {
+      return {
+        variable: variable.variable,
+        context: variable.context,
+        path: variable.path,
+        error: game.i18n.format('dnd35e.Formula.Errors.propertyNotFound', {
+          key,
+          path: `${variable.context}${pathTraversed.length > 0
+            ? '.' + pathTraversed.join('.')
+            : ''}`,
+        }),
+        severity: 'error',
+        index: variable.startIndex,
+      };
+    }
+
+    const obj = current as Record<string, unknown>;
+    if (key in obj) {
+      current = obj[key];
+    } else {
+      // Alias fallback — check leaf aliases then branch _aliases
+      const leafAlias = Object.entries(obj).find(([, v]) =>
+        isFieldAspect(v) && v.aliases?.includes(key)
+      );
+      if (leafAlias) {
+        current = leafAlias[1];
+      } else {
+        const branchAlias = Object.entries(obj).find(([, v]) =>
+          typeof v === 'object' && v !== null && !isFieldAspect(v)
+          && (v as { _aliases?: string[] })._aliases?.includes(key)
+        );
+        if (branchAlias) {
+          current = branchAlias[1];
+        } else {
+          // Localized display name fallback
+          const localDisplay = Object.entries(obj).find(([k, v]) => {
+            if (k.startsWith('_')) return false;
+            const localKey = isFieldAspect(v)
+              ? normalizeLabel((v as FieldAspect).display)
+              : normalizeLabel((v as AspectGroup)._display);
+            return localKey === key;
+          });
+          if (localDisplay) {
+            current = localDisplay[1];
+          } else {
+            return {
+              variable: variable.variable,
+              context: variable.context,
+              path: variable.path,
+              error: game.i18n.format('dnd35e.Formula.Errors.propertyNotFound', {
+                key,
+                path: `${variable.context}${pathTraversed.length > 0
+                  ? '.' + pathTraversed.join('.')
+                  : ''}`,
+              }),
+              severity: 'error',
+              index: variable.startIndex,
+            };
+          }
+        }
+      }
+    }
+    pathTraversed.push(key);
+  }
+
+  // The path must resolve to a leaf property, not an intermediate object
+  if (!isFieldAspect(current)) {
+    return {
+      variable: variable.variable,
+      context: variable.context,
+      path: variable.path,
+      error: game.i18n.format('dnd35e.Formula.Errors.notAProperty', { variable: variable.variable }),
+      severity: 'warning',
+      index: variable.startIndex,
+    };
+  }
+
+  variable.isValid = true;
+  return null;
+}

--- a/src/helpers/formulae/conditionalFormula.mts
+++ b/src/helpers/formulae/conditionalFormula.mts
@@ -1,0 +1,291 @@
+/**
+ * Conditional Formula Syntax — `#conditional(when(cond, value) ... else(default))`
+ *
+ * A flat rule-list conditional embedded directly in formula text, e.g.:
+ *
+ *   #conditional(when(#self.hp.value <= 0, 0) when(#self.isFlanked, 1d6+#self.sneakAttackDice) else(2))d6
+ *
+ * - `when(condition, value)` — zero or more, evaluated in left-to-right source order;
+ *   the first clause whose condition is true supplies the result.
+ * - `else(value)` — required exactly once, may appear anywhere among the clauses;
+ *   supplies the result when no `when()` matches.
+ * - Clause separators are don't-care — `when(...)`/`else(...)` are self-delimiting via
+ *   their own balanced parens, so commas, whitespace, or nothing between clauses are
+ *   all equivalent.
+ * - `#conditional(...)` behaves as a single inline token — surrounding literal text
+ *   and other `#context.property` tokens are untouched.
+ * - Matching is lenient: `#conditional`/`when`/`else` keywords are case-insensitive,
+ *   with optional whitespace before `(`.
+ * - `\(` and `\)` escape a literal parenthesis (same backslash convention as `\#`
+ *   for a literal `#`) — an escaped paren doesn't count toward balanced-paren
+ *   depth tracking, so a value can contain unbalanced literal parens, and
+ *   `\#conditional(`/escaping the paren right after `when`/`else` prevents that
+ *   occurrence from being parsed as the syntax construct at all.
+ * - `\,` escapes a literal comma inside a `when(...)`/`else(...)` argument (e.g.
+ *   a quoted string being compared against, `when(#self.name == "\,", 500)`) —
+ *   without it, the comma would be mistaken for the top-level separator between
+ *   that clause's own arguments (e.g. condition vs. value).
+ *
+ * See `docs/migration-plan/poc/phase-07-roll-formulas.md` §7.10 for the full design.
+ *
+ * @module
+ */
+
+/** A single `when(condition, value)` clause. */
+export interface ConditionalWhenClause {
+  condition: string;
+  value: string;
+}
+
+/** A reason a `#conditional(...)` block failed to parse cleanly. */
+export type ConditionalBlockError =
+  | 'unbalancedParens'
+  | 'missingElse'
+  | 'multipleElse'
+  | 'whenArgCount'
+  | 'elseArgCount';
+
+/** A single `#conditional(...)` block found within a formula string. */
+export interface ConditionalBlock {
+  /** Full "#conditional(...)" span exactly as it appeared in the source. */
+  raw: string;
+  startIndex: number;
+  endIndex: number;
+  whenClauses: ConditionalWhenClause[];
+  elseValue: string | null;
+  /** Present when the block is malformed — resolution leaves it raw/unresolved. */
+  error?: ConditionalBlockError;
+}
+
+const CONDITIONAL_OPEN_REGEX = /(?<!\\)#conditional\s*\(/gi;
+const CLAUSE_KEYWORD_REGEX = /(?<![\p{L}\p{N}_])(when|else)\s*\(/giu;
+
+/**
+ * Find the index of the closing paren matching the '(' at `openIndex`.
+ * Returns -1 if the parens never balance out.
+ *
+ * A backslash-escaped paren (`\(` or `\)`) doesn't count toward depth — it's
+ * skipped entirely (along with its backslash) so literal/unbalanced parens can
+ * appear inside a value without breaking the scan.
+ */
+function findMatchingParen(text: string, openIndex: number): number {
+  let depth = 0;
+  for (let i = openIndex; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === '\\') {
+      i++; // skip the escaped character entirely — not syntax-significant
+      continue;
+    }
+    if (ch === '(') depth++;
+    else if (ch === ')') {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Split text on top-level commas only, respecting nested parens.
+ * Backslash-escaped characters (`\(`, `\)`, `\,`, etc.) are passed through
+ * untouched and never treated as syntax (paren depth or a split point).
+ */
+function splitTopLevelArgs(argsText: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = '';
+
+  for (let i = 0; i < argsText.length; i++) {
+    const ch = argsText[i];
+    if (ch === '\\' && i + 1 < argsText.length) {
+      current += ch + argsText[i + 1];
+      i++;
+      continue;
+    }
+    if (ch === '(') {
+      depth++;
+      current += ch;
+    } else if (ch === ')') {
+      depth--;
+      current += ch;
+    } else if (ch === ',' && depth === 0) {
+      parts.push(current.trim());
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  parts.push(current.trim());
+  return parts;
+}
+
+interface RawClause {
+  keyword: 'when' | 'else';
+  argsText: string;
+}
+
+/**
+ * Scan `innerText` (the content between `#conditional(`'s parens) for
+ * `when(...)`/`else(...)` clauses. Nested clauses (e.g. inside a value that
+ * contains its own `#conditional(...)`) are skipped over automatically since
+ * each match consumes through its own balanced closing paren before resuming
+ * the search.
+ */
+function findClauses(innerText: string): { clauses: RawClause[]; error?: ConditionalBlockError } {
+  const clauses: RawClause[] = [];
+  const regex = new RegExp(CLAUSE_KEYWORD_REGEX.source, 'giu');
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(innerText)) !== null) {
+    const keyword = match[1].toLowerCase() as 'when' | 'else';
+    const openParenIndex = match.index + match[0].length - 1;
+    const closeParenIndex = findMatchingParen(innerText, openParenIndex);
+
+    if (closeParenIndex === -1) {
+      return { clauses, error: 'unbalancedParens' };
+    }
+
+    clauses.push({ keyword, argsText: innerText.substring(openParenIndex + 1, closeParenIndex) });
+    regex.lastIndex = closeParenIndex + 1;
+  }
+
+  return { clauses };
+}
+
+/**
+ * Find all `#conditional(...)` blocks in a formula string, parsing each into
+ * its `when`/`else` clauses. Malformed blocks are still returned (with
+ * `.error` set) so validation and resolution can handle them explicitly
+ * rather than throwing.
+ */
+export function findConditionalBlocks(formula: string): ConditionalBlock[] {
+  const blocks: ConditionalBlock[] = [];
+  const openRegex = new RegExp(CONDITIONAL_OPEN_REGEX.source, 'gi');
+  let match: RegExpExecArray | null;
+
+  while ((match = openRegex.exec(formula)) !== null) {
+    const startIndex = match.index;
+    const openParenIndex = match.index + match[0].length - 1;
+    const closeParenIndex = findMatchingParen(formula, openParenIndex);
+
+    if (closeParenIndex === -1) {
+      blocks.push({
+        raw: formula.substring(startIndex),
+        startIndex,
+        endIndex: formula.length,
+        whenClauses: [],
+        elseValue: null,
+        error: 'unbalancedParens',
+      });
+      break;
+    }
+
+    const innerText = formula.substring(openParenIndex + 1, closeParenIndex);
+    const { clauses, error: clauseError } = findClauses(innerText);
+
+    const whenClauses: ConditionalWhenClause[] = [];
+    let elseValue: string | null = null;
+    let elseCount = 0;
+    let shapeError: ConditionalBlockError | undefined;
+
+    for (const clause of clauses) {
+      const args = splitTopLevelArgs(clause.argsText);
+      if (clause.keyword === 'when') {
+        if (args.length !== 2) {
+          shapeError ??= 'whenArgCount';
+          continue;
+        }
+        whenClauses.push({ condition: args[0], value: args[1] });
+      } else {
+        elseCount++;
+        if (args.length !== 1) {
+          shapeError ??= 'elseArgCount';
+          continue;
+        }
+        elseValue = args[0];
+      }
+    }
+
+    let error = clauseError ?? shapeError;
+    if (!error && elseCount === 0) error = 'missingElse';
+    if (!error && elseCount > 1) error = 'multipleElse';
+
+    blocks.push({
+      raw: formula.substring(startIndex, closeParenIndex + 1),
+      startIndex,
+      endIndex: closeParenIndex + 1,
+      whenClauses,
+      elseValue,
+      ...(error && { error }),
+    });
+
+    openRegex.lastIndex = closeParenIndex + 1;
+  }
+
+  return blocks;
+}
+
+/**
+ * Resolve all `#conditional(...)` blocks in `formula`, replacing each with
+ * its winning branch's (still-unresolved) text. Ordinary `#context.property`
+ * tokens are left untouched — the caller is expected to run its own
+ * substitution pass over the result afterward.
+ *
+ * @param formula The formula text to scan for conditional blocks
+ * @param resolveSubFormula Fully resolves an arbitrary sub-formula string
+ *   (used to resolve a `when()` condition to a literal before evaluating it)
+ * @param evaluateCondition Evaluates a fully-resolved condition string to a boolean
+ */
+export function resolveConditionalFormula(
+  formula: string,
+  resolveSubFormula: (text: string) => string,
+  evaluateCondition: (resolvedCondition: string) => boolean
+): string {
+  const blocks = findConditionalBlocks(formula);
+  if (blocks.length === 0) return formula;
+
+  let result = formula;
+
+  // Process in reverse order so earlier blocks' indices stay valid as we splice.
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    const block = blocks[i];
+    // Malformed block — leave raw/unresolved rather than guessing.
+    if (block.error) continue;
+
+    let winningValue = block.elseValue ?? '';
+    for (const clause of block.whenClauses) {
+      const resolvedCondition = resolveSubFormula(clause.condition);
+      let isTrue = false;
+      try {
+        isTrue = evaluateCondition(resolvedCondition);
+      } catch {
+        isTrue = false;
+      }
+      if (isTrue) {
+        winningValue = clause.value;
+        break;
+      }
+    }
+
+    // Recursively resolve any nested #conditional(...) block within the winning
+    // branch — ordinary tokens are left for the caller's own substitution pass.
+    const resolvedWinningValue = resolveConditionalFormula(winningValue, resolveSubFormula, evaluateCondition);
+
+    result = result.substring(0, block.startIndex) + resolvedWinningValue + result.substring(block.endIndex);
+  }
+
+  return result;
+}
+
+/**
+ * True when `variable` (as produced by `extractVariables`) is the bare
+ * `#conditional` keyword token immediately followed by `(` — i.e. it's being
+ * used as this syntax construct, not as an actual (invalid) context reference.
+ */
+export function isConditionalKeywordToken(
+  formula: string,
+  variable: { context: string; path: string[]; endIndex: number }
+): boolean {
+  if (variable.context.toLowerCase() !== 'conditional' || variable.path.length !== 0) return false;
+  return /^\s*\(/.test(formula.slice(variable.endIndex));
+}

--- a/src/helpers/formulae/evaluateBooleanExpression.mts
+++ b/src/helpers/formulae/evaluateBooleanExpression.mts
@@ -1,0 +1,281 @@
+/**
+ * evaluateBooleanExpression — small, purpose-built comparison/logical expression
+ * evaluator for boolean-typed formulas (§7.2a of Phase 7).
+ *
+ * Operates on an already-substituted formula string (all `#context.property`
+ * tokens have been replaced with their literal values by `resolveFormula()`).
+ * This is NOT a general JS `eval` and is distinct from `Roll.safeEval` (which
+ * only handles dice-formula arithmetic, no comparison/logical operators).
+ *
+ * Supported grammar (standard precedence, lowest to highest):
+ *   orExpr         := andExpr ( '||' andExpr )*
+ *   andExpr        := notExpr ( '&&' notExpr )*
+ *   notExpr        := '!' notExpr | comparison
+ *   comparison     := additive ( ('>' | '<' | '>=' | '<=' | '==' | '!=') additive )?
+ *   additive       := multiplicative ( ('+' | '-') multiplicative )*
+ *   multiplicative := unary ( ('*' | '/') unary )*
+ *   unary          := ('-' | '+') unary | primary
+ *   primary        := '(' orExpr ')' | NUMBER | STRING | 'true' | 'false' | IDENT
+ *
+ * `IDENT` covers bareword literals — after substitution, a resolved string
+ * value (e.g. a weapon name) appears unquoted in the formula text, so any
+ * token that isn't a recognized literal/operator is treated as a string literal.
+ *
+ * Comparison operands may be arithmetic sub-expressions (e.g.
+ * `#actor.hp.max / 2`) — `+`/`-`/`*`/`/` are evaluated with standard
+ * precedence before the surrounding comparison is applied.
+ *
+ * @module
+ */
+
+type TokenType =
+  | 'number'
+  | 'string'
+  | 'boolean'
+  | 'ident'
+  | '('
+  | ')'
+  | '&&'
+  | '||'
+  | '!'
+  | '>'
+  | '<'
+  | '>='
+  | '<='
+  | '=='
+  | '!='
+  | '+'
+  | '-'
+  | '*'
+  | '/';
+
+interface Token {
+  type: TokenType;
+  value: string;
+}
+
+const TOKEN_REGEX = /\s*(?:(>=|<=|==|!=|&&|\|\||[()!<>+*/-])|('[^']*'|"[^"]*")|(\d+(?:\.\d+)?)|([^\s()!<>=&|]+))/g;
+
+function tokenize(expression: string): Token[] {
+  const tokens: Token[] = [];
+  let match: RegExpExecArray | null;
+  TOKEN_REGEX.lastIndex = 0;
+
+  while ((match = TOKEN_REGEX.exec(expression)) !== null) {
+    const [, operator, quoted, number, word] = match;
+    if (operator) {
+      tokens.push({ type: operator as TokenType, value: operator });
+    } else if (quoted) {
+      tokens.push({ type: 'string', value: quoted.slice(1, -1) });
+    } else if (number) {
+      tokens.push({ type: 'number', value: number });
+    } else if (word) {
+      if (word === 'true' || word === 'false') {
+        tokens.push({ type: 'boolean', value: word });
+      } else {
+        tokens.push({ type: 'ident', value: word });
+      }
+    } else {
+      // Only whitespace matched (or nothing) — advance to avoid an infinite loop
+      if (TOKEN_REGEX.lastIndex === match.index) TOKEN_REGEX.lastIndex++;
+    }
+  }
+
+  return tokens;
+}
+
+type LiteralValue = number | string | boolean;
+
+class ExpressionParser {
+  private readonly tokens: Token[];
+  private position = 0;
+
+  constructor(tokens: Token[]) {
+    this.tokens = tokens;
+  }
+
+  private peek(): Token | undefined {
+    return this.tokens[this.position];
+  }
+
+  private consume(expected?: TokenType): Token {
+    const token = this.tokens[this.position];
+    if (!token) throw new Error('Unexpected end of expression');
+    if (expected && token.type !== expected) {
+      throw new Error(`Expected '${expected}' but got '${token.value}'`);
+    }
+    this.position++;
+    return token;
+  }
+
+  parse(): boolean {
+    const result = this.parseOr();
+    if (this.position < this.tokens.length) {
+      throw new Error(`Unexpected token '${this.peek()?.value}'`);
+    }
+    return this.toBoolean(result);
+  }
+
+  private parseOr(): LiteralValue {
+    let left = this.parseAnd();
+    while (this.peek()?.type === '||') {
+      this.consume('||');
+      const right = this.parseAnd();
+      left = this.toBoolean(left) || this.toBoolean(right);
+    }
+    return left;
+  }
+
+  private parseAnd(): LiteralValue {
+    let left = this.parseNot();
+    while (this.peek()?.type === '&&') {
+      this.consume('&&');
+      const right = this.parseNot();
+      left = this.toBoolean(left) && this.toBoolean(right);
+    }
+    return left;
+  }
+
+  private parseNot(): LiteralValue {
+    if (this.peek()?.type === '!') {
+      this.consume('!');
+      return !this.toBoolean(this.parseNot());
+    }
+    return this.parseComparison();
+  }
+
+  private parseComparison(): LiteralValue {
+    const left = this.parseAdditive();
+    const operator = this.peek()?.type;
+    if (operator && ['>', '<', '>=', '<=', '==', '!='].includes(operator)) {
+      this.consume();
+      const right = this.parseAdditive();
+      return this.compare(left, operator, right);
+    }
+    return left;
+  }
+
+  private parseAdditive(): LiteralValue {
+    let left = this.parseMultiplicative();
+    while (this.peek()?.type === '+' || this.peek()?.type === '-') {
+      const operator = this.consume().type;
+      const right = this.parseMultiplicative();
+      left = this.arithmetic(left, operator, right);
+    }
+    return left;
+  }
+
+  private parseMultiplicative(): LiteralValue {
+    let left = this.parseUnary();
+    while (this.peek()?.type === '*' || this.peek()?.type === '/') {
+      const operator = this.consume().type;
+      const right = this.parseUnary();
+      left = this.arithmetic(left, operator, right);
+    }
+    return left;
+  }
+
+  private parseUnary(): LiteralValue {
+    if (this.peek()?.type === '-') {
+      this.consume('-');
+      const value = this.parseUnary();
+      const num = typeof value === 'number' ? value : Number(value);
+      if (Number.isNaN(num)) throw new Error(`Unary '-' requires a numeric operand (got '${value}')`);
+      return -num;
+    }
+    if (this.peek()?.type === '+') {
+      this.consume('+');
+      return this.parseUnary();
+    }
+    return this.parsePrimary();
+  }
+
+  private arithmetic(left: LiteralValue, operator: string, right: LiteralValue): number {
+    const leftNum = typeof left === 'number' ? left : Number(left);
+    const rightNum = typeof right === 'number' ? right : Number(right);
+    if (Number.isNaN(leftNum) || Number.isNaN(rightNum)) {
+      throw new Error(`Operator '${operator}' requires numeric operands (got '${left}', '${right}')`);
+    }
+
+    switch (operator) {
+      case '+': return leftNum + rightNum;
+      case '-': return leftNum - rightNum;
+      case '*': return leftNum * rightNum;
+      case '/': return leftNum / rightNum;
+      default: throw new Error(`Unknown operator '${operator}'`);
+    }
+  }
+
+  private parsePrimary(): LiteralValue {
+    const token = this.peek();
+    if (!token) throw new Error('Unexpected end of expression');
+
+    if (token.type === '(') {
+      this.consume('(');
+      const value = this.parseOr();
+      this.consume(')');
+      return value;
+    }
+    if (token.type === '!') {
+      return this.parseNot();
+    }
+    if (token.type === 'number') {
+      this.consume();
+      return Number(token.value);
+    }
+    if (token.type === 'boolean') {
+      this.consume();
+      return token.value === 'true';
+    }
+    if (token.type === 'string' || token.type === 'ident') {
+      this.consume();
+      return token.value;
+    }
+    throw new Error(`Unexpected token '${token.value}'`);
+  }
+
+  private compare(left: LiteralValue, operator: string, right: LiteralValue): boolean {
+    if (operator === '==') return left === right || String(left) === String(right);
+    if (operator === '!=') return !(left === right || String(left) === String(right));
+
+    // Ordering operators require numeric operands
+    const leftNum = typeof left === 'number' ? left : Number(left);
+    const rightNum = typeof right === 'number' ? right : Number(right);
+    if (Number.isNaN(leftNum) || Number.isNaN(rightNum)) {
+      throw new Error(`Operator '${operator}' requires numeric operands (got '${left}', '${right}')`);
+    }
+
+    switch (operator) {
+      case '>': return leftNum > rightNum;
+      case '<': return leftNum < rightNum;
+      case '>=': return leftNum >= rightNum;
+      case '<=': return leftNum <= rightNum;
+      default: throw new Error(`Unknown operator '${operator}'`);
+    }
+  }
+
+  private toBoolean(value: LiteralValue): boolean {
+    if (typeof value === 'boolean') return value;
+    if (typeof value === 'number') return value !== 0;
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    return value.length > 0;
+  }
+}
+
+/**
+ * Evaluate a boolean expression over already-substituted literals.
+ * Throws a descriptive Error on invalid syntax — callers should catch and
+ * fall back / surface a validation error rather than letting this throw
+ * during derived-data preparation.
+ */
+export function evaluateBooleanExpression(expression: string): boolean {
+  const trimmed = expression.trim();
+  if (!trimmed) throw new Error('Empty boolean expression');
+
+  const tokens = tokenize(trimmed);
+  if (!tokens.length) throw new Error('Empty boolean expression');
+
+  const parser = new ExpressionParser(tokens);
+  return parser.parse();
+}

--- a/src/helpers/formulae/index.mts
+++ b/src/helpers/formulae/index.mts
@@ -19,6 +19,8 @@ import { FormulaData } from './FormulaData.mjs';
 import type { FormulaFieldOptions } from './FormulaField.mjs';
 import { FormulaField } from './FormulaField.mjs';
 import FormulaFormGroup from './FormulaFormGroup.vue';
+import { FormulaResolver } from './FormulaResolver.mjs';
+import type { AspectLookupResult } from './FormulaResolver.types.mjs';
 import type {
   ContextDocumentType,
   DocumentContext,
@@ -56,34 +58,37 @@ import type { FamiliarKeyDownResult, UseFamiliarOptions } from './useFamiliar.mj
 import { measureTextOffset, useFamiliar } from './useFamiliar.mjs';
 import type { FamiliarOverlayInputApi, OverlayAutocompleteArgs } from './useFamiliarOverlayInput.mjs';
 import { useFamiliarOverlayInput } from './useFamiliarOverlayInput.mjs';
-import type { AspectLookupResult, GetAutocompleteOptionsConfig } from './utils.mjs';
+import type { GetAutocompleteOptionsConfig } from './utils.mjs';
 import {
   buildDocumentDataMap,
   canonicalizeFormula,
   ensureNameFormula,
   extractVariableAtPosition,
-  extractVariables,
-  fieldAspect,
-  filterExcludedFields,
-  findAspectByAccessPath,
   getAutocompleteOptions,
   getCaretCoordinates,
-  getNestedValue,
-  getPropertyValue,
   getTokenAtPosition,
   getVariableTokenIndex,
   getVariableTokens,
   insertAtCursor,
   localizeFormula,
-  mergeAspectGroups,
   nameToFormulaData,
-  parseFormula,
   renderFormulaDisplayHTML,
   renderFormulaHTML,
-  resolveFormula,
   resolveFormulaField,
-  validateFormula,
 } from './utils.mjs';
+
+const {
+  extractVariables,
+  fieldAspect,
+  filterExcludedFields,
+  findAspectByAccessPath,
+  getNestedValue,
+  getPropertyValue,
+  mergeAspectGroups,
+  parseFormula,
+  resolveFormula,
+  validateFormula,
+} = FormulaResolver;
 
 export {
   buildContextFromFormula,
@@ -104,6 +109,7 @@ export {
   FormulaData,
   FormulaField,
   FormulaFormGroup,
+  FormulaResolver,
   gatherAspectsFromSchema,
   getAutocompleteOptions,
   getCaretCoordinates,

--- a/src/helpers/formulae/registry.mts
+++ b/src/helpers/formulae/registry.mts
@@ -15,9 +15,9 @@ import type { EffectType } from '@effects/effectTypes.mjs';
 import type { ItemDnd35e } from '@items/baseItem/ItemDnd35e.mjs';
 import type { ItemType } from '@items/itemTypes.mjs';
 
+import { FormulaResolver } from './FormulaResolver.mjs';
 import { normalizeLabel } from './schemaWalker.mjs';
 import type { AspectGroup, FamiliarContext, FamiliarSchema, FormulaFieldData } from './types.mjs';
-import { mergeAspectGroups } from './utils.mjs';
 
 /** Union of all Foundry document classes that can serve as familiar context. */
 export type NonNullDocumentContext = ItemDnd35e | ActorDnd35e | ActiveEffectDnd35e;
@@ -268,7 +268,7 @@ function buildMergedFamiliarContext(
     }
   }
   if (groups.length === 0) return null;
-  return { properties: mergeAspectGroups(...groups) };
+  return { properties: FormulaResolver.mergeAspectGroups(...groups) };
 }
 
 export {

--- a/src/helpers/formulae/schemaWalker.mts
+++ b/src/helpers/formulae/schemaWalker.mts
@@ -18,6 +18,7 @@ import type { DocumentContext } from './registry.mjs';
 import type { AspectGroup, FieldAspect, FormulaFieldMeta } from './types.mjs';
 
 const {
+  BooleanField,
   NumberField,
   SchemaField,
 } = foundry.data.fields;
@@ -65,10 +66,11 @@ const DOCUMENT_LEVEL_ASPECTS: Record<string, Omit<FieldAspect, 'value'>> = {
 
 /**
  * Infer a familiar type from a DataField class.
- * NumberField → 'number', everything else → 'string'.
+ * NumberField → 'number', BooleanField → 'boolean', everything else → 'string'.
  */
-function inferFieldType(field: foundry.data.fields.DataField): 'string' | 'number' {
+function inferFieldType(field: foundry.data.fields.DataField): 'string' | 'number' | 'boolean' {
   if (field instanceof NumberField) return 'number';
+  if (field instanceof BooleanField) return 'boolean';
   return 'string';
 }
 
@@ -82,12 +84,13 @@ function inferFieldType(field: foundry.data.fields.DataField): 'string' | 'numbe
 function resolveValue(
   context: DocumentContext,
   accessPath: string,
-  type: 'string' | 'number'
+  type: 'string' | 'number' | 'boolean'
 ): string | number | undefined {
   const raw = foundry.utils.getProperty(context as object, accessPath) as unknown;
   if (raw === undefined || raw === null) return undefined;
 
   if (type === 'number') return Number(raw);
+  if (type === 'boolean') return raw ? 'true' : 'false';
 
   // Scalar → coerce directly
   if (typeof raw !== 'object') return String(raw);

--- a/src/helpers/formulae/types.mts
+++ b/src/helpers/formulae/types.mts
@@ -19,7 +19,7 @@ export interface FormulaFieldMeta {
   /** I18n key for Familiar-only display label override (preferred over familiarLabel). */
   familiarLabelKey?: string;
   /** Override the inferred aspect type (normally inferred from inner field class). */
-  aspectType?: 'string' | 'number';
+  aspectType?: 'string' | 'number' | 'boolean';
   /** Override the key used in the AspectGroup (normally the field name). */
   aspectKey?: string;
   /** Alternative names that also resolve to this field, e.g. ['dmg', 'damage']. */
@@ -108,8 +108,8 @@ export interface Dnd35eFieldOverrides {
  */
 export interface FieldAspect {
   display?: string;           // Localized label (e.g., "Hardness", "Rarity")
-  value?: string | number;    // Current computed value (e.g., 10, "common") — optional, filled at runtime
-  type: 'string' | 'number';  // Type determines what operations can be performed
+  value?: string | number;    // Current computed value (e.g., 10, "common") — optional, filled at runtime; booleans stored as 'true'/'false'
+  type: 'string' | 'number' | 'boolean';  // Type determines what operations can be performed
   accessPath: string;         // The real document path (e.g., "system.hardness", "name")
   aliases?: string[];         // Alternative names that also resolve to this field
 }

--- a/src/helpers/formulae/useFormulaEditor.mts
+++ b/src/helpers/formulae/useFormulaEditor.mts
@@ -8,6 +8,7 @@ import {
   parseFormula,
   renderFormulaHTML,
   validateFormula,
+  validateFormulaType,
 } from './utils.mjs';
 
 type FormulaEditorOptions = {
@@ -18,6 +19,8 @@ type FormulaEditorOptions = {
   getDropdownMenuElement: () => HTMLElement | undefined;
   onCommit: (canonicalValue: string) => void;
   focusOnMount?: () => boolean;
+  /** When provided, a resolved value that doesn't match this type surfaces a validation error. */
+  expectedType?: ComputedRef<'string' | 'number' | 'boolean' | undefined>;
 };
 
 export const useFormulaEditor = (options: FormulaEditorOptions) => {
@@ -72,7 +75,12 @@ export const useFormulaEditor = (options: FormulaEditorOptions) => {
   };
 
   const updateValidation = () => {
-    formulaErrors.value = validateFormula(localValue.value, options.contexts.value);
+    const errors = validateFormula(localValue.value, options.contexts.value);
+    const expectedType = options.expectedType?.value;
+    const typeError = expectedType
+      ? validateFormulaType(localValue.value, options.contexts.value, expectedType)
+      : null;
+    formulaErrors.value = typeError ? [...errors, typeError] : errors;
   };
 
   const updateAutocompleteMenu = (formula: string, cursorPosition: number) => {

--- a/src/helpers/formulae/useFormulaEditor.mts
+++ b/src/helpers/formulae/useFormulaEditor.mts
@@ -1,15 +1,15 @@
 import { computed, type ComputedRef, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 
+import { FormulaResolver } from './FormulaResolver.mjs';
 import type { AutocompleteOption, FamiliarSchema, ValidationError } from './types.mjs';
 import { useFamiliarOverlayInput } from './useFamiliarOverlayInput.mjs';
 import {
   canonicalizeFormula,
   localizeFormula,
-  parseFormula,
   renderFormulaHTML,
-  validateFormula,
-  validateFormulaType,
 } from './utils.mjs';
+
+const { parseFormula, validateFormula, validateFormulaType } = FormulaResolver;
 
 type FormulaEditorOptions = {
   contexts: ComputedRef<FamiliarSchema>;
@@ -37,14 +37,17 @@ export const useFormulaEditor = (options: FormulaEditorOptions) => {
 
   const localValue = ref('');
   const formulaErrors = ref<ValidationError[]>([]);
-  let isUserEditing = false;
+  // Tracks whether the field is currently being actively edited (focused/typed
+  // in). Reactive so `highlightedHTML` can escalate still-typing (yellow)
+  // states to definitive errors (red) once the user has moved on (blurred).
+  const isFocused = ref(false);
 
   const highlightedHTML = computed(() => {
     const val = localValue.value;
     if (!val) return '';
     const tokens = parseFormula(val);
     const errors = validateFormula(val, options.contexts.value);
-    return renderFormulaHTML(val, tokens, errors, options.contexts.value);
+    return renderFormulaHTML(val, tokens, errors, options.contexts.value, isFocused.value);
   });
 
   const syncScroll = () => {
@@ -127,7 +130,7 @@ export const useFormulaEditor = (options: FormulaEditorOptions) => {
     const target = event.target as HTMLInputElement;
     const value = target.value;
 
-    isUserEditing = true;
+    isFocused.value = true;
     localValue.value = value;
     updateValidation();
     nextTick(syncScroll);
@@ -143,14 +146,14 @@ export const useFormulaEditor = (options: FormulaEditorOptions) => {
   };
 
   const onFocus = () => {
-    isUserEditing = true;
+    isFocused.value = true;
   };
 
   const onBlur = () => {
     setTimeout(() => {
       dismissFamiliar();
-      if (isUserEditing) {
-        isUserEditing = false;
+      if (isFocused.value) {
+        isFocused.value = false;
         commitValue();
       }
     }, 200);
@@ -198,7 +201,7 @@ export const useFormulaEditor = (options: FormulaEditorOptions) => {
 
     if (event.key === 'Enter') {
       event.preventDefault();
-      isUserEditing = false;
+      isFocused.value = false;
       commitValue();
       options.getInputElement()?.blur();
       return;
@@ -206,21 +209,21 @@ export const useFormulaEditor = (options: FormulaEditorOptions) => {
 
     if (event.key === 'Escape') {
       localValue.value = localizeFormula(options.currentValue.value || '', options.contexts.value);
-      isUserEditing = false;
+      isFocused.value = false;
       options.getInputElement()?.blur();
       event.preventDefault();
     }
   };
 
   watch(options.currentValue, (newValue) => {
-    if (!isUserEditing) {
+    if (!isFocused.value) {
       localValue.value = localizeFormula(newValue || '', options.contexts.value);
       updateValidation();
     }
   });
 
   watch(options.contexts, (newContexts, oldContexts) => {
-    if (!isUserEditing) {
+    if (!isFocused.value) {
       const oldLocalized = localizeFormula(options.currentValue.value || '', oldContexts);
       if (localValue.value === oldLocalized) {
         localValue.value = localizeFormula(options.currentValue.value || '', newContexts);
@@ -238,7 +241,7 @@ export const useFormulaEditor = (options: FormulaEditorOptions) => {
   });
 
   onUnmounted(() => {
-    isUserEditing = false;
+    isFocused.value = false;
     dismissFamiliar();
   });
 

--- a/src/helpers/formulae/utils.mts
+++ b/src/helpers/formulae/utils.mts
@@ -453,12 +453,23 @@ function isVariableComplete(token: FormulaToken, formula: string): boolean {
  * Standard stack-based matching: nested parens resolve correctly (each `)`
  * pairs with the nearest still-open `(`); any `(` left on the stack at the
  * end, or any `)` with nothing to pop, is unmatched.
+ *
+ * Backslash-escaped parens (`\(`/`\)`) are skipped entirely — the escaped
+ * character is consumed alongside the backslash and never reaches the `(`/`)`
+ * checks below — mirroring `findMatchingParen` in
+ * FormulaResolver.conditionalGrammar.mts, so a literal escaped paren inside a
+ * `$conditional(...)` clause's value can't throw off the real grouping
+ * parens' balance.
  */
 function computeMatchedParenIndices(formula: string): Set<number> {
   const matched = new Set<number>();
   const stack: number[] = [];
   for (let i = 0; i < formula.length; i++) {
     const ch = formula[i];
+    if (ch === '\\') {
+      i++; // skip the escaped character entirely — not syntax-significant
+      continue;
+    }
     if (ch === '(') {
       stack.push(i);
     } else if (ch === ')') {
@@ -666,9 +677,16 @@ export function renderFormulaHTML(
   // the `(` itself for its own delimiter branch) so stray prose-like text
   // elsewhere in a formula isn't mistaken for the `$conditional(...)` clause
   // keywords. `$and`/`$or` are keyword aliases for `&&`/`||` (word-bounded so
-  // they don't clip a longer bareword like `$android`).
+  // they don't clip a longer bareword like `$android`). Backslash-escaped
+  // parens/`$conditional`/`$and`/`$or` (`\(`, `\)`, `\$conditional(`, `\$and`,
+  // `\$or`) are excluded via `(?<!\\)` so they fall through as plain text
+  // instead of structural syntax — mirrors the same single-backslash escape
+  // convention `FormulaResolver.conditionalGrammar.mts` uses for
+  // `$conditional(`'s own open-regex (comparison operators and `when`/`else`
+  // have no escape mechanism in the real grammar, so they're intentionally
+  // left un-escapable here too).
   const OPERATOR_SPLIT =
-    /(\(|\)|>=|<=|==|!=|&&|\|\||[!<>]|\$conditional(?=\s*\()|\bwhen(?=\s*\()|\belse(?=\s*\()|\$and\b|\$or\b)/i;
+    /((?<!\\)\(|(?<!\\)\)|>=|<=|==|!=|&&|\|\||[!<>]|(?<!\\)\$conditional(?=\s*\()|\bwhen(?=\s*\()|\belse(?=\s*\()|(?<!\\)\$and\b|(?<!\\)\$or\b)/i;
 
   return tokens
     .map(token => {

--- a/src/helpers/formulae/utils.mts
+++ b/src/helpers/formulae/utils.mts
@@ -2,6 +2,8 @@
  * FormulaFormGroup Utility Functions
  * Core parsing, validation, and resolution logic
  */
+import { findConditionalBlocks, isConditionalKeywordToken, resolveConditionalFormula } from './conditionalFormula.mjs';
+import { evaluateBooleanExpression } from './evaluateBooleanExpression.mjs';
 import type { FormulaDataSource } from './FormulaData.mjs';
 import { FormulaData } from './FormulaData.mjs';
 import type { DocumentContext } from './registry.mjs';
@@ -61,6 +63,17 @@ export function filterExcludedFields(
  * document path that isn't exposed through the familiar shortcuts.
  *
  * Uses a negative lookbehind so `\#` is treated as a literal `#`, not a variable.
+ *
+ * A `#token` immediately followed by more identifier characters with no
+ * separator (e.g. `#self.sneakAttackDiced6`) greedily matches as a single
+ * (invalid) path segment rather than `#self.sneakAttackDice` + literal `d6` —
+ * wrap the token in parens to disambiguate: `(#self.sneakAttackDice)d6`.
+ *
+ * `\#`, `\(`, `\)`, and `\,` all escape to their literal character (see the
+ * final unescape step in `resolveFormula()`) — the comma escape matters for
+ * `#conditional(...)` (see `conditionalFormula.mts`) so a literal comma inside
+ * a quoted string value (e.g. `when(#self.name == "\,", 500)`) isn't mistaken
+ * for the top-level comma separating a clause's own arguments.
  */
 // Unicode-aware: \p{L} = any letter, \p{N} = any digit — allows Polish/Czech/etc variable names
 const VARIABLE_REGEX = /(?<!\\)#[\p{L}\p{N}_]+(?:\.(?:'[^']*'|'[^ ']*|[\p{L}\p{N}_]+))*/gu;
@@ -203,8 +216,17 @@ export function resolveFormula(
   familiarSchema: FamiliarSchema,
   documentDataMap: Record<string, DocumentContext>
 ): string {
-  let result = formula;
-  const variables = extractVariables(formula);
+  // Pre-resolve #conditional(when(...) ... else(...)) blocks into their winning
+  // branch's (still-unresolved) text before the generic token substitution below
+  // runs — #conditional/when/else are not #context.property tokens themselves.
+  const withConditionalsResolved = resolveConditionalFormula(
+    formula,
+    sub => resolveFormula(sub, familiarSchema, documentDataMap),
+    resolvedCondition => evaluateBooleanExpression(resolvedCondition)
+  );
+
+  let result = withConditionalsResolved;
+  const variables = extractVariables(withConditionalsResolved);
 
   // Process in reverse order to maintain string indices
   for (let i = variables.length - 1; i >= 0; i--) {
@@ -262,8 +284,8 @@ export function resolveFormula(
     }
   }
 
-  // Unescape literal \# → #
-  result = result.replace(/\\#/g, '#');
+  // Unescape literal \# → #, \( → (, \) → ), \, → ,
+  result = result.replace(/\\([#(),])/g, '$1');
 
   return result;
 }
@@ -291,7 +313,7 @@ export function getNestedValue(obj: object, dottedPath: string): unknown {
  */
 export function fieldAspect<TContext extends DocumentContext>(
   display: string,
-  type: 'string' | 'number',
+  type: 'string' | 'number' | 'boolean',
   accessPath: string,
   context?: TContext
 ): FieldAspect {
@@ -299,7 +321,11 @@ export function fieldAspect<TContext extends DocumentContext>(
   if (context) {
     const raw = getNestedValue(context, accessPath);
     if (raw !== undefined && raw !== null) {
-      prop.value = type === 'number' ? Number(raw) : String(raw);
+      prop.value = type === 'number'
+        ? Number(raw)
+        : type === 'boolean'
+          ? (raw ? 'true' : 'false')
+          : String(raw);
     }
   }
   return prop;
@@ -409,11 +435,24 @@ export function findAspectByAccessPath(group: AspectGroup, accessPath: string): 
  * - Nested groups merge recursively.
  * - Leaf conflicts (same key in multiple groups): first group wins.
  * - A leaf in one group and a branch in another: first group wins (no mixing).
+ * - Branch metadata (`_display`/`_aliases`, set by the schema walker) is copied
+ *   as-is from the first group that declares it — never recursed into. These are
+ *   plain strings/string-arrays, not FieldAspect/AspectGroup nodes, so treating
+ *   them as branches (as a naive `!isFieldAspect` check would) sends
+ *   `Object.entries()` down a string's character indices, which — when two
+ *   groups both declare the same metadata on the same branch (e.g. every
+ *   ACTOR_TYPES subtype sharing one builder) — degenerates into merging
+ *   single-character strings with themselves forever (infinite recursion).
  */
 export function mergeAspectGroups(...groups: AspectGroup[]): AspectGroup {
   const result: AspectGroup = {};
   for (const group of groups) {
     for (const [key, value] of Object.entries(group)) {
+      if (key.startsWith('_')) {
+        // Branch metadata — first group wins, never merged/recursed into.
+        if (result[key] === undefined) result[key] = value;
+        continue;
+      }
       const existing = result[key];
       if (existing === undefined) {
         // New key — take it
@@ -580,13 +619,137 @@ export function validateFormula(formula: string, context: FamiliarSchema): Valid
   const variables = extractVariables(formula);
 
   for (const variable of variables) {
+    // The bare `#conditional` keyword token (immediately followed by `(`) is this
+    // syntax construct, not an invalid context reference — skip normal validation.
+    // Its when()/else() contents are plain text, so any #context.property tokens
+    // nested inside them are still picked up and validated by this same loop.
+    if (isConditionalKeywordToken(formula, variable)) continue;
+
     const error = validateVariable(variable, context);
     if (error) {
       errors.push(error);
     }
   }
 
+  for (const block of findConditionalBlocks(formula)) {
+    if (!block.error) continue;
+    errors.push({
+      variable: block.raw,
+      context: 'conditional',
+      path: [],
+      error: game.i18n.localize(`dnd35e.Formula.Errors.conditional.${block.error}`),
+      severity: 'error',
+      index: block.startIndex,
+    });
+  }
+
   return errors;
+}
+
+/**
+ * Substitute #context.property variables using the *schema's cached values*
+ * (`FieldAspect.value`) rather than a live document data map. Used for
+ * lightweight type-mismatch checks in the editor, where only a FamiliarSchema
+ * (not a full documentDataMap) is available.
+ *
+ * When a variable resolves to a known FieldAspect but has no cached `.value`
+ * (e.g. no live parent document — a merged fallback schema built without
+ * context, as when editing an orphaned/standalone effect), a type-appropriate
+ * placeholder ('0' / 'false' / '""') is substituted instead of leaving the
+ * variable unresolved. This still lets grammar/type validation run — e.g.
+ * catching `!#item.broken 0` (two adjacent expressions, no operator) — without
+ * needing real live data, since the *shape* of a formula doesn't depend on the
+ * variable's actual runtime value. Variables with no matching aspect at all
+ * (invalid/unresolvable path — already flagged separately by `validateFormula`)
+ * or custom quoted paths are left as-is.
+ */
+function resolveFormulaFromSchemaValues(formula: string, schema: FamiliarSchema): string {
+  let result = formula;
+  const variables = extractVariables(formula);
+
+  for (let i = variables.length - 1; i >= 0; i--) {
+    const variable = variables[i];
+    if (variable.customAccessPath !== undefined) continue;
+
+    const aspect = getFieldAspect(schema, variable.context, variable.path);
+    if (!aspect) continue;
+
+    const placeholder = aspect.type === 'number'
+      ? '0'
+      : aspect.type === 'boolean'
+        ? 'false'
+        : '""';
+    const value = aspect.value ?? placeholder;
+
+    result =
+      result.substring(0, variable.startIndex) +
+      String(value) +
+      result.substring(variable.endIndex);
+  }
+
+  return result;
+}
+
+/**
+ * Check whether a formula's resolved value matches its field's `expectedType`.
+ * Surfaces a validation error instead of silently falling back — a `number`-typed
+ * field whose formula resolves to a boolean/non-numeric string, or a
+ * `boolean`-typed field whose formula isn't a valid comparison/logical
+ * expression, both produce an error here.
+ *
+ * Known variables are substituted with either their live/cached value or a
+ * type-appropriate placeholder (see `resolveFormulaFromSchemaValues`), so
+ * grammar errors (e.g. `!#item.broken 0`) are still caught even without a live
+ * document to resolve real values from.
+ *
+ * Returns `null` when the type is `'string'` (no coercion possible to fail),
+ * the formula is empty, or any variable couldn't be resolved to a known
+ * schema aspect at all (invalid/unresolvable path — flagged separately by
+ * `validateFormula`).
+ */
+export function validateFormulaType(
+  formula: string,
+  context: FamiliarSchema,
+  expectedType: 'string' | 'number' | 'boolean'
+): ValidationError | null {
+  if (!formula || expectedType === 'string') return null;
+
+  const resolved = resolveFormulaFromSchemaValues(formula, context);
+  if (extractVariables(resolved).length > 0) return null;
+
+  if (expectedType === 'number') {
+    const trimmed = resolved.trim();
+    if (!trimmed) return null;
+    if (!Number.isNaN(Number(trimmed))) return null;
+    try {
+      if (!Number.isNaN(Roll.safeEval(trimmed))) return null;
+    } catch {
+      // fall through to error
+    }
+    return {
+      variable: formula,
+      context: '',
+      path: [],
+      error: game.i18n.format('dnd35e.Formula.Errors.notANumber', { resolved }),
+      severity: 'error',
+      index: 0,
+    };
+  }
+
+  // expectedType === 'boolean'
+  try {
+    evaluateBooleanExpression(resolved);
+    return null;
+  } catch {
+    return {
+      variable: formula,
+      context: '',
+      path: [],
+      error: game.i18n.localize('dnd35e.Formula.Errors.notABoolean'),
+      severity: 'error',
+      index: 0,
+    };
+  }
 }
 
 /**
@@ -627,7 +790,7 @@ function validateVariable(variable: FormulaVariable, context: FamiliarSchema): V
       variable: variable.variable,
       context: variable.context,
       path: variable.path,
-      error: `Context '${variable.context}' not found`,
+      error: game.i18n.format('dnd35e.Formula.Errors.contextNotFound', { context: variable.context }),
       severity: 'error',
       index: variable.startIndex,
     };
@@ -639,7 +802,7 @@ function validateVariable(variable: FormulaVariable, context: FamiliarSchema): V
       variable: variable.variable,
       context: variable.context,
       path: variable.path,
-      error: `Incomplete reference — specify a property (e.g. #${variable.context}.name)`,
+      error: game.i18n.format('dnd35e.Formula.Errors.incompleteReference', { context: variable.context }),
       severity: 'warning',
       index: variable.startIndex,
     };
@@ -654,7 +817,12 @@ function validateVariable(variable: FormulaVariable, context: FamiliarSchema): V
         variable: variable.variable,
         context: variable.context,
         path: variable.path,
-        error: `Property '${key}' not found on ${variable.context}${pathTraversed.length > 0 ? '.' + pathTraversed.join('.') : ''}`,
+        error: game.i18n.format('dnd35e.Formula.Errors.propertyNotFound', {
+          key,
+          path: `${variable.context}${pathTraversed.length > 0
+            ? '.' + pathTraversed.join('.')
+            : ''}`,
+        }),
         severity: 'error',
         index: variable.startIndex,
       };
@@ -693,7 +861,12 @@ function validateVariable(variable: FormulaVariable, context: FamiliarSchema): V
               variable: variable.variable,
               context: variable.context,
               path: variable.path,
-              error: `Property '${key}' not found on ${variable.context}${pathTraversed.length > 0 ? '.' + pathTraversed.join('.') : ''}`,
+              error: game.i18n.format('dnd35e.Formula.Errors.propertyNotFound', {
+                key,
+                path: `${variable.context}${pathTraversed.length > 0
+                  ? '.' + pathTraversed.join('.')
+                  : ''}`,
+              }),
               severity: 'error',
               index: variable.startIndex,
             };
@@ -710,7 +883,7 @@ function validateVariable(variable: FormulaVariable, context: FamiliarSchema): V
       variable: variable.variable,
       context: variable.context,
       path: variable.path,
-      error: `'${variable.variable}' is an object, not a property — specify a deeper path`,
+      error: game.i18n.format('dnd35e.Formula.Errors.notAProperty', { variable: variable.variable }),
       severity: 'warning',
       index: variable.startIndex,
     };
@@ -1002,6 +1175,34 @@ function isVariableComplete(token: FormulaToken, formula: string): boolean {
   return false;
 }
 
+/**
+ * Determine which `(`/`)` characters in a formula form a complete, balanced
+ * pair — used to color parens blue (matched, like a resolved variable) vs
+ * yellow (unmatched — still being typed, or genuinely mismatched), mirroring
+ * the blue/yellow convention already used for variable tokens.
+ *
+ * Standard stack-based matching: nested parens resolve correctly (each `)`
+ * pairs with the nearest still-open `(`); any `(` left on the stack at the
+ * end, or any `)` with nothing to pop, is unmatched.
+ */
+function computeMatchedParenIndices(formula: string): Set<number> {
+  const matched = new Set<number>();
+  const stack: number[] = [];
+  for (let i = 0; i < formula.length; i++) {
+    const ch = formula[i];
+    if (ch === '(') {
+      stack.push(i);
+    } else if (ch === ')') {
+      const openIndex = stack.pop();
+      if (openIndex !== undefined) {
+        matched.add(openIndex);
+        matched.add(i);
+      }
+    }
+  }
+  return matched;
+}
+
 export function renderFormulaHTML(
   formula: string,
   tokens: FormulaToken[],
@@ -1009,11 +1210,26 @@ export function renderFormulaHTML(
   familiarSchema?: FamiliarSchema
 ): string {
   let variableIndex = 0;
+  const matchedParenIndices = computeMatchedParenIndices(formula);
 
   return tokens
     .map(token => {
       if (token.type === 'text') {
-        return escapeHTML(token.value);
+        // Wrap `(`/`)` individually so each can be colored by its matched state;
+        // everything else in the text run passes through unhighlighted.
+        const pieces = token.value.split(/([()])/);
+        let out = '';
+        let cursor = token.startIndex;
+        for (const piece of pieces) {
+          if (piece === '(' || piece === ')') {
+            const stateClass = matchedParenIndices.has(cursor) ? '' : ' is-warning';
+            out += `<span class="formula-paren${stateClass}" data-start="${cursor}" data-end="${cursor + 1}">${piece}</span>`;
+          } else {
+            out += escapeHTML(piece);
+          }
+          cursor += piece.length;
+        }
+        return out;
       }
 
       const varIdx = variableIndex++;
@@ -1024,7 +1240,7 @@ export function renderFormulaHTML(
       if (token.partial) {
         if (complete) {
           // Unclosed quote terminated by space → all red
-          return `<span class="formula-variable is-error" title="Invalid variable" data-var-index="${varIdx}" data-start="${token.startIndex}" data-end="${token.endIndex}">${escapeHTML(token.value)}</span>`;
+          return `<span class="formula-variable is-error" title="${escapeHTML(game.i18n.localize('dnd35e.Formula.Errors.invalidVariable'))}" data-var-index="${varIdx}" data-start="${token.startIndex}" data-end="${token.endIndex}">${escapeHTML(token.value)}</span>`;
         }
         // Still typing custom path → ALL yellow
         return `<span class="formula-variable is-warning" data-var-index="${varIdx}" data-start="${token.startIndex}" data-end="${token.endIndex}">${escapeHTML(token.value)}</span>`;
@@ -1032,7 +1248,7 @@ export function renderFormulaHTML(
 
       // ── CUSTOM PATH (closed quote, e.g. #self.'system.isIdentified') → always yellow with tooltip ──
       if (matchingError?.severity === 'warning' && token.value.includes('\'')) {
-        const tooltip = ` title="Warning unknown path: ${escapeHTML(matchingError.error)}"`;
+        const tooltip = ` title="${escapeHTML(game.i18n.format('dnd35e.Formula.Errors.unknownPathWarning', { path: matchingError.error }))}"`;
         return `<span class="formula-variable is-warning"${tooltip} data-var-index="${varIdx}" data-start="${token.startIndex}" data-end="${token.endIndex}">${escapeHTML(token.value)}</span>`;
       }
 
@@ -1055,7 +1271,7 @@ export function renderFormulaHTML(
             }
           } else {
             const schema = familiarSchema[contextName];
-            tooltip = schema ? `Context: ${escapeHTML(contextName)}` : '';
+            tooltip = schema ? game.i18n.format('dnd35e.Formula.Errors.contextTooltip', { context: escapeHTML(contextName) }) : '';
           }
         }
         const titleAttr = tooltip ? ` title="${tooltip}"` : '';
@@ -1066,7 +1282,7 @@ export function renderFormulaHTML(
 
       if (complete) {
         // Complete + error → all red with "Invalid variable" tooltip
-        return `<span class="formula-variable is-error" title="Invalid variable" data-var-index="${varIdx}" data-start="${token.startIndex}" data-end="${token.endIndex}">${escapeHTML(token.value)}</span>`;
+        return `<span class="formula-variable is-error" title="${escapeHTML(game.i18n.localize('dnd35e.Formula.Errors.invalidVariable'))}" data-var-index="${varIdx}" data-start="${token.startIndex}" data-end="${token.endIndex}">${escapeHTML(token.value)}</span>`;
       }
 
       // In-progress + error: check if last segment partially matches familiar

--- a/src/helpers/formulae/utils.mts
+++ b/src/helpers/formulae/utils.mts
@@ -1,11 +1,12 @@
 /**
  * FormulaFormGroup Utility Functions
- * Core parsing, validation, and resolution logic
+ * Editor-support: HTML highlighting, autocomplete, and localized-display logic.
+ * Core parsing/resolution/validation logic lives in FormulaResolver.mts.
  */
-import { findConditionalBlocks, isConditionalKeywordToken, resolveConditionalFormula } from './conditionalFormula.mjs';
-import { evaluateBooleanExpression } from './evaluateBooleanExpression.mjs';
 import type { FormulaDataSource } from './FormulaData.mjs';
 import { FormulaData } from './FormulaData.mjs';
+import { FormulaResolver } from './FormulaResolver.mjs';
+import type { ConditionalBlockError } from './FormulaResolver.types.mjs';
 import type { DocumentContext } from './registry.mjs';
 import { buildContextFromFormula } from './registry.mjs';
 import { normalizeLabel } from './schemaWalker.mjs';
@@ -21,452 +22,6 @@ import type {
 } from './types.mjs';
 import { isFieldAspect } from './types.mjs';
 
-// ============================================================================
-// Schema Filtering
-// ============================================================================
-
-/**
- * Return a copy of `schema` with the given top-level aspect keys removed from
- * every context's properties.  Used to prevent circular references (e.g.
- * nameFormula must not reference `name`).
- *
- * Only strips keys at the root of each context's `properties` — nested paths
- * are not affected.
- */
-export function filterExcludedFields(
-  schema: FamiliarSchema,
-  excludedFields: string[]
-): FamiliarSchema {
-  if (!excludedFields.length) return schema;
-
-  const filtered: FamiliarSchema = {};
-  for (const [ctxName, ctx] of Object.entries(schema)) {
-    const props = { ...ctx.properties };
-    for (const key of excludedFields) {
-      delete props[key];
-      // Also delete the PascalCase-normalized form in case keys have been localized
-      const normalized = normalizeLabel(key);
-      if (normalized && normalized !== key) delete props[normalized];
-    }
-    filtered[ctxName] = { ...ctx, properties: props };
-  }
-  return filtered;
-}
-
-/**
- * Regex matching formula variables:
- *   #context.property.nested       — standard familiar path
- *   #context.'raw.dotted.path'     — custom / arbitrary document path (closed quote)
- *   #context.'partial.text         — unclosed quote, no spaces (still typing)
- *
- * The optional quoted segment (single-quotes) lets users reference any
- * document path that isn't exposed through the familiar shortcuts.
- *
- * Uses a negative lookbehind so `\#` is treated as a literal `#`, not a variable.
- *
- * A `#token` immediately followed by more identifier characters with no
- * separator (e.g. `#self.sneakAttackDiced6`) greedily matches as a single
- * (invalid) path segment rather than `#self.sneakAttackDice` + literal `d6` —
- * wrap the token in parens to disambiguate: `(#self.sneakAttackDice)d6`.
- *
- * `\#`, `\(`, `\)`, and `\,` all escape to their literal character (see the
- * final unescape step in `resolveFormula()`) — the comma escape matters for
- * `#conditional(...)` (see `conditionalFormula.mts`) so a literal comma inside
- * a quoted string value (e.g. `when(#self.name == "\,", 500)`) isn't mistaken
- * for the top-level comma separating a clause's own arguments.
- */
-// Unicode-aware: \p{L} = any letter, \p{N} = any digit — allows Polish/Czech/etc variable names
-const VARIABLE_REGEX = /(?<!\\)#[\p{L}\p{N}_]+(?:\.(?:'[^']*'|'[^ ']*|[\p{L}\p{N}_]+))*/gu;
-
-/**
- * Parse a formula into tokens (text and variables)
- * Handles #contextName.property.nested.path, #context.'raw.path' and partial syntax
- */
-export function parseFormula(formula: string): FormulaToken[] {
-  const tokens: FormulaToken[] = [];
-  const regex = new RegExp(VARIABLE_REGEX.source, 'gu');
-  let lastIndex = 0;
-  let match;
-
-  while ((match = regex.exec(formula)) !== null) {
-    // Add text token before the variable
-    if (match.index > lastIndex) {
-      tokens.push({
-        type: 'text',
-        value: formula.substring(lastIndex, match.index),
-        startIndex: lastIndex,
-        endIndex: match.index,
-      });
-    }
-
-    const raw = match[0];
-    // Detect unclosed quote — the match grabbed to EOL without a closing '
-    const quoteCount = (raw.match(/'/g) || []).length;
-    const isPartial = quoteCount % 2 !== 0;
-
-    tokens.push({
-      type: 'variable',
-      value: raw,
-      startIndex: match.index,
-      endIndex: match.index + raw.length,
-      ...(isPartial && { partial: true }),
-    });
-
-    lastIndex = match.index + raw.length;
-  }
-
-  // Add remaining text
-  if (lastIndex < formula.length) {
-    tokens.push({
-      type: 'text',
-      value: formula.substring(lastIndex),
-      startIndex: lastIndex,
-      endIndex: formula.length,
-    });
-  }
-
-  return tokens.length > 0 ? tokens : [{ type: 'text', value: formula, startIndex: 0, endIndex: formula.length }];
-}
-
-/**
- * Split a variable body (after the leading #) into segments,
- * respecting single-quoted segments which represent raw paths.
- * Returns { context, path, customAccessPath? }.
- *
- *   "self.hardness"               → { context: "self", path: ["hardness"] }
- *   "self.'system.isIdentified'"  → { context: "self", path: [], customAccessPath: "system.isIdentified" }
- */
-function parseVariableSegments(body: string): { context: string; path: string[]; customAccessPath?: string } {
-  const segments: string[] = [];
-  let current = '';
-  let inQuote = false;
-  let customAccessPath: string | undefined;
-
-  for (const ch of body) {
-    if (ch === '\'' && !inQuote) {
-      inQuote = true;
-    } else if (ch === '\'' && inQuote) {
-      // The content inside quotes is the raw access path
-      customAccessPath = current;
-      current = '';
-      inQuote = false;
-    } else if (ch === '.' && !inQuote) {
-      if (current) segments.push(current);
-      current = '';
-    } else {
-      current += ch;
-    }
-  }
-  if (current) {
-    if (inQuote) {
-      // Unclosed quote — treat accumulated text as a partial custom path
-      customAccessPath = current;
-    } else {
-      segments.push(current);
-    }
-  }
-
-  const context = segments[0] ?? '';
-  const path = customAccessPath !== undefined ? [] : segments.slice(1);
-  return { context, path, customAccessPath };
-}
-
-/**
- * Extract all variables from a formula
- * @param formula The formula string
- * @returns Array of found variables
- */
-export function extractVariables(formula: string): FormulaVariable[] {
-  const regex = new RegExp(VARIABLE_REGEX.source, 'gu');
-  const variables: FormulaVariable[] = [];
-  let match;
-
-  while ((match = regex.exec(formula)) !== null) {
-    const variable = match[0];
-    const body = variable.substring(1); // Remove leading #
-    const { context, path, customAccessPath } = parseVariableSegments(body);
-
-    variables.push({
-      variable,
-      context,
-      path,
-      startIndex: match.index,
-      endIndex: match.index + variable.length,
-      isValid: true,
-      ...(customAccessPath !== undefined && { customAccessPath }),
-    });
-  }
-
-  return variables;
-}
-
-/**
- * Resolve all variables in a formula against document data using familiar accessPaths.
- *
- * For each #context.path variable, looks up the FieldAspect in the schema
- * to find its accessPath, then reads that path from the document data.
- *
- * @param formula The formula string with #context.path variables
- * @param familiarSchema The familiar schema (defines accessPaths)
- * @param documentDataMap Maps context names to their document data objects
- * @returns Formula with variables replaced by their resolved values
- */
-export function resolveFormula(
-  formula: string,
-  familiarSchema: FamiliarSchema,
-  documentDataMap: Record<string, DocumentContext>
-): string {
-  // Pre-resolve #conditional(when(...) ... else(...)) blocks into their winning
-  // branch's (still-unresolved) text before the generic token substitution below
-  // runs — #conditional/when/else are not #context.property tokens themselves.
-  const withConditionalsResolved = resolveConditionalFormula(
-    formula,
-    sub => resolveFormula(sub, familiarSchema, documentDataMap),
-    resolvedCondition => evaluateBooleanExpression(resolvedCondition)
-  );
-
-  let result = withConditionalsResolved;
-  const variables = extractVariables(withConditionalsResolved);
-
-  // Process in reverse order to maintain string indices
-  for (let i = variables.length - 1; i >= 0; i--) {
-    const variable = variables[i];
-
-    // Resolve context data: direct lookup first, then via familiarSchema alias
-    let docData = documentDataMap[variable.context];
-    if (!docData) {
-      // variable.context may be a localized alias (e.g. 'Self') while documentDataMap
-      // uses the internal key ('self'). Use the familiarSchema to bridge them.
-      const ctxEntry = familiarSchema[variable.context]
-        ? { key: variable.context, ctx: familiarSchema[variable.context] }
-        : (() => {
-          const found = Object.entries(familiarSchema).find(([, ctx]) =>
-            ctx.aliases?.includes(variable.context)
-          );
-          return found ? { key: found[0], ctx: found[1] } : null;
-        })();
-      if (ctxEntry) {
-        // Try the primary FamiliarSchema key in documentDataMap
-        docData = documentDataMap[ctxEntry.key];
-        if (!docData) {
-          // Try each alias of that context in documentDataMap
-          for (const alias of (ctxEntry.ctx.aliases ?? [])) {
-            if (documentDataMap[alias]) { docData = documentDataMap[alias]; break; }
-          }
-        }
-      }
-    }
-    if (!docData) continue;
-
-    // Custom quoted path — use the raw path directly as the accessPath
-    if (variable.customAccessPath) {
-      const value = getNestedValue(docData, variable.customAccessPath);
-      if (value !== undefined && value !== null) {
-        result =
-          result.substring(0, variable.startIndex) +
-          String(value) +
-          result.substring(variable.endIndex);
-      }
-      continue;
-    }
-
-    // Find the FieldAspect to get the accessPath
-    const prop = getFieldAspect(familiarSchema, variable.context, variable.path);
-    if (!prop) continue;
-
-    const value = getNestedValue(docData, prop.accessPath);
-
-    if (value !== undefined && value !== null) {
-      result =
-        result.substring(0, variable.startIndex) +
-        String(value) +
-        result.substring(variable.endIndex);
-    }
-  }
-
-  // Unescape literal \# → #, \( → (, \) → ), \, → ,
-  result = result.replace(/\\([#(),])/g, '$1');
-
-  return result;
-}
-
-/**
- * Walk a dotted path on any object to retrieve a nested value.
- * Works with live Foundry documents (getter access) and plain objects alike.
- */
-export function getNestedValue(obj: object, dottedPath: string): unknown {
-  let current: unknown = obj;
-  for (const key of dottedPath.split('.')) {
-    if (current === null || current === undefined || typeof current !== 'object') return undefined;
-    current = (current as Record<string, unknown>)[key];
-  }
-  return current;
-}
-
-/**
- * Factory for FieldAspect that optionally resolves the value
- * from a context object (live document or plain object) using the accessPath.
- *
- * When `context` is provided, the value at `accessPath` is read (including
- * any custom getters) and coerced to the property's type. Without context,
- * only the schema shape is returned (value remains undefined).
- */
-export function fieldAspect<TContext extends DocumentContext>(
-  display: string,
-  type: 'string' | 'number' | 'boolean',
-  accessPath: string,
-  context?: TContext
-): FieldAspect {
-  const prop: FieldAspect = { display, type, accessPath };
-  if (context) {
-    const raw = getNestedValue(context, accessPath);
-    if (raw !== undefined && raw !== null) {
-      prop.value = type === 'number'
-        ? Number(raw)
-        : type === 'boolean'
-          ? (raw ? 'true' : 'false')
-          : String(raw);
-    }
-  }
-  return prop;
-}
-
-/**
- * Walk the familiar tree to find the FieldAspect at a given path.
- */
-function getFieldAspect(context: FamiliarSchema, contextName: string, path: string[]): FieldAspect | null {
-  let contextSchema = context[contextName];
-
-  if (!contextSchema) {
-    const foundKey = Object.keys(context).find(k => context[k].aliases?.includes(contextName));
-    if (foundKey) contextSchema = context[foundKey];
-  }
-
-  if (!contextSchema?.properties) return null;
-
-  let current: unknown = contextSchema.properties;
-  for (const key of path) {
-    if (typeof current !== 'object' || current === null) return null;
-    const obj = current as Record<string, unknown>;
-    if (key in obj) {
-      current = obj[key];
-    } else {
-      // Leaf alias fallback (FieldAspect.aliases)
-      const leafAlias = Object.entries(obj).find(([, v]) =>
-        isFieldAspect(v) && v.aliases?.includes(key)
-      );
-      if (leafAlias) {
-        current = leafAlias[1];
-        continue;
-      }
-      // Branch alias fallback (AspectGroup._aliases)
-      const branchAlias = Object.entries(obj).find(([, v]) =>
-        typeof v === 'object' && v !== null && !isFieldAspect(v)
-        && (v as { _aliases?: string[] })._aliases?.includes(key)
-      );
-      if (branchAlias) {
-        current = branchAlias[1];
-        continue;
-      }
-      // Localized display name fallback
-      const localDisplay = Object.entries(obj).find(([k, v]) => {
-        if (k.startsWith('_')) return false;
-        const localKey = isFieldAspect(v)
-          ? normalizeLabel((v as FieldAspect).display)
-          : normalizeLabel((v as AspectGroup)._display);
-        return localKey === key;
-      });
-      if (localDisplay) {
-        current = localDisplay[1];
-      } else {
-        return null;
-      }
-    }
-  }
-
-  return isFieldAspect(current) ? current : null;
-}
-
-/**
- * Get the value of a property from the familiar context.
- * Uses accessPath to read the value from the document data if available.
- * Falls back to the static value on the FieldAspect.
- */
-export function getPropertyValue(context: FamiliarSchema, contextName: string, path: string[]): string | number | null {
-  const prop = getFieldAspect(context, contextName, path);
-  if (!prop) return null;
-  return prop.value ?? null;
-}
-
-/** Result of a reverse-lookup from a raw document path to the familiar tree. */
-export interface AspectLookupResult {
-  /** The FieldAspect that matched. */
-  aspect: FieldAspect;
-  /** The familiar tree path segments (e.g., ['hp', 'max']). */
-  treePath: string[];
-}
-
-/**
- * Reverse-lookup: given a raw document `accessPath` (e.g. `system.hardness.value`),
- * find the FieldAspect and its familiar tree key path within an AspectGroup.
- *
- * Performs a depth-first search of the group tree, comparing each leaf's
- * `accessPath` against the target.
- */
-export function findAspectByAccessPath(group: AspectGroup, accessPath: string): AspectLookupResult | null {
-  for (const [key, value] of Object.entries(group)) {
-    if (isFieldAspect(value)) {
-      if (value.accessPath === accessPath) {
-        return { aspect: value, treePath: [key] };
-      }
-    } else if (typeof value === 'object' && value !== null) {
-      const nested = findAspectByAccessPath(value as AspectGroup, accessPath);
-      if (nested) {
-        return { aspect: nested.aspect, treePath: [key, ...nested.treePath] };
-      }
-    }
-  }
-  return null;
-}
-
-/**
- * Deep-merge multiple AspectGroups into one.
- *
- * - Nested groups merge recursively.
- * - Leaf conflicts (same key in multiple groups): first group wins.
- * - A leaf in one group and a branch in another: first group wins (no mixing).
- * - Branch metadata (`_display`/`_aliases`, set by the schema walker) is copied
- *   as-is from the first group that declares it — never recursed into. These are
- *   plain strings/string-arrays, not FieldAspect/AspectGroup nodes, so treating
- *   them as branches (as a naive `!isFieldAspect` check would) sends
- *   `Object.entries()` down a string's character indices, which — when two
- *   groups both declare the same metadata on the same branch (e.g. every
- *   ACTOR_TYPES subtype sharing one builder) — degenerates into merging
- *   single-character strings with themselves forever (infinite recursion).
- */
-export function mergeAspectGroups(...groups: AspectGroup[]): AspectGroup {
-  const result: AspectGroup = {};
-  for (const group of groups) {
-    for (const [key, value] of Object.entries(group)) {
-      if (key.startsWith('_')) {
-        // Branch metadata — first group wins, never merged/recursed into.
-        if (result[key] === undefined) result[key] = value;
-        continue;
-      }
-      const existing = result[key];
-      if (existing === undefined) {
-        // New key — take it
-        result[key] = value;
-      } else if (!isFieldAspect(existing) && !isFieldAspect(value)) {
-        // Both are branches — recurse
-        result[key] = mergeAspectGroups(existing as AspectGroup, value as AspectGroup);
-      }
-      // else: conflict (leaf vs leaf, or leaf vs branch) — first wins, skip
-    }
-  }
-  return result;
-}
-
 /**
  * Translate a formula from canonical storage form to the current locale's display form.
  *
@@ -479,7 +34,7 @@ export function mergeAspectGroups(...groups: AspectGroup[]): AspectGroup {
  * Segments that cannot be resolved are left as-is.
  */
 export function localizeFormula(formula: string, schema: FamiliarSchema): string {
-  const variables = extractVariables(formula);
+  const variables = FormulaResolver.extractVariables(formula);
   if (!variables.length) return formula;
 
   let result = formula;
@@ -531,7 +86,7 @@ export function localizeFormula(formula: string, schema: FamiliarSchema): string
  * on formulas that are already canonical.
  */
 export function canonicalizeFormula(formula: string, schema: FamiliarSchema): string {
-  const variables = extractVariables(formula);
+  const variables = FormulaResolver.extractVariables(formula);
   if (!variables.length) return formula;
 
   let result = formula;
@@ -605,292 +160,6 @@ export function canonicalizeFormula(formula: string, schema: FamiliarSchema): st
     result = result.substring(0, v.startIndex) + canonical + result.substring(v.endIndex);
   }
   return result;
-}
-
-/**
- * Validate all variables in a formula
- * @param formula The formula string
- * @param context The familiar context
- * @returns Array of validation errors (empty if valid)
- */
-export function validateFormula(formula: string, context: FamiliarSchema): ValidationError[] {
-  if (!context) return [];
-  const errors: ValidationError[] = [];
-  const variables = extractVariables(formula);
-
-  for (const variable of variables) {
-    // The bare `#conditional` keyword token (immediately followed by `(`) is this
-    // syntax construct, not an invalid context reference — skip normal validation.
-    // Its when()/else() contents are plain text, so any #context.property tokens
-    // nested inside them are still picked up and validated by this same loop.
-    if (isConditionalKeywordToken(formula, variable)) continue;
-
-    const error = validateVariable(variable, context);
-    if (error) {
-      errors.push(error);
-    }
-  }
-
-  for (const block of findConditionalBlocks(formula)) {
-    if (!block.error) continue;
-    errors.push({
-      variable: block.raw,
-      context: 'conditional',
-      path: [],
-      error: game.i18n.localize(`dnd35e.Formula.Errors.conditional.${block.error}`),
-      severity: 'error',
-      index: block.startIndex,
-    });
-  }
-
-  return errors;
-}
-
-/**
- * Substitute #context.property variables using the *schema's cached values*
- * (`FieldAspect.value`) rather than a live document data map. Used for
- * lightweight type-mismatch checks in the editor, where only a FamiliarSchema
- * (not a full documentDataMap) is available.
- *
- * When a variable resolves to a known FieldAspect but has no cached `.value`
- * (e.g. no live parent document — a merged fallback schema built without
- * context, as when editing an orphaned/standalone effect), a type-appropriate
- * placeholder ('0' / 'false' / '""') is substituted instead of leaving the
- * variable unresolved. This still lets grammar/type validation run — e.g.
- * catching `!#item.broken 0` (two adjacent expressions, no operator) — without
- * needing real live data, since the *shape* of a formula doesn't depend on the
- * variable's actual runtime value. Variables with no matching aspect at all
- * (invalid/unresolvable path — already flagged separately by `validateFormula`)
- * or custom quoted paths are left as-is.
- */
-function resolveFormulaFromSchemaValues(formula: string, schema: FamiliarSchema): string {
-  let result = formula;
-  const variables = extractVariables(formula);
-
-  for (let i = variables.length - 1; i >= 0; i--) {
-    const variable = variables[i];
-    if (variable.customAccessPath !== undefined) continue;
-
-    const aspect = getFieldAspect(schema, variable.context, variable.path);
-    if (!aspect) continue;
-
-    const placeholder = aspect.type === 'number'
-      ? '0'
-      : aspect.type === 'boolean'
-        ? 'false'
-        : '""';
-    const value = aspect.value ?? placeholder;
-
-    result =
-      result.substring(0, variable.startIndex) +
-      String(value) +
-      result.substring(variable.endIndex);
-  }
-
-  return result;
-}
-
-/**
- * Check whether a formula's resolved value matches its field's `expectedType`.
- * Surfaces a validation error instead of silently falling back — a `number`-typed
- * field whose formula resolves to a boolean/non-numeric string, or a
- * `boolean`-typed field whose formula isn't a valid comparison/logical
- * expression, both produce an error here.
- *
- * Known variables are substituted with either their live/cached value or a
- * type-appropriate placeholder (see `resolveFormulaFromSchemaValues`), so
- * grammar errors (e.g. `!#item.broken 0`) are still caught even without a live
- * document to resolve real values from.
- *
- * Returns `null` when the type is `'string'` (no coercion possible to fail),
- * the formula is empty, or any variable couldn't be resolved to a known
- * schema aspect at all (invalid/unresolvable path — flagged separately by
- * `validateFormula`).
- */
-export function validateFormulaType(
-  formula: string,
-  context: FamiliarSchema,
-  expectedType: 'string' | 'number' | 'boolean'
-): ValidationError | null {
-  if (!formula || expectedType === 'string') return null;
-
-  const resolved = resolveFormulaFromSchemaValues(formula, context);
-  if (extractVariables(resolved).length > 0) return null;
-
-  if (expectedType === 'number') {
-    const trimmed = resolved.trim();
-    if (!trimmed) return null;
-    if (!Number.isNaN(Number(trimmed))) return null;
-    try {
-      if (!Number.isNaN(Roll.safeEval(trimmed))) return null;
-    } catch {
-      // fall through to error
-    }
-    return {
-      variable: formula,
-      context: '',
-      path: [],
-      error: game.i18n.format('dnd35e.Formula.Errors.notANumber', { resolved }),
-      severity: 'error',
-      index: 0,
-    };
-  }
-
-  // expectedType === 'boolean'
-  try {
-    evaluateBooleanExpression(resolved);
-    return null;
-  } catch {
-    return {
-      variable: formula,
-      context: '',
-      path: [],
-      error: game.i18n.localize('dnd35e.Formula.Errors.notABoolean'),
-      severity: 'error',
-      index: 0,
-    };
-  }
-}
-
-/**
- * Validate a single variable
- * @param variable The FormulaVariable to validate
- * @param context The familiar context
- * @returns ValidationError or null if valid
- */
-function validateVariable(variable: FormulaVariable, context: FamiliarSchema): ValidationError | null {
-  // Custom quoted path — trusted, skip all validation, just flag as warning
-  if (variable.customAccessPath !== undefined) {
-    variable.isValid = true;
-    return {
-      variable: variable.variable,
-      context: variable.context,
-      path: variable.path,
-      error: variable.customAccessPath,
-      severity: 'warning',
-      index: variable.startIndex,
-    };
-  }
-
-  let contextSchema = context[variable.context];
-
-  if (!contextSchema) {
-    // Try to find by alias or localized display name
-    const foundKey = Object.keys(context).find(k =>
-      context[k].aliases?.includes(variable.context)
-      || (normalizeLabel(context[k].display) ?? '') === variable.context
-    );
-    if (foundKey) {
-      contextSchema = context[foundKey];
-    }
-  }
-
-  if (!contextSchema || typeof contextSchema !== 'object' || !('properties' in contextSchema)) {
-    return {
-      variable: variable.variable,
-      context: variable.context,
-      path: variable.path,
-      error: game.i18n.format('dnd35e.Formula.Errors.contextNotFound', { context: variable.context }),
-      severity: 'error',
-      index: variable.startIndex,
-    };
-  }
-
-  // Bare context reference without a property path (e.g. #owner) is incomplete
-  if (variable.path.length === 0) {
-    return {
-      variable: variable.variable,
-      context: variable.context,
-      path: variable.path,
-      error: game.i18n.format('dnd35e.Formula.Errors.incompleteReference', { context: variable.context }),
-      severity: 'warning',
-      index: variable.startIndex,
-    };
-  }
-
-  let current: unknown = (contextSchema as { properties: AspectGroup }).properties;
-  let pathTraversed: string[] = [];
-
-  for (const key of variable.path) {
-    if (typeof current !== 'object' || current === null) {
-      return {
-        variable: variable.variable,
-        context: variable.context,
-        path: variable.path,
-        error: game.i18n.format('dnd35e.Formula.Errors.propertyNotFound', {
-          key,
-          path: `${variable.context}${pathTraversed.length > 0
-            ? '.' + pathTraversed.join('.')
-            : ''}`,
-        }),
-        severity: 'error',
-        index: variable.startIndex,
-      };
-    }
-
-    const obj = current as Record<string, unknown>;
-    if (key in obj) {
-      current = obj[key];
-    } else {
-      // Alias fallback — check leaf aliases then branch _aliases
-      const leafAlias = Object.entries(obj).find(([, v]) =>
-        isFieldAspect(v) && v.aliases?.includes(key)
-      );
-      if (leafAlias) {
-        current = leafAlias[1];
-      } else {
-        const branchAlias = Object.entries(obj).find(([, v]) =>
-          typeof v === 'object' && v !== null && !isFieldAspect(v)
-          && (v as { _aliases?: string[] })._aliases?.includes(key)
-        );
-        if (branchAlias) {
-          current = branchAlias[1];
-        } else {
-          // Localized display name fallback
-          const localDisplay = Object.entries(obj).find(([k, v]) => {
-            if (k.startsWith('_')) return false;
-            const localKey = isFieldAspect(v)
-              ? normalizeLabel((v as FieldAspect).display)
-              : normalizeLabel((v as AspectGroup)._display);
-            return localKey === key;
-          });
-          if (localDisplay) {
-            current = localDisplay[1];
-          } else {
-            return {
-              variable: variable.variable,
-              context: variable.context,
-              path: variable.path,
-              error: game.i18n.format('dnd35e.Formula.Errors.propertyNotFound', {
-                key,
-                path: `${variable.context}${pathTraversed.length > 0
-                  ? '.' + pathTraversed.join('.')
-                  : ''}`,
-              }),
-              severity: 'error',
-              index: variable.startIndex,
-            };
-          }
-        }
-      }
-    }
-    pathTraversed.push(key);
-  }
-
-  // The path must resolve to a leaf property, not an intermediate object
-  if (!isFieldAspect(current)) {
-    return {
-      variable: variable.variable,
-      context: variable.context,
-      path: variable.path,
-      error: game.i18n.format('dnd35e.Formula.Errors.notAProperty', { variable: variable.variable }),
-      severity: 'warning',
-      index: variable.startIndex,
-    };
-  }
-
-  variable.isValid = true;
-  return null;
 }
 
 /** Configuration for `getAutocompleteOptions()`. */
@@ -1093,7 +362,7 @@ export function getAutocompleteOptions(
  * @returns The variable at that position or null
  */
 export function extractVariableAtPosition(formula: string, position: number): FormulaVariable | null {
-  const variables = extractVariables(formula);
+  const variables = FormulaResolver.extractVariables(formula);
   return variables.find(v => position >= v.startIndex && position <= v.endIndex) || null;
 }
 
@@ -1203,27 +472,240 @@ function computeMatchedParenIndices(formula: string): Set<number> {
   return matched;
 }
 
+/** Blue ('valid') / yellow ('partial', still typing) / red ('invalid') — shared
+ * tri-state used for every highlighted operator (`!`, comparisons, `&&`/`||`). */
+type OperandState = 'valid' | 'partial' | 'invalid';
+
+/**
+ * Escalate a 'partial' (still-typing) state to 'invalid' once the formula
+ * field is no longer focused — while typing, an incomplete operand is just
+ * "not done yet" (yellow); once the user has moved on, it's a real problem
+ * (red). 'valid' and 'invalid' are unaffected — they don't depend on focus.
+ */
+function escalateOnBlur(state: OperandState, isFocused: boolean): OperandState {
+  return !isFocused && state === 'partial' ? 'invalid' : state;
+}
+
+function stateToClass(state: OperandState): string {
+  if (state === 'partial') return ' is-warning';
+  if (state === 'invalid') return ' is-error';
+  return '';
+}
+
+/**
+ * Classify the operand immediately to the RIGHT of an operator at `index`
+ * (the position right after the operator's last character), scanning
+ * forward past whitespace, unary `!`/`-`/`+` prefixes, to the operand itself:
+ *
+ * - `'valid'` — a complete `#context.property` token, a matched `(...)`
+ *   group, a `true`/`false` literal, a closed quoted string, or (when
+ *   `strict` is false) a bare number/IDENT.
+ * - `'partial'` — nothing left to scan (formula ends here), or an
+ *   in-progress operand (unclosed quote, bare context reference with no
+ *   property path yet, unmatched/still-being-typed open paren).
+ * - `'invalid'` — a dangling closing delimiter with nothing meaningful
+ *   before it, or (when `strict` is true, used for `!`) plain text/a raw
+ *   number — syntactically fine to the evaluator, but rarely what the user
+ *   means to negate.
+ *
+ * `strict` distinguishes `!`'s stricter "does this operand make logical
+ * sense to negate" rule from comparison/`&&`/`||`'s more permissive "is
+ * there a complete literal here" rule (comparisons routinely compare raw
+ * numbers/strings, e.g. `Longsword != Dagger`).
+ */
+function classifyOperandForward(
+  formula: string,
+  index: number,
+  tokens: FormulaToken[],
+  matchedParenIndices: Set<number>,
+  errors: ValidationError[],
+  strict: boolean
+): OperandState {
+  let idx = index;
+  while (idx < formula.length && /[\s!]/.test(formula[idx])) idx++;
+  while (idx < formula.length && /[-+]/.test(formula[idx])) {
+    idx++;
+    while (idx < formula.length && /\s/.test(formula[idx])) idx++;
+  }
+
+  if (idx >= formula.length) return 'partial';
+
+  const ch = formula[idx];
+
+  if (ch === '#') {
+    const variableToken = tokens.find(t => t.type === 'variable' && t.startIndex === idx);
+    if (!variableToken) return 'partial';
+    if (variableToken.partial) return 'partial';
+    const matchingError = errors.find(e => e.index === variableToken.startIndex);
+    if (!matchingError) return 'valid';
+    return matchingError.severity === 'warning' ? 'partial' : 'invalid';
+  }
+
+  if (ch === '(') return matchedParenIndices.has(idx) ? 'valid' : 'partial';
+  if (ch === ')' || ch === '&' || ch === '|') return 'invalid';
+
+  if (ch === '\'' || ch === '"') {
+    const closeIdx = formula.indexOf(ch, idx + 1);
+    return closeIdx === -1 ? 'partial' : 'valid';
+  }
+
+  if (/^(?:true|false)\b/.test(formula.slice(idx))) return 'valid';
+
+  if (strict) return 'invalid';
+
+  // Lenient (comparisons / &&/||): a bare number or bareword IDENT counts
+  // as a valid, complete operand.
+  return /\S/.test(ch) ? 'valid' : 'invalid';
+}
+
+/**
+ * Classify the operand immediately to the LEFT of an operator at `index`
+ * (the operator's own start position), scanning backward past whitespace.
+ *
+ * There is no 'partial' state on the left — by the time an operator has
+ * been typed, whatever precedes it is already "finished" (the user has
+ * moved on); a missing/broken left operand is always `'invalid'`.
+ */
+function classifyOperandBackward(
+  formula: string,
+  index: number,
+  tokens: FormulaToken[],
+  matchedParenIndices: Set<number>,
+  errors: ValidationError[]
+): 'valid' | 'invalid' {
+  let idx = index;
+  while (idx > 0 && /\s/.test(formula[idx - 1])) idx--;
+
+  if (idx === 0) return 'invalid';
+
+  const prev = formula[idx - 1];
+
+  if (prev === ')') return matchedParenIndices.has(idx - 1) ? 'valid' : 'invalid';
+  if (prev === '(' || prev === '&' || prev === '|') return 'invalid';
+
+  if (prev === '\'' || prev === '"') {
+    const openIdx = formula.lastIndexOf(prev, idx - 2);
+    return openIdx === -1 ? 'invalid' : 'valid';
+  }
+
+  const variableToken = tokens.find(t => t.type === 'variable' && t.endIndex === idx);
+  if (variableToken) {
+    if (variableToken.partial) return 'invalid';
+    return errors.find(e => e.index === variableToken.startIndex) ? 'invalid' : 'valid';
+  }
+
+  // Bareword/number/keyword tail ending exactly here.
+  return /[^\s()!<>=&|'"]/.test(prev) ? 'valid' : 'invalid';
+}
+
+/**
+ * Classify a `!` (logical NOT) operator at `bangIndex` by what it negates.
+ * Thin wrapper over `classifyOperandForward` in strict mode (chained `!!...`
+ * is read through correctly since the forward-scan already skips leading
+ * `!`/whitespace).
+ */
+function classifyBangOperator(
+  formula: string,
+  bangIndex: number,
+  tokens: FormulaToken[],
+  matchedParenIndices: Set<number>,
+  errors: ValidationError[]
+): OperandState {
+  return classifyOperandForward(formula, bangIndex + 1, tokens, matchedParenIndices, errors, true);
+}
+
+/**
+ * Classify a binary operator (comparison `>`/`<`/`>=`/`<=`/`==`/`!=`, or
+ * logical `&&`/`||`) at `[opIndex, opIndex + opLength)` by combining its
+ * left and right operand states: red wins if either side is definitively
+ * broken, otherwise yellow wins if the right side is still being typed,
+ * otherwise blue.
+ */
+function classifyBinaryOperator(
+  formula: string,
+  opIndex: number,
+  opLength: number,
+  tokens: FormulaToken[],
+  matchedParenIndices: Set<number>,
+  errors: ValidationError[]
+): OperandState {
+  const left = classifyOperandBackward(formula, opIndex, tokens, matchedParenIndices, errors);
+  const right = classifyOperandForward(formula, opIndex + opLength, tokens, matchedParenIndices, errors, false);
+  if (left === 'invalid' || right === 'invalid') return 'invalid';
+  if (right === 'partial') return 'partial';
+  return 'valid';
+}
+
+/**
+ * Classify a malformed `$conditional(...)` block by its `ConditionalBlockError`:
+ *
+ * - `'partial'` (yellow, still typing) — `unbalancedParens`/`missingElse`
+ *   are exactly the states you'd expect mid-edit (haven't closed the outer
+ *   paren yet / haven't gotten to `else()` yet).
+ * - `'invalid'` (red, always) — `multipleElse`/`whenArgCount`/`elseArgCount`
+ *   are genuinely malformed regardless of focus (a closed clause with the
+ *   wrong shape isn't "still typing", it's just wrong).
+ */
+function conditionalErrorState(error: ConditionalBlockError): OperandState {
+  return error === 'unbalancedParens' || error === 'missingElse' ? 'partial' : 'invalid';
+}
+
 export function renderFormulaHTML(
   formula: string,
   tokens: FormulaToken[],
   errors: ValidationError[],
-  familiarSchema?: FamiliarSchema
+  familiarSchema?: FamiliarSchema,
+  isFocused = true
 ): string {
   let variableIndex = 0;
   const matchedParenIndices = computeMatchedParenIndices(formula);
+  const conditionalBlocks = FormulaResolver.findConditionalBlocks(formula);
+  // Longest-alternative-first so `>=`/`<=`/`==`/`!=`/`&&`/`||` win over their
+  // single-char prefixes (e.g. `!=` over bare `!`). `$conditional`/`when`/`else`
+  // only match when followed by optional whitespace + `(` (the lookahead leaves
+  // the `(` itself for its own delimiter branch) so stray prose-like text
+  // elsewhere in a formula isn't mistaken for the `$conditional(...)` clause
+  // keywords. `$and`/`$or` are keyword aliases for `&&`/`||` (word-bounded so
+  // they don't clip a longer bareword like `$android`).
+  const OPERATOR_SPLIT =
+    /(\(|\)|>=|<=|==|!=|&&|\|\||[!<>]|\$conditional(?=\s*\()|\bwhen(?=\s*\()|\belse(?=\s*\()|\$and\b|\$or\b)/i;
 
   return tokens
     .map(token => {
       if (token.type === 'text') {
-        // Wrap `(`/`)` individually so each can be colored by its matched state;
-        // everything else in the text run passes through unhighlighted.
-        const pieces = token.value.split(/([()])/);
+        // Wrap each operator/paren/keyword individually so it can be colored
+        // by its own state; everything else in the text run passes through
+        // unhighlighted.
+        const pieces = token.value.split(OPERATOR_SPLIT);
         let out = '';
         let cursor = token.startIndex;
         for (const piece of pieces) {
           if (piece === '(' || piece === ')') {
-            const stateClass = matchedParenIndices.has(cursor) ? '' : ' is-warning';
-            out += `<span class="formula-paren${stateClass}" data-start="${cursor}" data-end="${cursor + 1}">${piece}</span>`;
+            const state = escalateOnBlur(matchedParenIndices.has(cursor) ? 'valid' : 'partial', isFocused);
+            out += `<span class="formula-paren${stateToClass(state)}" data-start="${cursor}" data-end="${cursor + piece.length}">${piece}</span>`;
+          } else if (piece === '!') {
+            const state = escalateOnBlur(classifyBangOperator(formula, cursor, tokens, matchedParenIndices, errors), isFocused);
+            out += `<span class="formula-operator${stateToClass(state)}" data-start="${cursor}" data-end="${cursor + piece.length}">!</span>`;
+          } else if (/^\$conditional$/i.test(piece)) {
+            const block = conditionalBlocks.find(b => b.startIndex === cursor);
+            const state = escalateOnBlur(block?.error ? conditionalErrorState(block.error) : 'valid', isFocused);
+            const keywordError = errors.find(e => e.index === cursor);
+            const titleAttr = keywordError?.error ? ` title="${escapeHTML(keywordError.error)}"` : '';
+            out += `<span class="formula-keyword${stateToClass(state)}"${titleAttr} data-start="${cursor}" data-end="${cursor + piece.length}">${escapeHTML(piece)}</span>`;
+          } else if (/^(?:when|else)$/i.test(piece)) {
+            out += `<span class="formula-keyword" data-start="${cursor}" data-end="${cursor + piece.length}">${escapeHTML(piece)}</span>`;
+          } else if (/^\$(?:and|or)$/i.test(piece)) {
+            const state = escalateOnBlur(
+              classifyBinaryOperator(formula, cursor, piece.length, tokens, matchedParenIndices, errors),
+              isFocused
+            );
+            out += `<span class="formula-operator${stateToClass(state)}" data-start="${cursor}" data-end="${cursor + piece.length}">${escapeHTML(piece)}</span>`;
+          } else if (['>=', '<=', '==', '!=', '&&', '||', '<', '>'].includes(piece)) {
+            const state = escalateOnBlur(
+              classifyBinaryOperator(formula, cursor, piece.length, tokens, matchedParenIndices, errors),
+              isFocused
+            );
+            out += `<span class="formula-operator${stateToClass(state)}" data-start="${cursor}" data-end="${cursor + piece.length}">${escapeHTML(piece)}</span>`;
           } else {
             out += escapeHTML(piece);
           }
@@ -1242,8 +724,9 @@ export function renderFormulaHTML(
           // Unclosed quote terminated by space → all red
           return `<span class="formula-variable is-error" title="${escapeHTML(game.i18n.localize('dnd35e.Formula.Errors.invalidVariable'))}" data-var-index="${varIdx}" data-start="${token.startIndex}" data-end="${token.endIndex}">${escapeHTML(token.value)}</span>`;
         }
-        // Still typing custom path → ALL yellow
-        return `<span class="formula-variable is-warning" data-var-index="${varIdx}" data-start="${token.startIndex}" data-end="${token.endIndex}">${escapeHTML(token.value)}</span>`;
+        // Still typing custom path → yellow while focused, red once blurred
+        const stillTypingClass = stateToClass(escalateOnBlur('partial', isFocused));
+        return `<span class="formula-variable${stillTypingClass}" data-var-index="${varIdx}" data-start="${token.startIndex}" data-end="${token.endIndex}">${escapeHTML(token.value)}</span>`;
       }
 
       // ── CUSTOM PATH (closed quote, e.g. #self.'system.isIdentified') → always yellow with tooltip ──
@@ -1262,11 +745,11 @@ export function renderFormulaHTML(
           const contextName = parts[0];
           const path = parts.slice(1);
           if (path.length > 0) {
-            const value = getPropertyValue(familiarSchema, contextName, path);
+            const value = FormulaResolver.getPropertyValue(familiarSchema, contextName, path);
             if (value !== null && value !== undefined) {
               tooltip = escapeHTML(String(value));
             } else {
-              const prop = getFieldAspect(familiarSchema, contextName, path);
+              const prop = FormulaResolver.getFieldAspect(familiarSchema, contextName, path);
               if (prop) tooltip = escapeHTML(prop.accessPath);
             }
           } else {
@@ -1288,7 +771,7 @@ export function renderFormulaHTML(
       // In-progress + error: check if last segment partially matches familiar
       if (familiarSchema && matchingError.severity === 'error') {
         const body = token.value.substring(1);
-        const { context: ctxName, path } = parseVariableSegments(body);
+        const { context: ctxName, path } = FormulaResolver.parseVariableSegments(body);
 
         if (path.length > 0 && hasPartialAspectMatch(familiarSchema, ctxName, path)) {
           // Partial match → all blue, no tooltip (still typing)
@@ -1306,10 +789,10 @@ export function renderFormulaHTML(
         }
       }
 
-      // Fallback: show as warning (bare context, incomplete, etc.)
-      const isWarning = matchingError.severity === 'warning';
-      const stateClass = isWarning ? ' is-warning' : ' is-error';
-      return `<span class="formula-variable${stateClass}" data-var-index="${varIdx}" data-start="${token.startIndex}" data-end="${token.endIndex}">${escapeHTML(token.value)}</span>`;
+      // Fallback: show as warning (bare context, incomplete, etc.) while
+      // focused, escalating to an error once the field loses focus.
+      const fallbackState = escalateOnBlur(matchingError.severity === 'warning' ? 'partial' : 'invalid', isFocused);
+      return `<span class="formula-variable${stateToClass(fallbackState)}" data-var-index="${varIdx}" data-start="${token.startIndex}" data-end="${token.endIndex}">${escapeHTML(token.value)}</span>`;
     })
     .join('');
 }
@@ -1318,7 +801,7 @@ export function renderFormulaDisplayHTML(
   formula: string,
   familiarSchema?: FamiliarSchema
 ): string {
-  const tokens = parseFormula(formula);
+  const tokens = FormulaResolver.parseFormula(formula);
 
   return tokens
     .map(token => {
@@ -1331,12 +814,12 @@ export function renderFormulaDisplayHTML(
       }
 
       const body = token.value.substring(1);
-      const { context, path } = parseVariableSegments(body);
+      const { context, path } = FormulaResolver.parseVariableSegments(body);
       if (!familiarSchema || path.length === 0) {
         return `<span class="formula-variable">${escapeHTML(token.value)}</span>`;
       }
 
-      const value = getPropertyValue(familiarSchema, context, path);
+      const value = FormulaResolver.getPropertyValue(familiarSchema, context, path);
       const displayValue = value !== null && value !== undefined ? String(value) : token.value;
       return `<span class="formula-variable">${escapeHTML(displayValue)}</span>`;
     })
@@ -1459,7 +942,7 @@ export const resolveFormulaField = (
   if (!formulaData?.formula) return fallbackName;
 
   const familiarSchema = buildContextFromFormula(formulaData);
-  return resolveFormula(formulaData.formula, familiarSchema, documentDataMap);
+  return FormulaResolver.resolveFormula(formulaData.formula, familiarSchema, documentDataMap);
 };
 
 /**

--- a/src/lang/en/common.json
+++ b/src/lang/en/common.json
@@ -100,6 +100,24 @@
       "availableContexts": "Available Contexts",
       "Context": {
         "Self": "Self"
+      },
+      "Errors": {
+        "notANumber": "Formula does not resolve to a number (got \"{resolved}\")",
+        "notABoolean": "Formula does not resolve to a valid boolean expression",
+        "contextNotFound": "Context '{context}' not found",
+        "incompleteReference": "Incomplete reference — specify a property (e.g. #{context}.name)",
+        "propertyNotFound": "Property '{key}' not found on {path}",
+        "notAProperty": "'{variable}' is an object, not a property — specify a deeper path",
+        "invalidVariable": "Invalid variable",
+        "unknownPathWarning": "Warning unknown path: {path}",
+        "contextTooltip": "Context: {context}",
+        "conditional": {
+          "unbalancedParens": "#conditional(...) has unbalanced parentheses",
+          "missingElse": "#conditional(...) is missing a required else(...) clause",
+          "multipleElse": "#conditional(...) has more than one else(...) clause",
+          "whenArgCount": "when(...) requires exactly two arguments: when(condition, value)",
+          "elseArgCount": "else(...) requires exactly one argument: else(value)"
+        }
       }
     },
     "DOCUMENT": {

--- a/src/lang/en/common.json
+++ b/src/lang/en/common.json
@@ -112,9 +112,9 @@
         "unknownPathWarning": "Warning unknown path: {path}",
         "contextTooltip": "Context: {context}",
         "conditional": {
-          "unbalancedParens": "#conditional(...) has unbalanced parentheses",
-          "missingElse": "#conditional(...) is missing a required else(...) clause",
-          "multipleElse": "#conditional(...) has more than one else(...) clause",
+          "unbalancedParens": "$conditional(...) has unbalanced parentheses",
+          "missingElse": "$conditional(...) is missing a required else(...) clause",
+          "multipleElse": "$conditional(...) has more than one else(...) clause",
           "whenArgCount": "when(...) requires exactly two arguments: when(condition, value)",
           "elseArgCount": "else(...) requires exactly one argument: else(value)"
         }

--- a/src/lang/en/effects.json
+++ b/src/lang/en/effects.json
@@ -48,6 +48,7 @@
       "Headers": {
         "Actions": "Actions",
         "BonusType": "Bonus",
+        "Condition": "Condition",
         "Field": "Field",
         "Priority": "Priority",
         "Type": "Type",
@@ -60,7 +61,6 @@
         "Actor": "Actor"
       },
       "ChangeMode": {
-        "Familiar": "Formula Familiar",
         "Mask": "Mask"
       },
       "General": {

--- a/src/settings/combat/deathThreshold.mts
+++ b/src/settings/combat/deathThreshold.mts
@@ -49,15 +49,11 @@ const resolveDeathThresholdValue = (setting: DeathThresholdSetting, actor?: Acto
     )
     : normalizedFormula;
 
-  const safeEval = (Roll as unknown as { safeEval?: (formula: string) => number }).safeEval;
-
-  if (safeEval) {
-    try {
-      const evaluated = safeEval(resolvedFormula);
-      if (Number.isFinite(evaluated)) return evaluated;
-    } catch {
-      // Fall through to numeric parsing when formula evaluation fails.
-    }
+  try {
+    const evaluated = Roll.safeEval(resolvedFormula);
+    if (Number.isFinite(evaluated)) return evaluated;
+  } catch {
+    // Fall through to numeric parsing when formula evaluation fails.
   }
 
   const parsed = Number.parseFloat(resolvedFormula);

--- a/src/styles/_formula-familiar.scss
+++ b/src/styles/_formula-familiar.scss
@@ -91,6 +91,22 @@
   text-underline-offset: 3px;
 }
 
+/* Parenthesis pairing — blue once both `(` and its matching `)` exist, yellow
+   while unmatched (still being typed, or genuinely mismatched). */
+.familiar-overlay-highlight .formula-paren,
+.formula-display .formula-paren {
+  background: rgba(102, 166, 255, 0.18);
+  color: #66b3ff;
+  border-radius: 2px;
+  padding: 1px 0;
+}
+
+.familiar-overlay-highlight .formula-paren.is-warning,
+.formula-display .formula-paren.is-warning {
+  background: rgba(255, 200, 50, 0.15);
+  color: #e6c44d;
+}
+
 /**
  * Formula editor input + highlight overlay (GLOBAL, not scoped).
  *

--- a/src/styles/_formula-familiar.scss
+++ b/src/styles/_formula-familiar.scss
@@ -107,6 +107,70 @@
   color: #e6c44d;
 }
 
+.familiar-overlay-highlight .formula-paren.is-error,
+.formula-display .formula-paren.is-error {
+  background: rgba(255, 100, 100, 0.2);
+  color: #ff9999;
+}
+
+/* `!`, comparison (`<`/`>`/`>=`/`<=`/`==`/`!=`), and logical (`&&`/`||`)
+   operators — blue when both operand slots are complete/valid, yellow while
+   the trailing operand is still being typed (formula ends right after the
+   operator, an unclosed quote, an unmatched paren), red when an operand slot
+   is missing/broken. See `classifyBangOperator()`/`classifyBinaryOperator()`
+   in `utils.mts`. Also escalates from yellow to red once the field loses
+   focus (`escalateOnBlur()`) — "still typing" only applies while editing. */
+.familiar-overlay-highlight .formula-operator,
+.formula-display .formula-operator {
+  background: rgba(102, 166, 255, 0.18);
+  color: #66b3ff;
+  border-radius: 2px;
+  padding: 1px 0;
+}
+
+.familiar-overlay-highlight .formula-operator.is-warning,
+.formula-display .formula-operator.is-warning {
+  background: rgba(255, 200, 50, 0.15);
+  color: #e6c44d;
+}
+
+.familiar-overlay-highlight .formula-operator.is-error,
+.formula-display .formula-operator.is-error {
+  background: rgba(255, 100, 100, 0.2);
+  color: #ff9999;
+}
+
+/* `$conditional`/`when(`/`else(` keywords — a distinct purple, not blue,
+   since they're structural syntax (like a plain-language "if/then"), not a
+   real data reference. `$conditional` itself still escalates to yellow/red
+   when its block is malformed (unbalanced parens, missing/duplicate else(),
+   wrong arg count — see `conditionalErrorState()` in `utils.mts`), with the
+   specific error as its tooltip. `when(`/`else(` are always plain purple —
+   validity is only tracked at the `$conditional` token level. `$and`/`$or`
+   (keyword aliases for `&&`/`||`) render as `.formula-operator`, not
+   `.formula-keyword` — they're logical operators, not control-flow syntax. */
+.familiar-overlay-highlight .formula-keyword,
+.formula-display .formula-keyword {
+  background: rgba(199, 146, 234, 0.18);
+  color: #c792ea;
+  border-radius: 2px;
+  padding: 1px 0;
+}
+
+.familiar-overlay-highlight .formula-keyword.is-warning,
+.formula-display .formula-keyword.is-warning {
+  background: rgba(255, 200, 50, 0.15);
+  color: #e6c44d;
+}
+
+.familiar-overlay-highlight .formula-keyword.is-error,
+.formula-display .formula-keyword.is-error {
+  background: rgba(255, 100, 100, 0.2);
+  color: #ff9999;
+  text-decoration: wavy underline rgba(255, 100, 100, 0.6);
+  text-underline-offset: 3px;
+}
+
 /**
  * Formula editor input + highlight overlay (GLOBAL, not scoped).
  *

--- a/src/vue/components/fields/formGroups/AspectPicker.vue
+++ b/src/vue/components/fields/formGroups/AspectPicker.vue
@@ -51,10 +51,19 @@
     placeholder: { type: String, default: 'Select property...' },
     /** Form field name attribute */
     name: { type: String, default: undefined },
+    /**
+     * Suppress the auto-generated "Available Contexts: [...]" hint text.
+     * Used when a consumer renders that hint itself once, shared across
+     * several sibling fields (e.g. the AE Changes table's row-context line).
+     * Validation errors still surface via `update:error` regardless.
+     */
+    hideContextHint: { type: Boolean, default: false },
   });
 
   const emit = defineEmits<{
     'update:modelValue': [value: string];
+    /** Current validation error message for this field, or null when valid. */
+    'update:error': [error: string | null];
   }>();
 
   const familiarVerticalGap = 2;
@@ -147,13 +156,32 @@
   });
 
   const dynamicHint = computed(() => {
+    if (props.hideContextHint) return '';
     if (!props.familiarContext) return '';
     const ctx = wrappedSchema.value[props.contextName];
     const displayName = ctx?.display ?? (props.contextName.charAt(0).toUpperCase() + props.contextName.slice(1));
     return `Available Contexts: [${displayName}]`;
   });
 
-  const displayHint = computed(() => props.disabled ? '' : dynamicHint.value);
+  // Unresolvable key errors carry an empty context (they aren't tied to a specific
+  // #context.property variable) — exposed separately so consumers can surface it
+  // (e.g. combined into a shared row-context error line) even when the dynamic
+  // context hint itself is suppressed via `hideContextHint`.
+  const currentError = computed((): string | null => {
+    const keyError = validationErrors.value.find(e => e.context === '' && e.severity === 'error');
+    return keyError?.error ?? null;
+  });
+
+  const displayHint = computed(() => {
+    if (props.disabled) return '';
+    // Suppressed when the context hint is hidden — the consumer (e.g. the AE
+    // Changes table row) is already showing this error via the `update:error`
+    // emit in a shared line.
+    if (currentError.value && !props.hideContextHint) return currentError.value;
+    return dynamicHint.value;
+  });
+
+  watch(currentError, (error) => emit('update:error', error), { immediate: true });
 
   // Track whether user is actively editing
   let isUserEditing = false;
@@ -173,7 +201,28 @@
       return;
     }
 
-    validationErrors.value = validateFormula(displayValue.value, wrappedSchema.value);
+    const errors = validateFormula(displayValue.value, wrappedSchema.value);
+
+    // A stored raw path (not '#context.property' syntax) that can't be resolved in the
+    // current context — e.g. right after switching the Target dropdown — isn't caught by
+    // validateFormula's token-based extraction (no '#' tokens to inspect). Surface it as
+    // an explicit error instead of silently leaving the field looking valid.
+    if (
+      errors.length === 0
+      && props.modelValue
+      && !findAspectByAccessPath(props.familiarContext.properties, props.modelValue)
+    ) {
+      errors.push({
+        variable: props.modelValue,
+        context: '',
+        path: [],
+        error: game.i18n.format('dnd35e.Formula.Errors.propertyNotFound', { key: props.modelValue, path: props.contextName }),
+        severity: 'error',
+        index: 0,
+      });
+    }
+
+    validationErrors.value = errors;
   }
 
   function syncScroll() {

--- a/src/vue/components/fields/formGroups/AspectPicker.vue
+++ b/src/vue/components/fields/formGroups/AspectPicker.vue
@@ -32,9 +32,12 @@
 </template>
 
 <script setup lang="ts">
+  import { FormulaResolver } from '@helpers/formulae/FormulaResolver.mjs';
   import type { AutocompleteOption, FamiliarContext, FamiliarSchema, ValidationError } from '@helpers/formulae/types.mjs';
   import { useFamiliarOverlayInput } from '@helpers/formulae/useFamiliarOverlayInput.mjs';
-  import { canonicalizeFormula, findAspectByAccessPath, localizeFormula, parseFormula, renderFormulaHTML, validateFormula } from '@helpers/formulae/utils.mjs';
+  import { canonicalizeFormula, localizeFormula, renderFormulaHTML } from '@helpers/formulae/utils.mjs';
+
+  const { findAspectByAccessPath, parseFormula, validateFormula } = FormulaResolver;
   import FamiliarOverlayInput from '@vc/fields/formGroups/FamiliarOverlayInput.vue';
   import { computed, nextTick, onUnmounted, type PropType, ref, watch } from 'vue';
 

--- a/tests/setup.mts
+++ b/tests/setup.mts
@@ -64,6 +64,28 @@ function mergeObject<T extends Record<string, any>> (
   return output;
 }
 
+// Shared between the bare `ActiveEffect` global (used by e.g. EffectChangesList.vue's
+// `ActiveEffect.CHANGE_TYPES`) and `foundry.documents.ActiveEffect` (used by
+// ActorDnd35e.mts's `foundry.documents.ActiveEffect.CHANGE_PHASES`) — real Foundry exposes
+// both as the same class, so the stub must too, to keep them consistent.
+class ActiveEffectStub {
+  static metadata = {};
+  static CHANGE_PHASES: Record<string, { label: string; hint: string }> = {
+    initial: { label: '', hint: '' },
+    final: { label: '', hint: '' },
+  };
+  static CHANGE_TYPES: Record<string, { label: string; defaultPriority?: number }> = {
+    add: { label: 'EFFECT.CHANGE.TYPES.add', defaultPriority: 10 },
+  };
+  constructor (..._args: any[]) {}
+  _onCreate (..._args: any[]): void {}
+  _onDelete (..._args: any[]): void {}
+  async _preCreate (..._args: any[]): Promise<boolean | void> { return true; }
+  updateSource (..._args: any[]): void {}
+  async update (..._args: any[]): Promise<this> { return this; }
+}
+(globalThis as any).ActiveEffect = ActiveEffectStub;
+
 (globalThis as any).foundry = {
   utils: {
     Color: class {
@@ -103,15 +125,7 @@ function mergeObject<T extends Record<string, any>> (
   documents: {
     // Constructor-only; only used as a generic type argument in source.
     Item: class {},
-    ActiveEffect: class {
-      static metadata = {};
-      constructor (..._args: any[]) {}
-      _onCreate (..._args: any[]): void {}
-      _onDelete (..._args: any[]): void {}
-      async _preCreate (..._args: any[]): Promise<boolean | void> { return true; }
-      updateSource (..._args: any[]): void {}
-      async update (..._args: any[]): Promise<this> { return this; }
-    },
+    ActiveEffect: ActiveEffectStub,
   },
   applications: {
     // Application classes pulled in via deep imports (e.g. settings menus
@@ -144,13 +158,27 @@ function mergeObject<T extends Record<string, any>> (
       SchemaField: class { constructor (public fields: any, public options: any = {}) {} },
       ArrayField: class { constructor (public element: any, public options: any = {}) {} },
       ObjectField: class { constructor (public options: any = {}) {} },
+      AnyField: class { constructor (public options: any = {}) {} },
+      SetField: class { constructor (public element: any, public options: any = {}) {} },
     },
   },
 };
 
 // --- Roll ----------------------------------------------------------------
+// The real Foundry `Roll.safeEval` reads `this.MATH_PROXY` internally, so calling
+// it detached from `Roll` (e.g. `const fn = Roll.safeEval; fn(x)` instead of
+// `Roll.safeEval(x)`) silently breaks it in production. Enforce correct `this`
+// binding here with a regular (non-arrow) function so any future regression of
+// that bug class fails loudly in unit tests instead of passing silently.
 (globalThis as any).Roll = {
-  safeEval: vi.fn((expr: string) => {
+  safeEval: vi.fn(function (this: unknown, expr: string) {
+    if (this !== (globalThis as any).Roll) {
+      throw new Error(
+        'Roll.safeEval stub was called without `this` bound to `Roll` (e.g. via a destructured ' +
+        'reference like `const fn = Roll.safeEval; fn(expr)`). Call it as `Roll.safeEval(expr)` — ' +
+        'the real implementation depends on `this.MATH_PROXY` and breaks silently otherwise.'
+      );
+    }
     // Minimal stub — tests that need real evaluation should override per-test.
     const n = Number(expr);
     return Number.isFinite(n) ? n : 0;

--- a/tests/unit/components/AspectPicker.test.mts
+++ b/tests/unit/components/AspectPicker.test.mts
@@ -1,0 +1,82 @@
+// @vitest-environment happy-dom
+
+import type { FamiliarContext } from '@helpers/formulae/types.mjs';
+import AspectPicker from '@vc/fields/formGroups/AspectPicker.vue';
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import { defineComponent, h, nextTick } from 'vue';
+
+/**
+ * Regression tests for `hideContextHint` suppressing AspectPicker's own error display
+ * (fixing a duplicate error message shown both in this field's hint AND in a consumer's
+ * shared context/error line, e.g. the AE Changes table row).
+ *
+ * `updateValidation()` only runs on user interaction or a `modelValue`/`familiarContext`
+ * change (no initial validation on mount) — mount with a resolvable `modelValue`, then
+ * change it to an unresolvable raw path to trigger the "property not found" error via the
+ * real `validateFormula`/`findAspectByAccessPath` pipeline (not mocked).
+ */
+
+const familiarContext: FamiliarContext = {
+  properties: {
+    flag: { type: 'boolean', accessPath: 'system.flag', value: 'true' },
+  },
+};
+
+// AspectPicker calls `overlayRef.value?.getInputElement()` etc. via `nextTick(syncScroll)`
+// after every validation pass — expose no-op stand-ins so that deferred call doesn't throw.
+const FamiliarOverlayInputStub = defineComponent({
+  props: ['hint'],
+  setup (props, { expose }) {
+    expose({
+      getInputElement: () => undefined,
+      getHighlightElement: () => undefined,
+      getDropdownMenuElement: () => undefined,
+    });
+    return () => h('input', { 'data-hint': props.hint });
+  },
+});
+
+const mountAspectPicker = (options: { hideContextHint: boolean }) => {
+  return mount(AspectPicker, {
+    props: {
+      modelValue: 'system.flag',
+      familiarContext,
+      contextName: 'item',
+      hideContextHint: options.hideContextHint,
+    },
+    global: {
+      stubs: {
+        FamiliarOverlayInput: FamiliarOverlayInputStub,
+      },
+    },
+  });
+};
+
+describe('AspectPicker — hideContextHint error suppression', () => {
+  it('surfaces the "property not found" error in its own hint by default', async () => {
+    const wrapper = mountAspectPicker({ hideContextHint: false });
+    await wrapper.setProps({ modelValue: 'system.unresolvable' });
+    await nextTick();
+    const hint = wrapper.find('input').attributes('data-hint');
+    expect(hint).toBe('dnd35e.Formula.Errors.propertyNotFound');
+  });
+
+  it('suppresses the error from its own hint when hideContextHint is true', async () => {
+    const wrapper = mountAspectPicker({ hideContextHint: true });
+    await wrapper.setProps({ modelValue: 'system.unresolvable' });
+    await nextTick();
+    const hint = wrapper.find('input').attributes('data-hint');
+    expect(hint).toBe('');
+  });
+
+  it('still emits update:error when hideContextHint is true (consumer surfaces it instead)', async () => {
+    const wrapper = mountAspectPicker({ hideContextHint: true });
+    await wrapper.setProps({ modelValue: 'system.unresolvable' });
+    await nextTick();
+    const emitted = wrapper.emitted('update:error');
+    expect(emitted).toBeTruthy();
+    const lastError = emitted?.[emitted.length - 1]?.[0];
+    expect(lastError).toBe('dnd35e.Formula.Errors.propertyNotFound');
+  });
+});

--- a/tests/unit/components/EffectChangesList.test.mts
+++ b/tests/unit/components/EffectChangesList.test.mts
@@ -4,14 +4,26 @@ vi.mock('@documents/document/index.mjs', () => ({
   DocumentSheetStoreSymbol: Symbol.for('test.DocumentSheetStore'),
   RenderModeStoreSymbol: Symbol.for('test.RenderModeStore'),
 }));
+// `FormulaFormGroup.vue` imports these symbols directly from their defining modules
+// rather than the `@documents/document` barrel — mock those paths too so the real
+// (unstubbed) FormulaFormGroup used by the tests below can inject successfully.
+vi.mock('@documents/document/sheet/DocumentSheetStore.mjs', () => ({
+  DocumentSheetStoreSymbol: Symbol.for('test.DocumentSheetStore'),
+}));
+vi.mock('@documents/document/sheet/stores/RenderModeStore.mjs', () => ({
+  RenderModeStoreSymbol: Symbol.for('test.RenderModeStore'),
+}));
 
 import { DocumentSheetStoreSymbol, RenderModeStoreSymbol } from '@documents/document/index.mjs';
+import type { EffectChangeDataDnd35e } from '@effects/baseActiveEffect/data/ActiveEffectSystemData.mjs';
 import EffectChangesList from '@effects/baseActiveEffect/sheet/components/EffectChangesList.vue';
 import type { FamiliarContext, FamiliarSchema } from '@helpers/formulae/types.mjs';
 import { mount } from '@vue/test-utils';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { defineComponent, h } from 'vue';
-import { computed, ref } from 'vue';
+import { computed, nextTick, ref } from 'vue';
+
+import { createMockDocumentStore } from './setup';
 
 /**
  * Regression test for `EffectChangesList.vue`'s `getContextsForTarget()` — the Value/
@@ -106,5 +118,139 @@ describe('EffectChangesList — getContextsForTarget Self-context merge', () => 
     const conditionContexts = capturedContexts.value!['system.changes.0.condition'];
     expect(conditionContexts).toBeDefined();
     expect(Object.keys(conditionContexts!).sort()).toEqual(['item', 'self']);
+  });
+});
+
+/**
+ * The tests below mount the REAL `FormulaFormGroup`/`FormGroup` chain (only `AspectPicker`
+ * is stubbed, since the Field/key column isn't under test) to verify two integration points
+ * that a stubbed-FormulaFormGroup test can't reach: the Condition column's operator
+ * highlighting, and the Value column's expected-type mismatch surfacing.
+ */
+
+const numberAspectItemContext: FamiliarContext = {
+  display: 'Item',
+  properties: { hardness: { type: 'number', accessPath: 'system.hardness', value: 5 } },
+};
+
+const conditionSelfContext: FamiliarContext = {
+  display: 'Self',
+  properties: {
+    hp: { value: { type: 'number', accessPath: 'system.hp.value', value: 5 } },
+  },
+};
+
+const mkFullStore = (changes: Partial<EffectChangeDataDnd35e>[]) => {
+  const base = createMockDocumentStore() as {
+    documentGetters: Record<string, unknown>;
+    documentActions: Record<string, unknown>;
+    _storeUtils: Record<string, unknown>;
+  };
+  return {
+    ...base,
+    documentGetters: {
+      ...base.documentGetters,
+      visibleChanges: computed(() => changes),
+      familiarSchema: ref({ self: conditionSelfContext }),
+      getTargetFamiliarContext: vi.fn((target: string) => (target === 'item' ? numberAspectItemContext : undefined)),
+      getTargetFamiliarContextName: vi.fn((target: string) => target),
+    },
+    documentActions: {
+      ...base.documentActions,
+      addChange: vi.fn(),
+      removeChange: vi.fn(),
+      updateChangeField: vi.fn(),
+    },
+  };
+};
+
+const mountEffectChangesListReal = (changes: Partial<EffectChangeDataDnd35e>[]) => {
+  return mount(EffectChangesList, {
+    props: { variant: 'default', showChangeFieldControls: false },
+    global: {
+      provide: {
+        [DocumentSheetStoreSymbol as symbol]: mkFullStore(changes),
+        [RenderModeStoreSymbol as symbol]: { isEditMode: computed(() => true) },
+      },
+      stubs: {
+        AspectPicker: AspectPickerStub,
+      },
+    },
+  });
+};
+
+describe('EffectChangesList — Condition column accepts and evaluates a boolean formula with operator highlighting', () => {
+  it('highlights comparison and logical operators in a boolean condition formula', async () => {
+    const wrapper = mountEffectChangesListReal([
+      {
+        key: 'system.hardness',
+        type: 'add',
+        value: '5',
+        condition: '#self.hp.value > 0 && #self.hp.value < 10',
+        target: 'item',
+        priority: 10,
+      },
+    ]);
+    await nextTick();
+
+    const operatorSpans = wrapper.findAll('.change-condition .formula-operator');
+    expect(operatorSpans.map(span => span.text())).toEqual(['>', '&&', '<']);
+  });
+});
+
+describe('EffectChangesList — Value column rejects/flags a formula that doesn\'t match the picked aspect\'s type', () => {
+  // The global `Roll.safeEval` test stub (tests/setup.mts) always falls back to `0` (a
+  // finite number) for anything it can't parse, so it can never reproduce a genuine
+  // "not a number" failure on its own — the setup file explicitly invites per-test
+  // overrides for cases like this. Restore the original stub after this test.
+  const originalSafeEval = (globalThis as unknown as { Roll: { safeEval: unknown } }).Roll.safeEval;
+
+  afterEach(() => {
+    (globalThis as unknown as { Roll: { safeEval: unknown } }).Roll.safeEval = originalSafeEval;
+  });
+
+  it('surfaces a type-mismatch error when the Value formula resolves to a non-number for a number-typed aspect', async () => {
+    (globalThis as unknown as { Roll: { safeEval: (expr: string) => number } }).Roll.safeEval = vi.fn(
+      function (this: unknown, expr: string) {
+        // Mirrors the real Foundry behavior this stub otherwise papers over: a quoted
+        // string literal isn't a valid arithmetic expression and safeEval throws.
+        const n = Number(expr);
+        if (Number.isFinite(n)) return n;
+        throw new Error(`Invalid roll expression: ${expr}`);
+      }
+    );
+
+    const wrapper = mountEffectChangesListReal([
+      {
+        key: 'system.hardness',
+        type: 'add',
+        value: '"broken"',
+        condition: null,
+        target: 'item',
+        priority: 10,
+      },
+    ]);
+    await nextTick();
+
+    const rowContext = wrapper.find('.row-context');
+    expect(rowContext.exists()).toBe(true);
+    expect(rowContext.text()).toContain('dnd35e.EFFECT.Headers.Value');
+    expect(rowContext.text()).toContain('dnd35e.Formula.Errors.notANumber');
+  });
+
+  it('does not flag a Value formula that resolves to a valid number for a number-typed aspect', async () => {
+    const wrapper = mountEffectChangesListReal([
+      {
+        key: 'system.hardness',
+        type: 'add',
+        value: '5',
+        condition: null,
+        target: 'item',
+        priority: 10,
+      },
+    ]);
+    await nextTick();
+
+    expect(wrapper.find('.row-context.has-error').exists()).toBe(false);
   });
 });

--- a/tests/unit/components/EffectChangesList.test.mts
+++ b/tests/unit/components/EffectChangesList.test.mts
@@ -1,0 +1,110 @@
+// @vitest-environment happy-dom
+
+vi.mock('@documents/document/index.mjs', () => ({
+  DocumentSheetStoreSymbol: Symbol.for('test.DocumentSheetStore'),
+  RenderModeStoreSymbol: Symbol.for('test.RenderModeStore'),
+}));
+
+import { DocumentSheetStoreSymbol, RenderModeStoreSymbol } from '@documents/document/index.mjs';
+import EffectChangesList from '@effects/baseActiveEffect/sheet/components/EffectChangesList.vue';
+import type { FamiliarContext, FamiliarSchema } from '@helpers/formulae/types.mjs';
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import { defineComponent, h } from 'vue';
+import { computed, ref } from 'vue';
+
+/**
+ * Regression test for `EffectChangesList.vue`'s `getContextsForTarget()` — the Value/
+ * Condition formula columns must see BOTH the effect document's own "Self" context AND
+ * the change's target (item/actor) context merged into one schema (e.g. a Material AE's
+ * Value formula referencing `#Self.MagicEquivalency` alongside `#item.hardness`). The
+ * Field column (AspectPicker) deliberately does NOT get Self — verified separately.
+ */
+
+const selfContext: FamiliarContext = {
+  display: 'Self',
+  properties: { magicEquivalency: { type: 'number', accessPath: 'system.magicEquivalency', value: 1 } },
+};
+const itemContext: FamiliarContext = {
+  display: 'Item',
+  properties: { hardness: { type: 'number', accessPath: 'system.hardness', value: 5 } },
+};
+
+// Capture the `contexts` prop each real editor is mounted with instead of exercising the
+// full formula-editing machinery — this test is only about the merge, not formula UX.
+const capturedContexts: { value?: Record<string, FamiliarSchema | undefined> } = { value: {} };
+
+const FormulaFormGroupStub = defineComponent({
+  props: ['fieldPath', 'contexts'],
+  setup (props) {
+    capturedContexts.value![props.fieldPath] = props.contexts;
+    return () => h('div', { class: 'formula-stub' });
+  },
+});
+
+const AspectPickerStub = defineComponent({
+  props: ['familiarContext'],
+  setup () {
+    return () => h('div', { class: 'aspect-picker-stub' });
+  },
+});
+
+const FieldControlsStub = defineComponent({
+  setup (_props, { slots }) {
+    return () => h('div', { class: 'field-controls-stub' }, slots.default?.());
+  },
+});
+
+const mkStore = () => ({
+  documentGetters: {
+    visibleChanges: computed(() => [
+      { key: 'system.hardness', type: 'add', value: '#self.magicEquivalency', target: 'item', priority: 10 },
+    ]),
+    getIsFieldEditable: vi.fn(() => computed(() => true)),
+    getIsFieldVisible: vi.fn(() => computed(() => true)),
+    familiarSchema: ref({ self: selfContext }),
+    getTargetFamiliarContext: vi.fn((target: string) => (target === 'item' ? itemContext : undefined)),
+    getTargetFamiliarContextName: vi.fn((target: string) => target),
+  },
+  documentActions: {
+    addChange: vi.fn(),
+    removeChange: vi.fn(),
+    updateChangeField: vi.fn(),
+  },
+});
+
+const mountEffectChangesList = (variant: 'default' | 'mask' = 'mask') => {
+  capturedContexts.value = {};
+  return mount(EffectChangesList, {
+    props: { variant },
+    global: {
+      provide: {
+        [DocumentSheetStoreSymbol as symbol]: mkStore(),
+        [RenderModeStoreSymbol as symbol]: { isEditMode: computed(() => true) },
+      },
+      stubs: {
+        FormulaFormGroup: FormulaFormGroupStub,
+        AspectPicker: AspectPickerStub,
+        FieldControls: FieldControlsStub,
+      },
+    },
+  });
+};
+
+describe('EffectChangesList — getContextsForTarget Self-context merge', () => {
+  it('merges Self and the change target context for the Value formula editor', () => {
+    mountEffectChangesList('mask');
+    const valueContexts = capturedContexts.value!['system.changes.0.value'];
+    expect(valueContexts).toBeDefined();
+    expect(Object.keys(valueContexts!).sort()).toEqual(['item', 'self']);
+    expect(valueContexts!.item).toEqual(itemContext);
+    expect(valueContexts!.self).toEqual(selfContext);
+  });
+
+  it('also merges Self and the change target context for the Condition formula editor (default variant)', () => {
+    mountEffectChangesList('default');
+    const conditionContexts = capturedContexts.value!['system.changes.0.condition'];
+    expect(conditionContexts).toBeDefined();
+    expect(Object.keys(conditionContexts!).sort()).toEqual(['item', 'self']);
+  });
+});

--- a/tests/unit/documents/formulaRegistrationHelpers.test.mts
+++ b/tests/unit/documents/formulaRegistrationHelpers.test.mts
@@ -1,0 +1,123 @@
+import { buildFormulaContexts, type FormulaRegistrationHost } from '@documents/document/formulaRegistrationHelpers.mjs';
+import { ContainmentSystemModel } from '@effects/containment/data/ContainmentSystemModel.mjs';
+import { GeneralEffectSystemModel } from '@effects/general/data/GeneralEffectSystemModel.mjs';
+import { MaterialSystemModel } from '@effects/material/data/MaterialSystemModel.mjs';
+import { SecretSystemModel } from '@effects/secret/data/SecretSystemModel.mjs';
+import type { FormulaField } from '@helpers/formulae/FormulaField.mjs';
+import { ContainerSystemModel } from '@items/physical/container/data/ContainerSystemModel.mjs';
+import { WeaponSystemModel } from '@items/physical/weapon/data/WeaponSystemModel.mjs';
+import { describe, expect, it } from 'vitest';
+
+import { createSchemaTester } from '../../helpers/schemaTester.mjs';
+
+/**
+ * Regression tests for the `nameFormula` field's `formulaContexts` declarations
+ * (Parent/Owner/Container/Item) across every AE subtype + the two item subtypes
+ * that declare one. Two layers:
+ *
+ *  1. Shape — the declared array on the real `defineSchema()` output has the
+ *     expected `contextName`/`resolvePath`/`documentType`/`aliases`.
+ *  2. Behavior — `buildFormulaContexts()` (the schema walker consumer) actually
+ *     resolves a live `parent` into a correctly-keyed context entry, and also
+ *     resolves every declared alias's underlying context under the same key
+ *     shape a formula author would reference (e.g. `#Owner...` / `#Parent...`).
+ */
+
+describe('nameFormula formulaContexts — declared schema shape', () => {
+  it('SecretSystemModel declares Parent (Item, no fallback)', () => {
+    const t = createSchemaTester(SecretSystemModel);
+    const field = t.field('nameFormula') as FormulaField;
+    expect(field.formulaContexts).toEqual([
+      { contextName: 'Parent', resolvePath: 'parent', documentType: 'Item', fallbackSubtypes: [] },
+    ]);
+  });
+
+  it('GeneralEffectSystemModel declares Parent (Item, no fallback)', () => {
+    const t = createSchemaTester(GeneralEffectSystemModel);
+    const field = t.field('nameFormula') as FormulaField;
+    expect(field.formulaContexts).toEqual([
+      { contextName: 'Parent', resolvePath: 'parent', documentType: 'Item', fallbackSubtypes: [] },
+    ]);
+  });
+
+  it('MaterialSystemModel declares Item (Item/weapon fallback, aliased to Parent)', () => {
+    const t = createSchemaTester(MaterialSystemModel);
+    const field = t.field('nameFormula') as FormulaField;
+    expect(field.formulaContexts).toEqual([
+      { contextName: 'Item', resolvePath: 'parent', documentType: 'Item', fallbackSubtypes: ['weapon'], aliases: ['Parent'] },
+    ]);
+  });
+
+  it('ContainmentSystemModel declares Container (Item/container fallback, aliased to Owner+Parent)', () => {
+    const t = createSchemaTester(ContainmentSystemModel);
+    const field = t.field('nameFormula') as FormulaField;
+    expect(field.formulaContexts).toEqual([
+      { contextName: 'Container', resolvePath: 'parent', documentType: 'Item', fallbackSubtypes: ['container'], aliases: ['Owner', 'Parent'] },
+    ]);
+  });
+
+  it('ContainerSystemModel declares Owner (Actor/character fallback, aliased to Parent)', () => {
+    const t = createSchemaTester(ContainerSystemModel);
+    const field = t.field('nameFormula') as FormulaField;
+    expect(field.formulaContexts).toEqual([
+      { contextName: 'Owner', resolvePath: 'parent', documentType: 'Actor', fallbackSubtypes: ['character'], aliases: ['Parent'] },
+    ]);
+  });
+
+  it('WeaponSystemModel declares Owner (Actor/character fallback, aliased to Parent)', () => {
+    const t = createSchemaTester(WeaponSystemModel);
+    const field = t.field('nameFormula') as FormulaField;
+    expect(field.formulaContexts).toEqual([
+      { contextName: 'Owner', resolvePath: 'parent', documentType: 'Actor', fallbackSubtypes: ['character'], aliases: ['Parent'] },
+    ]);
+  });
+});
+
+describe('buildFormulaContexts — resolves declared contexts from a live parent', () => {
+  const mkHost = (schemaModel: { defineSchema (): Record<string, any> }, parent: unknown): FormulaRegistrationHost => ({
+    system: { schema: { fields: schemaModel.defineSchema() } },
+    documentName: 'ActiveEffect',
+    type: 'test',
+    registeredFormulas: new Set(),
+    toObject: () => ({}),
+    updateSource: () => undefined,
+    parent,
+  } as unknown as FormulaRegistrationHost);
+
+  it('resolves Secret\'s Parent context from a live Item parent', () => {
+    const parentItem = {
+      documentName: 'Item',
+      type: 'weapon',
+      name: 'Longsword',
+      toObject: () => ({ name: 'Longsword', type: 'weapon' }),
+    };
+    const host = mkHost(SecretSystemModel, parentItem);
+
+    const contexts = buildFormulaContexts(host, 'system.nameFormula');
+    expect(contexts.Parent).toBeDefined();
+    expect(contexts.Parent.documentName).toBe('Item');
+    expect(contexts.Parent.type).toBe('weapon');
+  });
+
+  it('resolves Container\'s Owner context from a live Actor parent', () => {
+    const parentActor = {
+      documentName: 'Actor',
+      type: 'character',
+      name: 'Hero',
+      toObject: () => ({ name: 'Hero', type: 'character' }),
+    };
+    const host = mkHost(ContainerSystemModel, parentActor);
+
+    const contexts = buildFormulaContexts(host, 'system.nameFormula');
+    expect(contexts.Owner).toBeDefined();
+    expect(contexts.Owner.documentName).toBe('Actor');
+    expect(contexts.Owner.type).toBe('character');
+  });
+
+  it('returns no context when the declared resolvePath has no live parent', () => {
+    const host = mkHost(GeneralEffectSystemModel, undefined);
+
+    const contexts = buildFormulaContexts(host, 'system.nameFormula');
+    expect(contexts).toEqual({});
+  });
+});

--- a/tests/unit/effects/evaluate-change-condition.test.mts
+++ b/tests/unit/effects/evaluate-change-condition.test.mts
@@ -1,0 +1,74 @@
+import { evaluateChangeCondition } from '@effects/baseActiveEffect/logic/evaluateChangeCondition.mjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Unit tests for `evaluateChangeCondition()` (Story B, §7.7a).
+ *
+ * Uses the real `FormulaData.resolveSource()` (not mocked) with pure literal
+ * boolean expressions (no `#context.property` tokens), matching the approach
+ * in `tests/unit/familiar/formula-data-boolean.test.mts` — this avoids needing
+ * a full FormulaFamiliar schema registration while still exercising real
+ * boolean-grammar resolution end-to-end.
+ *
+ * Conditions are string-only (FormulaFamiliar boolean grammar) — a function
+ * form was removed since conditions are persisted to the database and a
+ * function could never round-trip through it.
+ */
+
+function mkChange (overrides: Partial<{
+  key: string;
+  condition: string | null;
+}> = {}) {
+  return {
+    key: 'system.foo',
+    value: '5',
+    condition: null,
+    ...overrides,
+  } as any;
+}
+
+describe('evaluateChangeCondition', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('condition: null → applies unconditionally (true)', () => {
+    const change = mkChange({ condition: null });
+    expect(evaluateChangeCondition(change)).toBe(true);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('string condition resolving to "true" → applies (true)', () => {
+    const change = mkChange({ condition: '6 > 5' });
+    expect(evaluateChangeCondition(change, {})).toBe(true);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('string condition resolving to "false" → skipped (false)', () => {
+    const change = mkChange({ condition: '4 > 5' });
+    expect(evaluateChangeCondition(change, {})).toBe(false);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('invalid condition formula → errors (not warns) and treats as false, never throws', () => {
+    const change = mkChange({ condition: '5 >' });
+    expect(() => evaluateChangeCondition(change, {})).not.toThrow();
+    expect(evaluateChangeCondition(change, {})).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('string condition with no contextMap → warns and treats as false', () => {
+    const change = mkChange({ condition: '6 > 5' });
+    expect(evaluateChangeCondition(change)).toBe(false);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/effects/general-material-tab-parity.test.mts
+++ b/tests/unit/effects/general-material-tab-parity.test.mts
@@ -1,0 +1,52 @@
+// @vitest-environment happy-dom
+
+import { effectDurationTab, getDefaultActiveEffectTabs } from '@effects/baseActiveEffect/sheet/tabs/index.mjs';
+import { materialChangesTab, materialDetailsTab } from '@effects/material/sheet/tabs/index.mjs';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Structural parity check between the General AE sheet (a thin pass-through that uses
+ * `getDefaultActiveEffectTabs()` unmodified — see `GeneralStore.mts`) and the Material AE
+ * sheet (which replaces Details/Changes but keeps the base Duration tab — see
+ * `MaterialStore.mts`'s `replaceTabs([materialDetailsTab, ...default.filter(...), materialChangesTab])`).
+ *
+ * Both sheets must expose the same Duration tab and an equivalently-positioned Changes tab,
+ * even though Material swaps in its own tab components for Details/Changes.
+ */
+describe('General vs Material AE sheet — Duration/Changes tab parity', () => {
+  const generalTabs = getDefaultActiveEffectTabs();
+  // Mirrors MaterialStore.mts's actual `replaceTabs(...)` call.
+  const materialTabs = [
+    materialDetailsTab,
+    ...getDefaultActiveEffectTabs().filter(tab => tab.id !== 'details' && tab.id !== 'changes'),
+    materialChangesTab,
+  ];
+
+  it('General includes the base Duration tab unmodified', () => {
+    const duration = generalTabs.find(tab => tab.id === 'duration');
+    expect(duration).toEqual(effectDurationTab);
+  });
+
+  it('Material keeps the exact same Duration tab as General (not overridden)', () => {
+    const duration = materialTabs.find(tab => tab.id === 'duration');
+    expect(duration).toEqual(effectDurationTab);
+    expect(duration).toEqual(generalTabs.find(tab => tab.id === 'duration'));
+  });
+
+  it('both sheets expose a Changes tab at the same order/label, even though Material uses its own component', () => {
+    const generalChanges = generalTabs.find(tab => tab.id === 'changes')!;
+    const materialChanges = materialTabs.find(tab => tab.id === 'changes')!;
+
+    expect(generalChanges.order).toBe(materialChanges.order);
+    expect(generalChanges.label).toBe(materialChanges.label);
+    expect(generalChanges.icon).toBe(materialChanges.icon);
+    // Deliberate divergence, not a parity violation: Material renders its own Changes component.
+    expect(materialChanges).toBe(materialChangesTab);
+    expect(materialChanges.component).not.toBe(generalChanges.component);
+  });
+
+  it('General has details/duration/changes tabs; Material has the same 3 tab ids', () => {
+    expect(generalTabs.map(tab => tab.id).sort()).toEqual(['changes', 'details', 'duration']);
+    expect(materialTabs.map(tab => tab.id).sort()).toEqual(['changes', 'details', 'duration']);
+  });
+});

--- a/tests/unit/effects/secret-ae.test.mts
+++ b/tests/unit/effects/secret-ae.test.mts
@@ -240,6 +240,25 @@ describe('resolveActiveEffectChangeValue', () => {
 
     expect(resolveActiveEffectChangeValue(effect, change)).toBe(5);
     expect(safeEval).toHaveBeenCalledWith('2+3');
+    // Regression: Roll.safeEval must be called bound to `Roll` (`Roll.safeEval(x)`), not a
+    // destructured/detached reference (`const fn = Roll.safeEval; fn(x)`) — the real Foundry
+    // implementation depends on `this.MATH_PROXY` and breaks silently when detached.
+    expect(safeEval.mock.contexts[0]).toBe((globalThis as any).Roll);
+  });
+
+  it('NumberField + parenthesized formula → Roll.safeEval called with correct `this` (regression)', () => {
+    const actor = mkDoc({
+      documentName: 'Actor',
+      type: 'character',
+      systemFields: { 'attributes.str': new NumberField({}) },
+    });
+    const effect = mkEffect(actor);
+    const change = mkChange({ key: 'system.attributes.str', value: '(6 + 2)' });
+
+    // Uses the DEFAULT (un-overridden) tests/setup.mts stub, which throws if Roll.safeEval
+    // is ever invoked detached from `Roll` — this proves the real call site in
+    // resolveChangeValue.mts's `tryEvaluateNumber` preserves `this` correctly.
+    expect(() => resolveActiveEffectChangeValue(effect, change)).not.toThrow();
   });
 
   it('NumberField + un-evaluable garbage → falls back to raw value', () => {

--- a/tests/unit/familiar/conditional-formula.test.mts
+++ b/tests/unit/familiar/conditional-formula.test.mts
@@ -1,21 +1,23 @@
-import {
-  findConditionalBlocks,
-  isConditionalKeywordToken,
-  resolveConditionalFormula,
-} from '@helpers/formulae/conditionalFormula.mjs';
 import { FormulaData } from '@helpers/formulae/FormulaData.mjs';
+import { FormulaResolver } from '@helpers/formulae/FormulaResolver.mjs';
 import type { FamiliarSchema, FieldAspect } from '@helpers/formulae/types.mjs';
-import { extractVariables, resolveFormula, validateFormula } from '@helpers/formulae/utils.mjs';
 import { describe, expect, it } from 'vitest';
 
+const {
+  findConditionalBlocks,
+  resolveConditionalFormula,
+  resolveFormula,
+  validateFormula,
+} = FormulaResolver;
+
 /**
- * Story C (redesigned) — `#conditional(when(cond, value) ... else(default))`
+ * Story C (redesigned) — `$conditional(when(cond, value) ... else(default))`
  * flat rule-list conditional syntax. See
  * `docs/migration-plan/poc/phase-07-roll-formulas.md` §7.10 "Compiled Syntax".
  */
 describe('findConditionalBlocks — parsing', () => {
   it('parses a single when() + else()', () => {
-    const blocks = findConditionalBlocks('#conditional(when(1 > 0, 5) else(2))');
+    const blocks = findConditionalBlocks('$conditional(when(1 > 0, 5) else(2))');
     expect(blocks).toHaveLength(1);
     expect(blocks[0].error).toBeUndefined();
     expect(blocks[0].whenClauses).toEqual([{ condition: '1 > 0', value: '5' }]);
@@ -23,7 +25,7 @@ describe('findConditionalBlocks — parsing', () => {
   });
 
   it('parses multiple when() clauses in left-to-right order', () => {
-    const blocks = findConditionalBlocks('#conditional(when(a, 1) when(b, 2) when(c, 3) else(4))');
+    const blocks = findConditionalBlocks('$conditional(when(a, 1) when(b, 2) when(c, 3) else(4))');
     expect(blocks[0].whenClauses).toEqual([
       { condition: 'a', value: '1' },
       { condition: 'b', value: '2' },
@@ -33,7 +35,7 @@ describe('findConditionalBlocks — parsing', () => {
   });
 
   it('allows else() to appear anywhere among the clauses', () => {
-    const blocks = findConditionalBlocks('#conditional(else(4) when(a, 1) when(b, 2))');
+    const blocks = findConditionalBlocks('$conditional(else(4) when(a, 1) when(b, 2))');
     expect(blocks[0].error).toBeUndefined();
     expect(blocks[0].elseValue).toBe('4');
     expect(blocks[0].whenClauses).toEqual([
@@ -43,35 +45,35 @@ describe('findConditionalBlocks — parsing', () => {
   });
 
   it('treats the clause separator as dont-care (comma, space, or nothing)', () => {
-    const commaSeparated = findConditionalBlocks('#conditional(when(a, 1), when(b, 2), else(3))');
-    const spaceSeparated = findConditionalBlocks('#conditional(when(a, 1) when(b, 2) else(3))');
-    const noSeparator = findConditionalBlocks('#conditional(when(a, 1)when(b, 2)else(3))');
+    const commaSeparated = findConditionalBlocks('$conditional(when(a, 1), when(b, 2), else(3))');
+    const spaceSeparated = findConditionalBlocks('$conditional(when(a, 1) when(b, 2) else(3))');
+    const noSeparator = findConditionalBlocks('$conditional(when(a, 1)when(b, 2)else(3))');
     expect(commaSeparated[0].whenClauses).toEqual(spaceSeparated[0].whenClauses);
     expect(spaceSeparated[0].whenClauses).toEqual(noSeparator[0].whenClauses);
     expect(noSeparator[0].elseValue).toBe('3');
   });
 
   it('is case-insensitive and tolerant of whitespace before (', () => {
-    const blocks = findConditionalBlocks('#CONDITIONAL ( WHEN ( a , 1 ) ELSE ( 2 ) )');
+    const blocks = findConditionalBlocks('$CONDITIONAL ( WHEN ( a , 1 ) ELSE ( 2 ) )');
     expect(blocks[0].error).toBeUndefined();
     expect(blocks[0].whenClauses).toEqual([{ condition: 'a', value: '1' }]);
     expect(blocks[0].elseValue).toBe('2');
   });
 
-  it('handles a value containing a nested #conditional(...) via balanced-paren scanning', () => {
+  it('handles a value containing a nested $conditional(...) via balanced-paren scanning', () => {
     const blocks = findConditionalBlocks(
-      '#conditional(when(a, #conditional(when(x, 1) else(2))) else(3))'
+      '$conditional(when(a, $conditional(when(x, 1) else(2))) else(3))'
     );
     expect(blocks[0].error).toBeUndefined();
     expect(blocks[0].whenClauses).toEqual([
-      { condition: 'a', value: '#conditional(when(x, 1) else(2))' },
+      { condition: 'a', value: '$conditional(when(x, 1) else(2))' },
     ]);
     expect(blocks[0].elseValue).toBe('3');
   });
 
-  it('finds multiple independent #conditional(...) blocks in one formula', () => {
+  it('finds multiple independent $conditional(...) blocks in one formula', () => {
     const blocks = findConditionalBlocks(
-      '#conditional(when(a, 1) else(2))+#conditional(when(b, 3) else(4))'
+      '$conditional(when(a, 1) else(2))+$conditional(when(b, 3) else(4))'
     );
     expect(blocks).toHaveLength(2);
     expect(blocks[0].elseValue).toBe('2');
@@ -79,27 +81,27 @@ describe('findConditionalBlocks — parsing', () => {
   });
 
   it('flags a missing else() as an error', () => {
-    const blocks = findConditionalBlocks('#conditional(when(a, 1))');
+    const blocks = findConditionalBlocks('$conditional(when(a, 1))');
     expect(blocks[0].error).toBe('missingElse');
   });
 
   it('flags more than one else() as an error', () => {
-    const blocks = findConditionalBlocks('#conditional(when(a, 1) else(2) else(3))');
+    const blocks = findConditionalBlocks('$conditional(when(a, 1) else(2) else(3))');
     expect(blocks[0].error).toBe('multipleElse');
   });
 
   it('flags a when() with the wrong argument count as an error', () => {
-    const blocks = findConditionalBlocks('#conditional(when(a) else(2))');
+    const blocks = findConditionalBlocks('$conditional(when(a) else(2))');
     expect(blocks[0].error).toBe('whenArgCount');
   });
 
   it('flags an else() with the wrong argument count as an error', () => {
-    const blocks = findConditionalBlocks('#conditional(when(a, 1) else(2, 3))');
+    const blocks = findConditionalBlocks('$conditional(when(a, 1) else(2, 3))');
     expect(blocks[0].error).toBe('elseArgCount');
   });
 
   it('flags unbalanced parens as an error', () => {
-    const blocks = findConditionalBlocks('#conditional(when(a, 1) else(2)');
+    const blocks = findConditionalBlocks('$conditional(when(a, 1) else(2)');
     expect(blocks[0].error).toBe('unbalancedParens');
   });
 });
@@ -110,13 +112,13 @@ describe('resolveConditionalFormula — resolution', () => {
   const identityResolve = (text: string): string => text;
   const literalEvaluate = (resolvedCondition: string): boolean => resolvedCondition.trim() === 'true';
 
-  it('returns the formula unchanged when there are no #conditional(...) blocks', () => {
+  it('returns the formula unchanged when there are no $conditional(...) blocks', () => {
     expect(resolveConditionalFormula('2d6+3', identityResolve, literalEvaluate)).toBe('2d6+3');
   });
 
   it('picks the first true when() clause', () => {
     const result = resolveConditionalFormula(
-      '#conditional(when(false, 1) when(true, 2) else(3))',
+      '$conditional(when(false, 1) when(true, 2) else(3))',
       identityResolve,
       literalEvaluate
     );
@@ -125,7 +127,7 @@ describe('resolveConditionalFormula — resolution', () => {
 
   it('falls back to else() when no when() clause matches', () => {
     const result = resolveConditionalFormula(
-      '#conditional(when(false, 1) when(false, 2) else(3))',
+      '$conditional(when(false, 1) when(false, 2) else(3))',
       identityResolve,
       literalEvaluate
     );
@@ -134,16 +136,16 @@ describe('resolveConditionalFormula — resolution', () => {
 
   it('preserves surrounding literal text around the block', () => {
     const result = resolveConditionalFormula(
-      '#conditional(when(true, 0) else(2))d6',
+      '$conditional(when(true, 0) else(2))d6',
       identityResolve,
       literalEvaluate
     );
     expect(result).toBe('0d6');
   });
 
-  it('recursively resolves a nested #conditional(...) within the winning branch', () => {
+  it('recursively resolves a nested $conditional(...) within the winning branch', () => {
     const result = resolveConditionalFormula(
-      '#conditional(when(true, #conditional(when(true, 1) else(2))) else(3))',
+      '$conditional(when(true, $conditional(when(true, 1) else(2))) else(3))',
       identityResolve,
       literalEvaluate
     );
@@ -151,7 +153,7 @@ describe('resolveConditionalFormula — resolution', () => {
   });
 
   it('leaves a malformed block raw/unresolved rather than guessing', () => {
-    const formula = '#conditional(when(true, 1))';
+    const formula = '$conditional(when(true, 1))';
     expect(resolveConditionalFormula(formula, identityResolve, literalEvaluate)).toBe(formula);
   });
 
@@ -160,7 +162,7 @@ describe('resolveConditionalFormula — resolution', () => {
       throw new Error('boom');
     };
     const result = resolveConditionalFormula(
-      '#conditional(when(anything, 1) else(2))',
+      '$conditional(when(anything, 1) else(2))',
       identityResolve,
       throwingEvaluate
     );
@@ -168,27 +170,7 @@ describe('resolveConditionalFormula — resolution', () => {
   });
 });
 
-describe('isConditionalKeywordToken', () => {
-  it('is true for the bare #conditional token immediately followed by (', () => {
-    const formula = '#conditional(when(a, 1) else(2))';
-    const [variable] = extractVariables(formula);
-    expect(isConditionalKeywordToken(formula, variable)).toBe(true);
-  });
-
-  it('is true even with whitespace before the (', () => {
-    const formula = '#conditional (when(a, 1) else(2))';
-    const [variable] = extractVariables(formula);
-    expect(isConditionalKeywordToken(formula, variable)).toBe(true);
-  });
-
-  it('is false for an ordinary #context.property token', () => {
-    const formula = '#self.hp.value';
-    const [variable] = extractVariables(formula);
-    expect(isConditionalKeywordToken(formula, variable)).toBe(false);
-  });
-});
-
-describe('resolveFormula — end-to-end with #conditional(...)', () => {
+describe('resolveFormula — end-to-end with $conditional(...)', () => {
   const schema: FamiliarSchema = {
     self: {
       properties: {
@@ -202,7 +184,7 @@ describe('resolveFormula — end-to-end with #conditional(...)', () => {
   it('resolves the doc example — HP <= 0 branch wins', () => {
     const docMap = { self: { system: { hp: { value: 0 }, isFlanked: false, sneakAttackDice: '1d6' } } };
     const resolved = resolveFormula(
-      '#conditional(when(#self.hp.value <= 0, 0) when(#self.isFlanked, 1d6+#self.sneakAttackDice) else(2d6))',
+      '$conditional(when(#self.hp.value <= 0, 0) when(#self.isFlanked, 1d6+#self.sneakAttackDice) else(2d6))',
       schema,
       docMap as never
     );
@@ -212,7 +194,7 @@ describe('resolveFormula — end-to-end with #conditional(...)', () => {
   it('resolves the doc example — flanked branch wins when HP is positive', () => {
     const docMap = { self: { system: { hp: { value: 10 }, isFlanked: true, sneakAttackDice: '1d6' } } };
     const resolved = resolveFormula(
-      '#conditional(when(#self.hp.value <= 0, 0) when(#self.isFlanked, 1d6+#self.sneakAttackDice) else(2d6))',
+      '$conditional(when(#self.hp.value <= 0, 0) when(#self.isFlanked, 1d6+#self.sneakAttackDice) else(2d6))',
       schema,
       docMap as never
     );
@@ -222,28 +204,28 @@ describe('resolveFormula — end-to-end with #conditional(...)', () => {
   it('resolves the doc example — else() default wins when no rule matches', () => {
     const docMap = { self: { system: { hp: { value: 10 }, isFlanked: false, sneakAttackDice: '1d6' } } };
     const resolved = resolveFormula(
-      '#conditional(when(#self.hp.value <= 0, 0) when(#self.isFlanked, 1d6+#self.sneakAttackDice) else(2d6))',
+      '$conditional(when(#self.hp.value <= 0, 0) when(#self.isFlanked, 1d6+#self.sneakAttackDice) else(2d6))',
       schema,
       docMap as never
     );
     expect(resolved).toBe('2d6');
   });
 
-  it('is fully backward compatible — a formula with zero #conditional(...) blocks is untouched', () => {
+  it('is fully backward compatible — a formula with zero $conditional(...) blocks is untouched', () => {
     const docMap = { self: { system: { hp: { value: 10 }, isFlanked: false, sneakAttackDice: '1d6' } } };
     expect(resolveFormula('2d6+3', schema, docMap as never)).toBe('2d6+3');
   });
 
   it('resolves through FormulaData.resolveSource (number expectedType) end-to-end', () => {
     const result = FormulaData.resolveSource(
-      { formula: '#conditional(when(0 <= 0, 0) else(5))', resolvedValue: null, expectedType: 'number' },
+      { formula: '$conditional(when(0 <= 0, 0) else(5))', resolvedValue: null, expectedType: 'number' },
       {}
     );
     expect(result).toBe('0');
   });
 });
 
-describe('validateFormula — #conditional(...) syntax', () => {
+describe('validateFormula — $conditional(...) syntax', () => {
   const schema: FamiliarSchema = {
     self: {
       properties: {
@@ -252,24 +234,24 @@ describe('validateFormula — #conditional(...) syntax', () => {
     },
   };
 
-  it('does not flag a well-formed #conditional(...) as an unknown context', () => {
-    const errors = validateFormula('#conditional(when(#self.hp.value <= 0, 0) else(2))', schema);
+  it('does not flag a well-formed $conditional(...) as an unknown context', () => {
+    const errors = validateFormula('$conditional(when(#self.hp.value <= 0, 0) else(2))', schema);
     expect(errors).toHaveLength(0);
   });
 
   it('still validates nested #context.property tokens inside when()/else()', () => {
-    const errors = validateFormula('#conditional(when(#self.bogus.path <= 0, 0) else(2))', schema);
+    const errors = validateFormula('$conditional(when(#self.bogus.path <= 0, 0) else(2))', schema);
     expect(errors.length).toBeGreaterThan(0);
     expect(errors.some(e => e.severity === 'error')).toBe(true);
   });
 
   it('surfaces a structural error for a missing else()', () => {
-    const errors = validateFormula('#conditional(when(#self.hp.value <= 0, 0))', schema);
+    const errors = validateFormula('$conditional(when(#self.hp.value <= 0, 0))', schema);
     expect(errors.some(e => e.error.length > 0 && e.severity === 'error')).toBe(true);
   });
 
   it('surfaces a structural error for unbalanced parens', () => {
-    const errors = validateFormula('#conditional(when(#self.hp.value <= 0, 0) else(2)', schema);
+    const errors = validateFormula('$conditional(when(#self.hp.value <= 0, 0) else(2)', schema);
     expect(errors.some(e => e.severity === 'error')).toBe(true);
   });
 });
@@ -278,7 +260,7 @@ describe('validateFormula — #conditional(...) syntax', () => {
  * A `#token` immediately followed by more identifier characters with no
  * separator greedily merges into one (invalid) path segment — parens are
  * required to disambiguate. This is a pre-existing `VARIABLE_REGEX` behavior,
- * not specific to `#conditional(...)`, but it's exactly the shape a
+ * not specific to `$conditional(...)`, but it's exactly the shape a
  * `when()`/`else()` value tends to take when dice notation trails a token.
  */
 describe('token/literal-text adjacency — parens required to disambiguate', () => {
@@ -313,38 +295,38 @@ describe('escaping literal parentheses — \\( and \\)', () => {
   it('findMatchingParen skips an escaped paren when counting depth', () => {
     // The when() value contains a literal, unbalanced "(" that must not be
     // mistaken for the start of a new nesting level.
-    const blocks = findConditionalBlocks('#conditional(when(true, "Note: unbalanced \\(") else(2))');
+    const blocks = findConditionalBlocks('$conditional(when(true, "Note: unbalanced \\(") else(2))');
     expect(blocks[0].error).toBeUndefined();
     expect(blocks[0].whenClauses[0].value).toBe('"Note: unbalanced \\("');
   });
 
   it('an unescaped unbalanced literal paren in a value produces a parse error', () => {
-    const blocks = findConditionalBlocks('#conditional(when(true, "Note: unbalanced (") else(2))');
+    const blocks = findConditionalBlocks('$conditional(when(true, "Note: unbalanced (") else(2))');
     expect(blocks[0].error).toBe('unbalancedParens');
   });
 
   it('a balanced pair of literal parens in a value needs no escaping', () => {
-    const blocks = findConditionalBlocks('#conditional(when(true, "Longsword (Masterwork)") else("none"))');
+    const blocks = findConditionalBlocks('$conditional(when(true, "Longsword (Masterwork)") else("none"))');
     expect(blocks[0].error).toBeUndefined();
     expect(blocks[0].whenClauses[0].value).toBe('"Longsword (Masterwork)"');
   });
 
   it('resolveFormula unescapes \\( and \\) back to literal parens in the final output', () => {
     const schema: FamiliarSchema = { self: { properties: {} } };
-    const resolved = resolveFormula('#conditional(when(true, \\(escaped\\)) else(2))', schema, {} as never);
+    const resolved = resolveFormula('$conditional(when(true, \\(escaped\\)) else(2))', schema, {} as never);
     expect(resolved).toBe('(escaped)');
   });
 
   it('escaping the paren right after "when"/"else" prevents it from being parsed as a clause', () => {
-    // "when\(" is literal text, not a clause opener — the whole #conditional(...)
+    // "when\(" is literal text, not a clause opener — the whole $conditional(...)
     // is malformed as a result (no recognized when()/else() clauses at all).
-    const blocks = findConditionalBlocks('#conditional(when\\(not a clause\\))');
+    const blocks = findConditionalBlocks('$conditional(when\\(not a clause\\))');
     expect(blocks[0].error).toBe('missingElse');
     expect(blocks[0].whenClauses).toHaveLength(0);
   });
 
-  it('escaping the # in \\#conditional( prevents the block from being recognized at all', () => {
-    const blocks = findConditionalBlocks('\\#conditional(when(true, 1) else(2))');
+  it('escaping the $ in \\$conditional( prevents the block from being recognized at all', () => {
+    const blocks = findConditionalBlocks('\\$conditional(when(true, 1) else(2))');
     expect(blocks).toHaveLength(0);
   });
 
@@ -354,7 +336,7 @@ describe('escaping literal parentheses — \\( and \\)', () => {
     // picked up as a real clause. Without the word-boundary lookbehind, the
     // "when(" substring inside "somewhen(" would be wrongly matched as a
     // when() clause with a single (invalid) argument.
-    const blocks = findConditionalBlocks('#conditional(xsomewhen(3) else(2))');
+    const blocks = findConditionalBlocks('$conditional(xsomewhen(3) else(2))');
     expect(blocks[0].error).toBeUndefined();
     expect(blocks[0].whenClauses).toHaveLength(0);
     expect(blocks[0].elseValue).toBe('2');
@@ -363,7 +345,7 @@ describe('escaping literal parentheses — \\( and \\)', () => {
 
 describe('escaping a literal comma — \\,', () => {
   it('an escaped comma inside a quoted string value is not mistaken for the arg separator', () => {
-    const blocks = findConditionalBlocks('#conditional(when(#self.name == "\\,", 500) else(0))');
+    const blocks = findConditionalBlocks('$conditional(when(#self.name == "\\,", 500) else(0))');
     expect(blocks[0].error).toBeUndefined();
     expect(blocks[0].whenClauses).toHaveLength(1);
     expect(blocks[0].whenClauses[0].condition).toBe('#self.name == "\\,"');
@@ -376,7 +358,7 @@ describe('escaping a literal comma — \\,', () => {
     };
     const docMap = { self: { name: ',' } };
     const resolved = resolveFormula(
-      '#conditional(when(#self.name == "\\,", 500) else(0))',
+      '$conditional(when(#self.name == "\\,", 500) else(0))',
       schema,
       docMap as never
     );
@@ -384,7 +366,7 @@ describe('escaping a literal comma — \\,', () => {
   });
 
   it('without the escape, an unescaped comma in the value would split into an extra (invalid) arg', () => {
-    const blocks = findConditionalBlocks('#conditional(when(#self.name == ",", 500) else(0))');
+    const blocks = findConditionalBlocks('$conditional(when(#self.name == ",", 500) else(0))');
     expect(blocks[0].error).toBe('whenArgCount');
   });
 });

--- a/tests/unit/familiar/conditional-formula.test.mts
+++ b/tests/unit/familiar/conditional-formula.test.mts
@@ -1,0 +1,391 @@
+import {
+  findConditionalBlocks,
+  isConditionalKeywordToken,
+  resolveConditionalFormula,
+} from '@helpers/formulae/conditionalFormula.mjs';
+import { FormulaData } from '@helpers/formulae/FormulaData.mjs';
+import type { FamiliarSchema, FieldAspect } from '@helpers/formulae/types.mjs';
+import { extractVariables, resolveFormula, validateFormula } from '@helpers/formulae/utils.mjs';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Story C (redesigned) — `#conditional(when(cond, value) ... else(default))`
+ * flat rule-list conditional syntax. See
+ * `docs/migration-plan/poc/phase-07-roll-formulas.md` §7.10 "Compiled Syntax".
+ */
+describe('findConditionalBlocks — parsing', () => {
+  it('parses a single when() + else()', () => {
+    const blocks = findConditionalBlocks('#conditional(when(1 > 0, 5) else(2))');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].error).toBeUndefined();
+    expect(blocks[0].whenClauses).toEqual([{ condition: '1 > 0', value: '5' }]);
+    expect(blocks[0].elseValue).toBe('2');
+  });
+
+  it('parses multiple when() clauses in left-to-right order', () => {
+    const blocks = findConditionalBlocks('#conditional(when(a, 1) when(b, 2) when(c, 3) else(4))');
+    expect(blocks[0].whenClauses).toEqual([
+      { condition: 'a', value: '1' },
+      { condition: 'b', value: '2' },
+      { condition: 'c', value: '3' },
+    ]);
+    expect(blocks[0].elseValue).toBe('4');
+  });
+
+  it('allows else() to appear anywhere among the clauses', () => {
+    const blocks = findConditionalBlocks('#conditional(else(4) when(a, 1) when(b, 2))');
+    expect(blocks[0].error).toBeUndefined();
+    expect(blocks[0].elseValue).toBe('4');
+    expect(blocks[0].whenClauses).toEqual([
+      { condition: 'a', value: '1' },
+      { condition: 'b', value: '2' },
+    ]);
+  });
+
+  it('treats the clause separator as dont-care (comma, space, or nothing)', () => {
+    const commaSeparated = findConditionalBlocks('#conditional(when(a, 1), when(b, 2), else(3))');
+    const spaceSeparated = findConditionalBlocks('#conditional(when(a, 1) when(b, 2) else(3))');
+    const noSeparator = findConditionalBlocks('#conditional(when(a, 1)when(b, 2)else(3))');
+    expect(commaSeparated[0].whenClauses).toEqual(spaceSeparated[0].whenClauses);
+    expect(spaceSeparated[0].whenClauses).toEqual(noSeparator[0].whenClauses);
+    expect(noSeparator[0].elseValue).toBe('3');
+  });
+
+  it('is case-insensitive and tolerant of whitespace before (', () => {
+    const blocks = findConditionalBlocks('#CONDITIONAL ( WHEN ( a , 1 ) ELSE ( 2 ) )');
+    expect(blocks[0].error).toBeUndefined();
+    expect(blocks[0].whenClauses).toEqual([{ condition: 'a', value: '1' }]);
+    expect(blocks[0].elseValue).toBe('2');
+  });
+
+  it('handles a value containing a nested #conditional(...) via balanced-paren scanning', () => {
+    const blocks = findConditionalBlocks(
+      '#conditional(when(a, #conditional(when(x, 1) else(2))) else(3))'
+    );
+    expect(blocks[0].error).toBeUndefined();
+    expect(blocks[0].whenClauses).toEqual([
+      { condition: 'a', value: '#conditional(when(x, 1) else(2))' },
+    ]);
+    expect(blocks[0].elseValue).toBe('3');
+  });
+
+  it('finds multiple independent #conditional(...) blocks in one formula', () => {
+    const blocks = findConditionalBlocks(
+      '#conditional(when(a, 1) else(2))+#conditional(when(b, 3) else(4))'
+    );
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].elseValue).toBe('2');
+    expect(blocks[1].elseValue).toBe('4');
+  });
+
+  it('flags a missing else() as an error', () => {
+    const blocks = findConditionalBlocks('#conditional(when(a, 1))');
+    expect(blocks[0].error).toBe('missingElse');
+  });
+
+  it('flags more than one else() as an error', () => {
+    const blocks = findConditionalBlocks('#conditional(when(a, 1) else(2) else(3))');
+    expect(blocks[0].error).toBe('multipleElse');
+  });
+
+  it('flags a when() with the wrong argument count as an error', () => {
+    const blocks = findConditionalBlocks('#conditional(when(a) else(2))');
+    expect(blocks[0].error).toBe('whenArgCount');
+  });
+
+  it('flags an else() with the wrong argument count as an error', () => {
+    const blocks = findConditionalBlocks('#conditional(when(a, 1) else(2, 3))');
+    expect(blocks[0].error).toBe('elseArgCount');
+  });
+
+  it('flags unbalanced parens as an error', () => {
+    const blocks = findConditionalBlocks('#conditional(when(a, 1) else(2)');
+    expect(blocks[0].error).toBe('unbalancedParens');
+  });
+});
+
+describe('resolveConditionalFormula — resolution', () => {
+  // A trivial sub-resolver/evaluator pair for unit-testing the resolver in isolation
+  // from the full FamiliarSchema/documentDataMap machinery.
+  const identityResolve = (text: string): string => text;
+  const literalEvaluate = (resolvedCondition: string): boolean => resolvedCondition.trim() === 'true';
+
+  it('returns the formula unchanged when there are no #conditional(...) blocks', () => {
+    expect(resolveConditionalFormula('2d6+3', identityResolve, literalEvaluate)).toBe('2d6+3');
+  });
+
+  it('picks the first true when() clause', () => {
+    const result = resolveConditionalFormula(
+      '#conditional(when(false, 1) when(true, 2) else(3))',
+      identityResolve,
+      literalEvaluate
+    );
+    expect(result).toBe('2');
+  });
+
+  it('falls back to else() when no when() clause matches', () => {
+    const result = resolveConditionalFormula(
+      '#conditional(when(false, 1) when(false, 2) else(3))',
+      identityResolve,
+      literalEvaluate
+    );
+    expect(result).toBe('3');
+  });
+
+  it('preserves surrounding literal text around the block', () => {
+    const result = resolveConditionalFormula(
+      '#conditional(when(true, 0) else(2))d6',
+      identityResolve,
+      literalEvaluate
+    );
+    expect(result).toBe('0d6');
+  });
+
+  it('recursively resolves a nested #conditional(...) within the winning branch', () => {
+    const result = resolveConditionalFormula(
+      '#conditional(when(true, #conditional(when(true, 1) else(2))) else(3))',
+      identityResolve,
+      literalEvaluate
+    );
+    expect(result).toBe('1');
+  });
+
+  it('leaves a malformed block raw/unresolved rather than guessing', () => {
+    const formula = '#conditional(when(true, 1))';
+    expect(resolveConditionalFormula(formula, identityResolve, literalEvaluate)).toBe(formula);
+  });
+
+  it('treats a condition evaluation throw as false (falls through to the next clause)', () => {
+    const throwingEvaluate = (): boolean => {
+      throw new Error('boom');
+    };
+    const result = resolveConditionalFormula(
+      '#conditional(when(anything, 1) else(2))',
+      identityResolve,
+      throwingEvaluate
+    );
+    expect(result).toBe('2');
+  });
+});
+
+describe('isConditionalKeywordToken', () => {
+  it('is true for the bare #conditional token immediately followed by (', () => {
+    const formula = '#conditional(when(a, 1) else(2))';
+    const [variable] = extractVariables(formula);
+    expect(isConditionalKeywordToken(formula, variable)).toBe(true);
+  });
+
+  it('is true even with whitespace before the (', () => {
+    const formula = '#conditional (when(a, 1) else(2))';
+    const [variable] = extractVariables(formula);
+    expect(isConditionalKeywordToken(formula, variable)).toBe(true);
+  });
+
+  it('is false for an ordinary #context.property token', () => {
+    const formula = '#self.hp.value';
+    const [variable] = extractVariables(formula);
+    expect(isConditionalKeywordToken(formula, variable)).toBe(false);
+  });
+});
+
+describe('resolveFormula — end-to-end with #conditional(...)', () => {
+  const schema: FamiliarSchema = {
+    self: {
+      properties: {
+        hp: { value: { type: 'number', accessPath: 'system.hp.value' } as FieldAspect },
+        isFlanked: { type: 'boolean', accessPath: 'system.isFlanked' } as FieldAspect,
+        sneakAttackDice: { type: 'string', accessPath: 'system.sneakAttackDice' } as FieldAspect,
+      },
+    },
+  };
+
+  it('resolves the doc example — HP <= 0 branch wins', () => {
+    const docMap = { self: { system: { hp: { value: 0 }, isFlanked: false, sneakAttackDice: '1d6' } } };
+    const resolved = resolveFormula(
+      '#conditional(when(#self.hp.value <= 0, 0) when(#self.isFlanked, 1d6+#self.sneakAttackDice) else(2d6))',
+      schema,
+      docMap as never
+    );
+    expect(resolved).toBe('0');
+  });
+
+  it('resolves the doc example — flanked branch wins when HP is positive', () => {
+    const docMap = { self: { system: { hp: { value: 10 }, isFlanked: true, sneakAttackDice: '1d6' } } };
+    const resolved = resolveFormula(
+      '#conditional(when(#self.hp.value <= 0, 0) when(#self.isFlanked, 1d6+#self.sneakAttackDice) else(2d6))',
+      schema,
+      docMap as never
+    );
+    expect(resolved).toBe('1d6+1d6');
+  });
+
+  it('resolves the doc example — else() default wins when no rule matches', () => {
+    const docMap = { self: { system: { hp: { value: 10 }, isFlanked: false, sneakAttackDice: '1d6' } } };
+    const resolved = resolveFormula(
+      '#conditional(when(#self.hp.value <= 0, 0) when(#self.isFlanked, 1d6+#self.sneakAttackDice) else(2d6))',
+      schema,
+      docMap as never
+    );
+    expect(resolved).toBe('2d6');
+  });
+
+  it('is fully backward compatible — a formula with zero #conditional(...) blocks is untouched', () => {
+    const docMap = { self: { system: { hp: { value: 10 }, isFlanked: false, sneakAttackDice: '1d6' } } };
+    expect(resolveFormula('2d6+3', schema, docMap as never)).toBe('2d6+3');
+  });
+
+  it('resolves through FormulaData.resolveSource (number expectedType) end-to-end', () => {
+    const result = FormulaData.resolveSource(
+      { formula: '#conditional(when(0 <= 0, 0) else(5))', resolvedValue: null, expectedType: 'number' },
+      {}
+    );
+    expect(result).toBe('0');
+  });
+});
+
+describe('validateFormula — #conditional(...) syntax', () => {
+  const schema: FamiliarSchema = {
+    self: {
+      properties: {
+        hp: { value: { type: 'number', accessPath: 'system.hp.value' } as FieldAspect },
+      },
+    },
+  };
+
+  it('does not flag a well-formed #conditional(...) as an unknown context', () => {
+    const errors = validateFormula('#conditional(when(#self.hp.value <= 0, 0) else(2))', schema);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('still validates nested #context.property tokens inside when()/else()', () => {
+    const errors = validateFormula('#conditional(when(#self.bogus.path <= 0, 0) else(2))', schema);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.some(e => e.severity === 'error')).toBe(true);
+  });
+
+  it('surfaces a structural error for a missing else()', () => {
+    const errors = validateFormula('#conditional(when(#self.hp.value <= 0, 0))', schema);
+    expect(errors.some(e => e.error.length > 0 && e.severity === 'error')).toBe(true);
+  });
+
+  it('surfaces a structural error for unbalanced parens', () => {
+    const errors = validateFormula('#conditional(when(#self.hp.value <= 0, 0) else(2)', schema);
+    expect(errors.some(e => e.severity === 'error')).toBe(true);
+  });
+});
+
+/**
+ * A `#token` immediately followed by more identifier characters with no
+ * separator greedily merges into one (invalid) path segment — parens are
+ * required to disambiguate. This is a pre-existing `VARIABLE_REGEX` behavior,
+ * not specific to `#conditional(...)`, but it's exactly the shape a
+ * `when()`/`else()` value tends to take when dice notation trails a token.
+ */
+describe('token/literal-text adjacency — parens required to disambiguate', () => {
+  const schema: FamiliarSchema = {
+    self: {
+      properties: {
+        sneakAttackDice: { type: 'string', accessPath: 'system.sneakAttackDice' } as FieldAspect,
+      },
+    },
+  };
+
+  it('an unparenthesized token immediately followed by literal text is invalid (propertyNotFound)', () => {
+    const errors = validateFormula('#self.sneakAttackDiced6', schema);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].severity).toBe('error');
+    expect(errors[0].path).toEqual(['sneakAttackDiced6']);
+  });
+
+  it('wrapping the token in parens resolves correctly', () => {
+    const docMap = { self: { system: { sneakAttackDice: '1d6' } } };
+    const resolved = resolveFormula('(#self.sneakAttackDice)d6', schema, docMap as never);
+    expect(resolved).toBe('(1d6)d6');
+  });
+
+  it('wrapping the token in parens validates with no errors', () => {
+    const errors = validateFormula('(#self.sneakAttackDice)d6', schema);
+    expect(errors).toHaveLength(0);
+  });
+});
+
+describe('escaping literal parentheses — \\( and \\)', () => {
+  it('findMatchingParen skips an escaped paren when counting depth', () => {
+    // The when() value contains a literal, unbalanced "(" that must not be
+    // mistaken for the start of a new nesting level.
+    const blocks = findConditionalBlocks('#conditional(when(true, "Note: unbalanced \\(") else(2))');
+    expect(blocks[0].error).toBeUndefined();
+    expect(blocks[0].whenClauses[0].value).toBe('"Note: unbalanced \\("');
+  });
+
+  it('an unescaped unbalanced literal paren in a value produces a parse error', () => {
+    const blocks = findConditionalBlocks('#conditional(when(true, "Note: unbalanced (") else(2))');
+    expect(blocks[0].error).toBe('unbalancedParens');
+  });
+
+  it('a balanced pair of literal parens in a value needs no escaping', () => {
+    const blocks = findConditionalBlocks('#conditional(when(true, "Longsword (Masterwork)") else("none"))');
+    expect(blocks[0].error).toBeUndefined();
+    expect(blocks[0].whenClauses[0].value).toBe('"Longsword (Masterwork)"');
+  });
+
+  it('resolveFormula unescapes \\( and \\) back to literal parens in the final output', () => {
+    const schema: FamiliarSchema = { self: { properties: {} } };
+    const resolved = resolveFormula('#conditional(when(true, \\(escaped\\)) else(2))', schema, {} as never);
+    expect(resolved).toBe('(escaped)');
+  });
+
+  it('escaping the paren right after "when"/"else" prevents it from being parsed as a clause', () => {
+    // "when\(" is literal text, not a clause opener — the whole #conditional(...)
+    // is malformed as a result (no recognized when()/else() clauses at all).
+    const blocks = findConditionalBlocks('#conditional(when\\(not a clause\\))');
+    expect(blocks[0].error).toBe('missingElse');
+    expect(blocks[0].whenClauses).toHaveLength(0);
+  });
+
+  it('escaping the # in \\#conditional( prevents the block from being recognized at all', () => {
+    const blocks = findConditionalBlocks('\\#conditional(when(true, 1) else(2))');
+    expect(blocks).toHaveLength(0);
+  });
+
+  it('a keyword-like substring mid-identifier (e.g. "somewhen(") is not misparsed as a clause', () => {
+    // "xsomewhen(3)" is stray/ignored text (not a recognized clause, per the
+    // lenient "don't care what's between clauses" design) — only else(2) is
+    // picked up as a real clause. Without the word-boundary lookbehind, the
+    // "when(" substring inside "somewhen(" would be wrongly matched as a
+    // when() clause with a single (invalid) argument.
+    const blocks = findConditionalBlocks('#conditional(xsomewhen(3) else(2))');
+    expect(blocks[0].error).toBeUndefined();
+    expect(blocks[0].whenClauses).toHaveLength(0);
+    expect(blocks[0].elseValue).toBe('2');
+  });
+});
+
+describe('escaping a literal comma — \\,', () => {
+  it('an escaped comma inside a quoted string value is not mistaken for the arg separator', () => {
+    const blocks = findConditionalBlocks('#conditional(when(#self.name == "\\,", 500) else(0))');
+    expect(blocks[0].error).toBeUndefined();
+    expect(blocks[0].whenClauses).toHaveLength(1);
+    expect(blocks[0].whenClauses[0].condition).toBe('#self.name == "\\,"');
+    expect(blocks[0].whenClauses[0].value).toBe('500');
+  });
+
+  it('resolveFormula unescapes \\, back to a literal comma so the comparison sees ","', () => {
+    const schema: FamiliarSchema = {
+      self: { properties: { name: { type: 'string', accessPath: 'name' } as FieldAspect } },
+    };
+    const docMap = { self: { name: ',' } };
+    const resolved = resolveFormula(
+      '#conditional(when(#self.name == "\\,", 500) else(0))',
+      schema,
+      docMap as never
+    );
+    expect(resolved).toBe('500');
+  });
+
+  it('without the escape, an unescaped comma in the value would split into an extra (invalid) arg', () => {
+    const blocks = findConditionalBlocks('#conditional(when(#self.name == ",", 500) else(0))');
+    expect(blocks[0].error).toBe('whenArgCount');
+  });
+});
+

--- a/tests/unit/familiar/evaluate-boolean-expression.test.mts
+++ b/tests/unit/familiar/evaluate-boolean-expression.test.mts
@@ -1,5 +1,7 @@
-import { evaluateBooleanExpression } from '@helpers/formulae/evaluateBooleanExpression.mjs';
+import { FormulaResolver } from '@helpers/formulae/FormulaResolver.mjs';
 import { describe, expect, it } from 'vitest';
+
+const { evaluateBooleanExpression } = FormulaResolver;
 
 /**
  * Story A (§7.2a, Phase 7) — boolean-typed formula grammar.
@@ -50,6 +52,20 @@ describe('evaluateBooleanExpression — comparison & logical grammar', () => {
       expect(evaluateBooleanExpression('!true')).toBe(false);
     });
 
+    it('"!" binds like JS (tighter than comparison) -- negates only its immediate operand', () => {
+      // !0 > -1 reads as (!0) > -1, i.e. true > -1, i.e. 1 > -1 -> true.
+      // Under the old (looser-than-comparison) precedence this would have
+      // been !(0 > -1) -> !true -> false, so this is a genuine behavior check.
+      expect(evaluateBooleanExpression('!0 > -1')).toBe(true);
+      // !5 > 0 reads as (!5) > 0, i.e. false > 0, i.e. 0 > 0 -> false.
+      expect(evaluateBooleanExpression('!5 > 0')).toBe(false);
+    });
+
+    it('parens still force negating the whole comparison, same as before', () => {
+      expect(evaluateBooleanExpression('!(0 > -1)')).toBe(false);
+      expect(evaluateBooleanExpression('!(5 > -1)')).toBe(false);
+    });
+
     it('evaluates parenthesized grouping with correct precedence', () => {
       expect(evaluateBooleanExpression('(3 > 2) && (1 == 1)')).toBe(true);
       expect(evaluateBooleanExpression('!(3 > 2) && true')).toBe(false);
@@ -59,6 +75,34 @@ describe('evaluateBooleanExpression — comparison & logical grammar', () => {
     it('evaluates the doc example: compound ability/BAB gate', () => {
       expect(evaluateBooleanExpression('2 >= 2 && 1 > 0')).toBe(true);
       expect(evaluateBooleanExpression('1 >= 2 && 1 > 0')).toBe(false);
+    });
+  });
+
+  describe('"$and"/"$or" — keyword aliases for "&&"/"||"', () => {
+    it('"$and" behaves exactly like "&&"', () => {
+      expect(evaluateBooleanExpression('true $and true')).toBe(true);
+      expect(evaluateBooleanExpression('true $and false')).toBe(false);
+    });
+
+    it('"$or" behaves exactly like "||"', () => {
+      expect(evaluateBooleanExpression('false $or true')).toBe(true);
+      expect(evaluateBooleanExpression('false $or false')).toBe(false);
+    });
+
+    it('is case-insensitive', () => {
+      expect(evaluateBooleanExpression('true $AND true')).toBe(true);
+      expect(evaluateBooleanExpression('false $Or true')).toBe(true);
+    });
+
+    it('mixes freely with "&&"/"||" and respects the same precedence/grouping', () => {
+      expect(evaluateBooleanExpression('2 > 1 $and 1 > 5 $or 3 == 3')).toBe(true);
+      expect(evaluateBooleanExpression('(3 > 2) $and (1 == 1)')).toBe(true);
+      expect(evaluateBooleanExpression('2 > 1 && 1 > 5 $or 3 == 3')).toBe(true);
+    });
+
+    it('does not clip a longer bareword starting with "and"/"or" (word-boundary check)', () => {
+      expect(() => evaluateBooleanExpression('$android')).not.toThrow();
+      expect(evaluateBooleanExpression('$android')).toBe(true); // truthy bareword, not parsed as "$and" + "roid"
     });
   });
 

--- a/tests/unit/familiar/evaluate-boolean-expression.test.mts
+++ b/tests/unit/familiar/evaluate-boolean-expression.test.mts
@@ -1,0 +1,141 @@
+import { evaluateBooleanExpression } from '@helpers/formulae/evaluateBooleanExpression.mjs';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Story A (§7.2a, Phase 7) — boolean-typed formula grammar.
+ *
+ * `evaluateBooleanExpression()` operates on an already-substituted formula
+ * string (all `#context.property` tokens replaced with literal values by
+ * `resolveFormula()`), so these tests exercise it directly with literal
+ * expressions rather than full document resolution.
+ */
+describe('evaluateBooleanExpression — comparison & logical grammar', () => {
+  describe('comparison operators', () => {
+    it('evaluates ">" true/false on both sides of the threshold', () => {
+      expect(evaluateBooleanExpression('6 > 5')).toBe(true);
+      expect(evaluateBooleanExpression('4 > 5')).toBe(false);
+    });
+
+    it('evaluates "<", ">=", "<="', () => {
+      expect(evaluateBooleanExpression('4 < 5')).toBe(true);
+      expect(evaluateBooleanExpression('5 >= 5')).toBe(true);
+      expect(evaluateBooleanExpression('6 <= 5')).toBe(false);
+    });
+
+    it('evaluates "==" and "!=" for numbers and strings', () => {
+      expect(evaluateBooleanExpression('5 == 5')).toBe(true);
+      expect(evaluateBooleanExpression('5 != 5')).toBe(false);
+      expect(evaluateBooleanExpression('Longsword == Longsword')).toBe(true);
+      expect(evaluateBooleanExpression('Longsword != Dagger')).toBe(true);
+    });
+
+    it('throws when an ordering operator is used on non-numeric operands', () => {
+      expect(() => evaluateBooleanExpression('Longsword > Dagger')).toThrow();
+    });
+  });
+
+  describe('logical operators and grouping', () => {
+    it('evaluates "&&"', () => {
+      expect(evaluateBooleanExpression('true && true')).toBe(true);
+      expect(evaluateBooleanExpression('true && false')).toBe(false);
+    });
+
+    it('evaluates "||"', () => {
+      expect(evaluateBooleanExpression('false || true')).toBe(true);
+      expect(evaluateBooleanExpression('false || false')).toBe(false);
+    });
+
+    it('evaluates unary "!"', () => {
+      expect(evaluateBooleanExpression('!false')).toBe(true);
+      expect(evaluateBooleanExpression('!true')).toBe(false);
+    });
+
+    it('evaluates parenthesized grouping with correct precedence', () => {
+      expect(evaluateBooleanExpression('(3 > 2) && (1 == 1)')).toBe(true);
+      expect(evaluateBooleanExpression('!(3 > 2) && true')).toBe(false);
+      expect(evaluateBooleanExpression('2 > 1 && 1 > 5 || 3 == 3')).toBe(true);
+    });
+
+    it('evaluates the doc example: compound ability/BAB gate', () => {
+      expect(evaluateBooleanExpression('2 >= 2 && 1 > 0')).toBe(true);
+      expect(evaluateBooleanExpression('1 >= 2 && 1 > 0')).toBe(false);
+    });
+  });
+
+  describe('arithmetic operators in comparison operands', () => {
+    it('evaluates "+", "-", "*", "/" with standard precedence', () => {
+      expect(evaluateBooleanExpression('2 + 3 * 4 == 14')).toBe(true);
+      expect(evaluateBooleanExpression('(2 + 3) * 4 == 20')).toBe(true);
+      expect(evaluateBooleanExpression('10 - 4 / 2 == 8')).toBe(true);
+    });
+
+    it('evaluates the doc example: a half-hp threshold check', () => {
+      expect(evaluateBooleanExpression('20 > (100 / 2)')).toBe(false);
+      expect(evaluateBooleanExpression('60 > (100 / 2)')).toBe(true);
+    });
+
+    it('evaluates unary minus', () => {
+      expect(evaluateBooleanExpression('-5 < 0')).toBe(true);
+      expect(evaluateBooleanExpression('5 * -1 == -5')).toBe(true);
+    });
+
+    it('tokenizes arithmetic operators without surrounding whitespace', () => {
+      expect(evaluateBooleanExpression('20/2==10')).toBe(true);
+      expect(evaluateBooleanExpression('5+3==8')).toBe(true);
+    });
+
+    it('throws when an arithmetic operator is used on non-numeric operands', () => {
+      expect(() => evaluateBooleanExpression('Longsword + 1 == 2')).toThrow();
+    });
+  });
+
+  describe('invalid expressions', () => {
+    it('throws (does not silently return a value) on incomplete syntax', () => {
+      expect(() => evaluateBooleanExpression('5 >')).toThrow();
+      expect(() => evaluateBooleanExpression('&& true')).toThrow();
+      expect(() => evaluateBooleanExpression('(true')).toThrow();
+    });
+
+    it('throws on an empty expression', () => {
+      expect(() => evaluateBooleanExpression('')).toThrow();
+      expect(() => evaluateBooleanExpression('   ')).toThrow();
+    });
+  });
+
+  describe('quoted strings — single and double quotes both accepted', () => {
+    it('accepts single- or double-quoted string literals interchangeably', () => {
+      expect(evaluateBooleanExpression('"Longsword" == "Longsword"')).toBe(true);
+      expect(evaluateBooleanExpression('\'Longsword\' == \'Longsword\'')).toBe(true);
+      expect(evaluateBooleanExpression('"Longsword" == \'Longsword\'')).toBe(true);
+      expect(evaluateBooleanExpression('"Longsword" != \'Dagger\'')).toBe(true);
+    });
+
+    it('allows a comma (or other separator-like characters) inside a quoted string', () => {
+      expect(evaluateBooleanExpression('"," == ","')).toBe(true);
+      expect(evaluateBooleanExpression('\',\' == \',\'')).toBe(true);
+    });
+  });
+
+  describe('non-boolean condition values are coerced truthy (like a bare condition, not compared)', () => {
+    it('a non-empty resolved string (bareword) is truthy', () => {
+      expect(evaluateBooleanExpression('Aragorn')).toBe(true);
+    });
+
+    it('a nonzero resolved number is truthy, zero is falsy', () => {
+      expect(evaluateBooleanExpression('5')).toBe(true);
+      expect(evaluateBooleanExpression('0')).toBe(false);
+    });
+
+    it('a quoted empty string is falsy, a quoted non-empty string is truthy', () => {
+      expect(evaluateBooleanExpression('""')).toBe(false);
+      expect(evaluateBooleanExpression('"x"')).toBe(true);
+    });
+
+    it('an empty expression throws rather than silently being falsy — callers treat the throw as false', () => {
+      // e.g. #self.name resolving to an empty string leaves the condition text
+      // empty; resolveConditionalFormula's evaluateCondition callback catches
+      // this and treats the whole when() clause as not matching.
+      expect(() => evaluateBooleanExpression('')).toThrow();
+    });
+  });
+});

--- a/tests/unit/familiar/formula-data-boolean.test.mts
+++ b/tests/unit/familiar/formula-data-boolean.test.mts
@@ -1,0 +1,181 @@
+import { evaluateBooleanExpression } from '@helpers/formulae/evaluateBooleanExpression.mjs';
+import { FormulaData } from '@helpers/formulae/FormulaData.mjs';
+import type { FamiliarSchema,FieldAspect } from '@helpers/formulae/types.mjs';
+import { resolveFormula, validateFormulaType } from '@helpers/formulae/utils.mjs';
+import type { Mock } from 'vitest';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Story A (§7.2a, Phase 7) — boolean formula resolution + type-mismatch validation.
+ *
+ * `FormulaData.resolveSource()` is exercised with an empty documentDataMap so no
+ * FormulaFamiliar schema registration is required — these tests use formulas
+ * with no `#context.property` tokens (pure literal expressions), which is
+ * sufficient to prove `_finalizeResolvedValue()`'s new 'boolean' branch.
+ */
+describe('FormulaData — boolean expectedType resolution', () => {
+  it('resolves a comparison expression to the string "true"', () => {
+    const result = FormulaData.resolveSource(
+      { formula: '6 > 5', resolvedValue: null, expectedType: 'boolean' },
+      {}
+    );
+    expect(result).toBe('true');
+  });
+
+  it('resolves a comparison expression to the string "false" on the other side of the threshold', () => {
+    const result = FormulaData.resolveSource(
+      { formula: '4 > 5', resolvedValue: null, expectedType: 'boolean' },
+      {}
+    );
+    expect(result).toBe('false');
+  });
+
+  it('evaluates compound expressions (&&, ||, !, parentheses)', () => {
+    expect(FormulaData.resolveSource({ formula: '(3 > 2) && (1 == 1)', resolvedValue: null, expectedType: 'boolean' }, {})).toBe('true');
+    expect(FormulaData.resolveSource({ formula: '3 > 2 || false', resolvedValue: null, expectedType: 'boolean' }, {})).toBe('true');
+    expect(FormulaData.resolveSource({ formula: '!(3 > 2) && true', resolvedValue: null, expectedType: 'boolean' }, {})).toBe('false');
+  });
+
+  it('does not throw on an invalid boolean expression — falls back to the raw resolved text', () => {
+    expect(() => FormulaData.resolveSource(
+      { formula: '5 >', resolvedValue: null, expectedType: 'boolean' },
+      {}
+    )).not.toThrow();
+    const result = FormulaData.resolveSource(
+      { formula: '5 >', resolvedValue: null, expectedType: 'boolean' },
+      {}
+    );
+    expect(result).toBe('5 >');
+  });
+});
+
+describe('FormulaData — number expectedType, Roll.safeEval this-binding regression', () => {
+  it('resolves a parenthesized numeric formula without throwing (Roll.safeEval called bound to `Roll`)', () => {
+    // Uses the DEFAULT (un-overridden) tests/setup.mts Roll.safeEval stub, which throws if
+    // called detached from `Roll` (e.g. `const fn = Roll.safeEval; fn(x)`) — the real Foundry
+    // implementation depends on `this.MATH_PROXY` and breaks silently in that case. A
+    // regression here would cause `_finalizeResolvedValue` to catch the throw and fall back
+    // to the raw, unresolved formula text instead of a numeric string.
+    const result = FormulaData.resolveSource(
+      { formula: '(6 + 2)', resolvedValue: null, expectedType: 'number' },
+      {}
+    );
+    expect(result).not.toBe('(6 + 2)');
+    expect(Number.isNaN(Number(result))).toBe(false);
+  });
+});
+
+describe('resolveFormula + evaluateBooleanExpression — the doc example end-to-end', () => {
+  const schema: FamiliarSchema = {
+    self: {
+      properties: {
+        skill: {
+          concentration: {
+            ranks: { type: 'number', accessPath: 'system.skill.concentration.ranks' } as FieldAspect,
+          },
+        },
+      },
+    },
+  };
+
+  it('"#self.skill.concentration.ranks > 5" resolves true above the threshold', () => {
+    const docMap = { self: { system: { skill: { concentration: { ranks: 6 } } } } };
+    const resolved = resolveFormula('#self.skill.concentration.ranks > 5', schema, docMap as never);
+    expect(resolved).toBe('6 > 5');
+    expect(evaluateBooleanExpression(resolved)).toBe(true);
+  });
+
+  it('"#self.skill.concentration.ranks > 5" resolves false below the threshold', () => {
+    const docMap = { self: { system: { skill: { concentration: { ranks: 3 } } } } };
+    const resolved = resolveFormula('#self.skill.concentration.ranks > 5', schema, docMap as never);
+    expect(resolved).toBe('3 > 5');
+    expect(evaluateBooleanExpression(resolved)).toBe(false);
+  });
+});
+
+describe('validateFormulaType — expectedType mismatch surfaces a validation error', () => {
+  it('flags a number-typed field whose formula resolves to boolean text', () => {
+    // The test-harness Roll.safeEval stub (tests/setup.mts) returns 0 for any
+    // non-numeric input rather than throwing/NaN like Foundry's real dice-formula
+    // parser does on non-arithmetic text — override it here, for this call only,
+    // to match real behavior.
+    (globalThis.Roll.safeEval as Mock).mockImplementationOnce(() => {
+      throw new Error('not a valid dice formula');
+    });
+
+    const schema: FamiliarSchema = {
+      self: { properties: { flag: { type: 'boolean', accessPath: 'system.flag', value: 'true' } } },
+    };
+    const error = validateFormulaType('#self.flag', schema, 'number');
+    expect(error).not.toBeNull();
+    expect(error?.severity).toBe('error');
+  });
+
+  it('passes a number-typed field whose formula resolves to a number', () => {
+    const schema: FamiliarSchema = {
+      self: { properties: { hp: { type: 'number', accessPath: 'system.hp', value: 10 } } },
+    };
+    expect(validateFormulaType('#self.hp + 5', schema, 'number')).toBeNull();
+  });
+
+  it('passes a parenthesized number-typed formula (Roll.safeEval this-binding regression)', () => {
+    // Regression for the exact user-reported bug: `(#self.level)`-style parenthesized
+    // numeric formulas failing to resolve because a detached `Roll.safeEval` reference
+    // lost its `this` binding. The default tests/setup.mts stub now throws on wrong
+    // binding, so this test fails loudly if that regresses.
+    const schema: FamiliarSchema = {
+      self: { properties: { hp: { type: 'number', accessPath: 'system.hp', value: 10 } } },
+    };
+    expect(validateFormulaType('(#self.hp + 5)', schema, 'number')).toBeNull();
+  });
+
+  it('passes a boolean-typed field whose formula is a valid comparison', () => {
+    const schema: FamiliarSchema = {
+      self: { properties: { ranks: { type: 'number', accessPath: 'system.ranks', value: 6 } } },
+    };
+    expect(validateFormulaType('#self.ranks > 5', schema, 'boolean')).toBeNull();
+  });
+
+  it('flags a boolean-typed field whose formula is not a valid boolean expression', () => {
+    const schema: FamiliarSchema = {
+      self: { properties: { ranks: { type: 'number', accessPath: 'system.ranks', value: 6 } } },
+    };
+    const error = validateFormulaType('#self.ranks >', schema, 'boolean');
+    expect(error).not.toBeNull();
+    expect(error?.severity).toBe('error');
+  });
+
+  it('does not flag string-typed fields (no type coercion possible)', () => {
+    const schema: FamiliarSchema = {
+      self: { properties: { name: { type: 'string', accessPath: 'system.name', value: 'Longsword' } } },
+    };
+    expect(validateFormulaType('#self.name', schema, 'string')).toBeNull();
+  });
+
+  describe('without a live/cached FieldAspect value (no live parent document)', () => {
+    it('still flags a syntax error — two adjacent expressions with no operator', () => {
+      // No `.value` on `broken` — this is the shape of a merged fallback schema
+      // (e.g. an orphaned/standalone effect with no live parent to resolve real
+      // values from). The bug: this used to bail out silently instead of
+      // catching the missing operator between `!#self.broken` and `0`.
+      const schema: FamiliarSchema = {
+        self: { properties: { broken: { type: 'boolean', accessPath: 'system.broken' } } },
+      };
+      const error = validateFormulaType('!#self.broken 0', schema, 'boolean');
+      expect(error).not.toBeNull();
+      expect(error?.severity).toBe('error');
+    });
+
+    it('does not false-positive on a valid comparison', () => {
+      const schema: FamiliarSchema = {
+        self: { properties: { ranks: { type: 'number', accessPath: 'system.ranks' } } },
+      };
+      expect(validateFormulaType('#self.ranks > 5', schema, 'boolean')).toBeNull();
+    });
+
+    it('unresolvable variables (no matching aspect at all) still skip validation', () => {
+      const schema: FamiliarSchema = { self: { properties: {} } };
+      expect(validateFormulaType('!#self.missing 0', schema, 'boolean')).toBeNull();
+    });
+  });
+});

--- a/tests/unit/familiar/formula-data-boolean.test.mts
+++ b/tests/unit/familiar/formula-data-boolean.test.mts
@@ -1,9 +1,10 @@
-import { evaluateBooleanExpression } from '@helpers/formulae/evaluateBooleanExpression.mjs';
 import { FormulaData } from '@helpers/formulae/FormulaData.mjs';
+import { FormulaResolver } from '@helpers/formulae/FormulaResolver.mjs';
 import type { FamiliarSchema,FieldAspect } from '@helpers/formulae/types.mjs';
-import { resolveFormula, validateFormulaType } from '@helpers/formulae/utils.mjs';
 import type { Mock } from 'vitest';
 import { describe, expect, it } from 'vitest';
+
+const { evaluateBooleanExpression, resolveFormula, validateFormulaType } = FormulaResolver;
 
 /**
  * Story A (§7.2a, Phase 7) — boolean formula resolution + type-mismatch validation.

--- a/tests/unit/familiar/formula-form-group-hide-context-hint.test.mts
+++ b/tests/unit/familiar/formula-form-group-hide-context-hint.test.mts
@@ -1,0 +1,101 @@
+// @vitest-environment happy-dom
+
+import { mount } from '@vue/test-utils';
+import type { Mock } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { nextTick } from 'vue';
+
+// FormulaFormGroup injects these two stores via their direct module paths (not the
+// `@documents/document/index.mjs` barrel other FormGroups use), so mock those exact
+// specifiers with the same `Symbol.for(...)` identities `../components/setup.ts` provides.
+vi.mock('@documents/document/sheet/DocumentSheetStore.mjs', () => ({
+  DocumentSheetStoreSymbol: Symbol.for('test.DocumentSheetStore'),
+}));
+vi.mock('@documents/document/sheet/stores/RenderModeStore.mjs', () => ({
+  RenderModeStoreSymbol: Symbol.for('test.RenderModeStore'),
+}));
+
+import FormulaFormGroup from '@helpers/formulae/FormulaFormGroup.vue';
+import type { FamiliarSchema } from '@helpers/formulae/types.mjs';
+
+import { createMockRenderModeStore, makeGlobalProvide } from '../components/setup';
+
+/**
+ * Regression tests for `hideContextHint` suppressing FormulaFormGroup's own error display
+ * (fixing a duplicate error message shown both in this field's hint AND in a consumer's
+ * shared context/error line, e.g. the AE Changes table row).
+ *
+ * `expectedType: 'number'` + a formula resolving to a boolean-typed context property
+ * produces a real type-mismatch `ValidationError` via `validateFormulaType()`
+ * (`utils.mts`), which surfaces through `useFormulaEditor`'s `formulaErrors` — this
+ * exercises the real validation pipeline, not a mocked one.
+ */
+
+const schema: FamiliarSchema = {
+  self: { properties: { flag: { type: 'boolean', accessPath: 'system.flag', value: 'true' } } },
+};
+
+const mountFormulaFormGroup = (options: { hideContextHint: boolean }) => {
+  return mount(FormulaFormGroup, {
+    props: {
+      fieldPath: 'system.changes.0.condition',
+      value: '#self.flag',
+      expectedType: 'number',
+      contexts: schema,
+      hideContextHint: options.hideContextHint,
+    },
+    global: {
+      provide: makeGlobalProvide({
+        renderModeStore: createMockRenderModeStore({ isEditMode: true }),
+      }),
+      stubs: {
+        FormGroup: { template: '<div class="fg-stub" :data-hint="hint"><slot /><slot name="readonly" /></div>', props: ['hint'] },
+        FamiliarOverlayInput: { template: '<input />' },
+      },
+    },
+  });
+};
+
+describe('FormulaFormGroup — hideContextHint error suppression', () => {
+  afterEach(() => {
+    (globalThis.Roll.safeEval as Mock).mockReset();
+  });
+
+  // The default tests/setup.mts Roll.safeEval stub always returns a finite number (0) for
+  // non-numeric text, unlike Foundry's real dice-formula parser, which throws — force a
+  // throw here so `validateFormulaType`'s 'number' branch actually produces an error.
+  const forceTypeMismatchError = () => {
+    (globalThis.Roll.safeEval as Mock).mockImplementation(() => {
+      throw new Error('not a valid dice formula');
+    });
+  };
+
+  it('surfaces the type-mismatch error in its own hint by default', async () => {
+    forceTypeMismatchError();
+    const wrapper = mountFormulaFormGroup({ hideContextHint: false });
+    // onMounted validates synchronously but the re-render reflecting it is scheduled — flush it.
+    await nextTick();
+    const hint = wrapper.find('.fg-stub').attributes('data-hint');
+    expect(hint).toBe('dnd35e.Formula.Errors.notANumber');
+  });
+
+  it('suppresses the type-mismatch error from its own hint when hideContextHint is true', async () => {
+    forceTypeMismatchError();
+    const wrapper = mountFormulaFormGroup({ hideContextHint: true });
+    await nextTick();
+    const hint = wrapper.find('.fg-stub').attributes('data-hint');
+    expect(hint).toBe('');
+  });
+
+  it('still emits update:error when hideContextHint is true (consumer surfaces it instead)', async () => {
+    forceTypeMismatchError();
+    const wrapper = mountFormulaFormGroup({ hideContextHint: true });
+    // `onMounted` sets formulaErrors reactively (pre-flush queue) — the `watch(currentError, ...)`
+    // re-emission after mount-time validation needs a tick to flush before it's observable.
+    await nextTick();
+    const emitted = wrapper.emitted('update:error');
+    expect(emitted).toBeTruthy();
+    const lastError = emitted?.[emitted.length - 1]?.[0];
+    expect(lastError).toBe('dnd35e.Formula.Errors.notANumber');
+  });
+});

--- a/tests/unit/familiar/render-formula-html-comparison-operators.test.mts
+++ b/tests/unit/familiar/render-formula-html-comparison-operators.test.mts
@@ -1,0 +1,178 @@
+import { FormulaResolver } from '@helpers/formulae/FormulaResolver.mjs';
+import type { FamiliarSchema, FieldAspect } from '@helpers/formulae/types.mjs';
+import { renderFormulaHTML } from '@helpers/formulae/utils.mjs';
+import { describe, expect, it } from 'vitest';
+
+const { parseFormula, validateFormula } = FormulaResolver;
+
+/**
+ * Comparison (`<`, `>`, `>=`, `<=`, `==`, `!=`) and logical (`&&`, `||`)
+ * operator highlighting — §7.7b operator-highlighting work, extending the
+ * `!`/paren conventions to binary operators.
+ *
+ * - blue (no modifier) — both operand slots are present/complete (a number,
+ *   a bareword IDENT, a closed quoted string, `true`/`false`, a resolvable
+ *   `#variable`, or a matched `(...)` group).
+ * - yellow (`is-warning`) — the trailing (right) operand is still being
+ *   typed: formula ends right after the operator, or an unclosed quote.
+ *   There is no yellow state on the left — a missing left operand is always
+ *   red (the user has already typed past that point).
+ * - red (`is-error`) — an operand slot is missing/broken and definitively
+ *   terminated (e.g. a `)` immediately closes the group right after the
+ *   operator, leaving nothing between them).
+ *
+ * `&&`/`||` use the exact same left/right classification — their "operand"
+ * is typically a parenthesized group, whose matched/unmatched paren state
+ * cascades into the logical operator's own color.
+ */
+describe('renderFormulaHTML — comparison/logical operator highlighting', () => {
+  const schema: FamiliarSchema = {
+    self: {
+      properties: {
+        name: { type: 'string', accessPath: 'name' } as FieldAspect,
+        Level: { type: 'number', accessPath: 'system.level' } as FieldAspect,
+      },
+    },
+    owner: {
+      properties: {
+        strength: {
+          mod: { type: 'number', accessPath: 'system.abilities.str.mod' } as FieldAspect,
+        },
+      },
+    },
+  };
+
+  function render(formula: string): string {
+    return renderFormulaHTML(formula, parseFormula(formula), validateFormula(formula, schema), schema);
+  }
+
+  /** `symbol` is the raw operator text (e.g. '<', '&&') -- escaped once to match the rendered HTML. */
+  function operatorSpans(html: string, symbol: string): string[] {
+    const escaped = symbol.replace(/[&<>]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' })[c] as string);
+    return html.match(new RegExp(`<span class="formula-operator[^"]*"[^>]*>${escaped}</span>`, 'g')) ?? [];
+  }
+
+  describe('yellow — right operand still being typed', () => {
+    it('"0 <" — nothing after the operator', () => {
+      const spans = operatorSpans(render('0 <'), '<');
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).toContain('is-warning');
+    });
+
+    it('\'#self.name == "words\' — unclosed quoted string', () => {
+      const spans = operatorSpans(render('#self.name == "words'), '==');
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).toContain('is-warning');
+    });
+  });
+
+  describe('red — operand slot missing and definitively closed', () => {
+    it('"(#self.Level >)" — the group closes immediately after the operator', () => {
+      const spans = operatorSpans(render('(#self.Level >)'), '>');
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).toContain('is-error');
+    });
+  });
+
+  describe('blue — both operands present and valid', () => {
+    it('"0 < #self.Level"', () => {
+      const spans = operatorSpans(render('0 < #self.Level'), '<');
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).not.toMatch(/is-warning|is-error/);
+    });
+
+    it('\'#self.name == "words"\'', () => {
+      const spans = operatorSpans(render('#self.name == "words"'), '==');
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).not.toMatch(/is-warning|is-error/);
+    });
+  });
+
+  describe('missing left operand — always red, never yellow', () => {
+    it('"> 5" — formula starts with the operator', () => {
+      const spans = operatorSpans(render('> 5'), '>');
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).toContain('is-error');
+    });
+
+    it('"(> 5)" — nothing between the opening paren and the operator', () => {
+      const spans = operatorSpans(render('(> 5)'), '>');
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).toContain('is-error');
+    });
+  });
+
+  describe('&&/|| — mixed: complete group blue, still-typing group + join yellow', () => {
+    it('"(#self.Level > 1) && (#owner.strength.mod >" — first group blue, join + trailing yellow', () => {
+      const html = render('(#self.Level > 1) && (#owner.strength.mod >');
+
+      const firstGt = operatorSpans(html, '>')[0];
+      expect(firstGt).not.toMatch(/is-warning|is-error/);
+
+      const andSpan = operatorSpans(html, '&&')[0];
+      expect(andSpan).toContain('is-warning');
+
+      const secondGt = operatorSpans(html, '>')[1];
+      expect(secondGt).toContain('is-warning');
+    });
+
+    it('"(#self.Level > 1) || (#owner.strength.mod > 2)" — both groups complete, all blue', () => {
+      const html = render('(#self.Level > 1) || (#owner.strength.mod > 2)');
+      const orSpan = operatorSpans(html, '||')[0];
+      expect(orSpan).not.toMatch(/is-warning|is-error/);
+      for (const span of operatorSpans(html, '>')) {
+        expect(span).not.toMatch(/is-warning|is-error/);
+      }
+    });
+  });
+
+  describe('bareword/number operands are valid for comparisons (unlike "!")', () => {
+    it('"Longsword != Dagger" — bareword IDENT on both sides', () => {
+      const spans = operatorSpans(render('Longsword != Dagger'), '!=');
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).not.toMatch(/is-warning|is-error/);
+    });
+
+    it('">= and <= render valid when both sides are numbers', () => {
+      expect(operatorSpans(render('3 >= 2'), '>=')[0]).not.toMatch(/is-warning|is-error/);
+      expect(operatorSpans(render('3 <= 2'), '<=')[0]).not.toMatch(/is-warning|is-error/);
+    });
+  });
+});
+
+describe('renderFormulaHTML — focus-based severity escalation (isFocused param)', () => {
+  const schema: FamiliarSchema = {
+    self: { properties: { Level: { type: 'number', accessPath: 'system.level' } as FieldAspect } },
+  };
+
+  function render(formula: string, isFocused: boolean): string {
+    return renderFormulaHTML(formula, parseFormula(formula), validateFormula(formula, schema), schema, isFocused);
+  }
+
+  it('a still-typing right operand is yellow while focused, red once blurred', () => {
+    const focused = render('0 <', true);
+    const blurred = render('0 <', false);
+    expect(focused).toContain('is-warning');
+    expect(blurred).not.toContain('is-warning');
+    expect(blurred).toContain('is-error');
+  });
+
+  it('an unmatched paren is yellow while focused, red once blurred', () => {
+    const focused = render('(#self.Level > 1', true);
+    const blurred = render('(#self.Level > 1', false);
+    expect(focused).toContain('formula-paren is-warning');
+    expect(blurred).toContain('formula-paren is-error');
+  });
+
+  it('"!" targeting a still-typing bare reference is yellow while focused, red once blurred', () => {
+    const focused = render('!#self.', true);
+    const blurred = render('!#self.', false);
+    expect(focused).toContain('formula-operator is-warning');
+    expect(blurred).toContain('formula-operator is-error');
+  });
+
+  it('isFocused defaults to true when omitted (existing callers unaffected)', () => {
+    const html = renderFormulaHTML('0 <', parseFormula('0 <'), validateFormula('0 <', schema), schema);
+    expect(html).toContain('is-warning');
+  });
+});

--- a/tests/unit/familiar/render-formula-html-conditional-keyword.test.mts
+++ b/tests/unit/familiar/render-formula-html-conditional-keyword.test.mts
@@ -119,4 +119,22 @@ describe('renderFormulaHTML — $conditional/when/else keyword highlighting', ()
       expect(spans[0]).not.toContain('is-warning');
     });
   });
+
+  /**
+   * A backslash-escaped `\$conditional(` is not a real block opener to
+   * `FormulaResolver.conditionalGrammar.mts` (`CONDITIONAL_OPEN_REGEX` has a
+   * `(?<!\\)` guard) — the editor highlighter must not wrap it in a
+   * `.formula-keyword` span either, or it would visually promise structure
+   * the parser will never honor.
+   */
+  it('does not highlight an escaped "\\$conditional(" as a formula-keyword span', () => {
+    const formula = '\\$conditional(when(#self.hp.value <= 0, 0) else(2))';
+    const html = render(formula);
+    // "$conditional" itself is inert literal text — no keyword span.
+    expect(html).not.toMatch(/<span class="formula-keyword[^"]*"[^>]*>\$conditional<\/span>/);
+    // The "(" right after it is an ordinary, unescaped grouping paren (not
+    // part of any "$conditional(" keyword token), so it's still highlighted
+    // and matched normally — same as any other real paren in the formula.
+    expect(html).toContain('\\$conditional<span class="formula-paren"');
+  });
 });

--- a/tests/unit/familiar/render-formula-html-conditional-keyword.test.mts
+++ b/tests/unit/familiar/render-formula-html-conditional-keyword.test.mts
@@ -1,0 +1,122 @@
+import { FormulaResolver } from '@helpers/formulae/FormulaResolver.mjs';
+import type { FamiliarSchema, FieldAspect } from '@helpers/formulae/types.mjs';
+import { renderFormulaHTML } from '@helpers/formulae/utils.mjs';
+import { describe, expect, it } from 'vitest';
+
+const { parseFormula, validateFormula } = FormulaResolver;
+
+/**
+ * `$conditional(...)` / `when(`/`else(` keyword highlighting — a distinct
+ * "keyword" color (purple, `.formula-keyword`) since these are structural
+ * syntax, not real `#context.property` data references.
+ *
+ * - `$conditional` itself tracks the block's own well-formedness:
+ *   - purple (no modifier) — the block parses cleanly.
+ *   - yellow (`is-warning`) while focused, escalating to red (`is-error`)
+ *     once blurred — `unbalancedParens`/`missingElse` (still typing).
+ *   - red (`is-error`) always, regardless of focus — `multipleElse`/
+ *     `whenArgCount`/`elseArgCount` (genuinely malformed, not "still typing").
+ *   - the malformed-case tooltip carries the specific localized error.
+ * - `when(`/`else(` keyword literals are always plain purple — their own
+ *   well-formedness isn't separately tracked, only `$conditional`'s is.
+ * - Nested `#context.property` tokens and comparison operators inside
+ *   when()/else() clauses are untouched — still highlighted normally.
+ */
+describe('renderFormulaHTML — $conditional/when/else keyword highlighting', () => {
+  const schema: FamiliarSchema = {
+    self: {
+      properties: {
+        hp: { value: { type: 'number', accessPath: 'system.hp.value' } as FieldAspect },
+      },
+    },
+  };
+
+  function render(formula: string, isFocused = true): string {
+    return renderFormulaHTML(formula, parseFormula(formula), validateFormula(formula, schema), schema, isFocused);
+  }
+
+  function keywordSpans(html: string, text: string): string[] {
+    return html.match(new RegExp(`<span class="formula-keyword[^"]*"[^>]*>${text}</span>`, 'gi')) ?? [];
+  }
+
+  describe('well-formed block — $conditional/when/else all plain purple', () => {
+    const formula = '$conditional(when(#self.hp.value <= 0, 0) else(2))';
+
+    it('"$conditional" has no state modifier', () => {
+      const spans = keywordSpans(render(formula), '\\$conditional');
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).not.toMatch(/is-warning|is-error/);
+    });
+
+    it('"when" and "else" have no state modifier', () => {
+      const html = render(formula);
+      expect(keywordSpans(html, 'when')[0]).not.toMatch(/is-warning|is-error/);
+      expect(keywordSpans(html, 'else')[0]).not.toMatch(/is-warning|is-error/);
+    });
+
+    it('nested #self.hp.value and <= still highlight normally', () => {
+      const html = render(formula);
+      expect(html).toContain('class="formula-variable"');
+      expect(html).toMatch(/<span class="formula-operator[^"]*"[^>]*>&lt;=<\/span>/);
+    });
+  });
+
+  describe('missingElse — still typing (yellow while focused, red once blurred)', () => {
+    const formula = '$conditional(when(#self.hp.value <= 0, 0))';
+
+    it('yellow while focused', () => {
+      const spans = keywordSpans(render(formula, true), '\\$conditional');
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).toContain('is-warning');
+    });
+
+    it('red once blurred, with the specific error as a tooltip', () => {
+      const spans = keywordSpans(render(formula, false), '\\$conditional');
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).toContain('is-error');
+      expect(spans[0]).toContain('dnd35e.Formula.Errors.conditional.missingElse');
+    });
+  });
+
+  describe('unbalancedParens — still typing (yellow while focused, red once blurred)', () => {
+    const formula = '$conditional(when(#self.hp.value <= 0, 0)';
+
+    it('yellow while focused', () => {
+      const spans = keywordSpans(render(formula, true), '\\$conditional');
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).toContain('is-warning');
+    });
+
+    it('red once blurred, with the specific error as a tooltip', () => {
+      const spans = keywordSpans(render(formula, false), '\\$conditional');
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).toContain('is-error');
+      expect(spans[0]).toContain('dnd35e.Formula.Errors.conditional.unbalancedParens');
+    });
+  });
+
+  describe('multipleElse — genuinely malformed, always red regardless of focus', () => {
+    const formula = '$conditional(when(#self.hp.value <= 0, 0) else(1) else(2))';
+
+    it('red while focused', () => {
+      const spans = keywordSpans(render(formula, true), '\\$conditional');
+      expect(spans[0]).toContain('is-error');
+      expect(spans[0]).not.toContain('is-warning');
+    });
+
+    it('red once blurred', () => {
+      const spans = keywordSpans(render(formula, false), '\\$conditional');
+      expect(spans[0]).toContain('is-error');
+    });
+  });
+
+  describe('whenArgCount — genuinely malformed, always red regardless of focus', () => {
+    const formula = '$conditional(when(#self.hp.value <= 0) else(2))';
+
+    it('red while focused', () => {
+      const spans = keywordSpans(render(formula, true), '\\$conditional');
+      expect(spans[0]).toContain('is-error');
+      expect(spans[0]).not.toContain('is-warning');
+    });
+  });
+});

--- a/tests/unit/familiar/render-formula-html-not-operator.test.mts
+++ b/tests/unit/familiar/render-formula-html-not-operator.test.mts
@@ -1,0 +1,129 @@
+import { FormulaResolver } from '@helpers/formulae/FormulaResolver.mjs';
+import type { FamiliarSchema, FieldAspect } from '@helpers/formulae/types.mjs';
+import { renderFormulaHTML } from '@helpers/formulae/utils.mjs';
+import { describe, expect, it } from 'vitest';
+
+const { extractVariables, parseFormula, validateFormula } = FormulaResolver;
+
+/**
+ * `!` (logical NOT) operator highlighting — added alongside §7.7b's
+ * operator-highlighting work. `renderFormulaHTML()` wraps each `!` in a
+ * `formula-operator` span:
+ *
+ * - blue (no modifier)  — targets a valid operand: a complete/valid
+ *   `#context.property` token, a matched `(...)` group, or `true`/`false`.
+ * - yellow (`is-warning`) — nothing typed yet after `!`, or the operand is
+ *   still being typed (bare context reference, unclosed quote, unmatched
+ *   paren).
+ * - red (`is-error`) — targets plain text/a number, not a meaningful boolean
+ *   operand.
+ */
+describe('renderFormulaHTML — "!" operator highlighting', () => {
+  const schema: FamiliarSchema = {
+    self: {
+      properties: {
+        name: { type: 'string', accessPath: 'name' } as FieldAspect,
+        Level: { type: 'number', accessPath: 'system.level' } as FieldAspect,
+      },
+    },
+    target: {
+      properties: {
+        isFlanked: { type: 'boolean', accessPath: 'flags.isFlanked' } as FieldAspect,
+      },
+    },
+  };
+
+  function render(formula: string): string {
+    return renderFormulaHTML(formula, parseFormula(formula), validateFormula(formula, schema), schema);
+  }
+
+  function bangSpans(html: string): string[] {
+    return html.match(/<span class="formula-operator[^"]*"[^>]*>!<\/span>/g) ?? [];
+  }
+
+  describe('yellow — still typing', () => {
+    it('a bare "!" with nothing after it', () => {
+      const spans = bangSpans(render('!'));
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).toContain('is-warning');
+    });
+
+    it('"!#self." — mid-typing a property path (bare context reference so far)', () => {
+      const spans = bangSpans(render('!#self.'));
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).toContain('is-warning');
+    });
+  });
+
+  describe('red — targets plain text or a number', () => {
+    it('"!text"', () => {
+      const spans = bangSpans(render('!text'));
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).toContain('is-error');
+    });
+
+    it('"!9"', () => {
+      const spans = bangSpans(render('!9'));
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).toContain('is-error');
+    });
+  });
+
+  describe('blue — targets a valid operand', () => {
+    it('"!#self.name" — a valid, resolvable variable', () => {
+      const spans = bangSpans(render('!#self.name'));
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).not.toContain('is-warning');
+      expect(spans[0]).not.toContain('is-error');
+    });
+
+    it('"!#target.isFlanked" — a valid, resolvable variable', () => {
+      const spans = bangSpans(render('!#target.isFlanked'));
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).not.toContain('is-warning');
+      expect(spans[0]).not.toContain('is-error');
+    });
+
+    it('"!(#self.Level > 0)" — a matched paren group', () => {
+      const spans = bangSpans(render('!(#self.Level > 0)'));
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).not.toContain('is-warning');
+      expect(spans[0]).not.toContain('is-error');
+    });
+
+    it('"!true" / "!false" — literal boolean keywords', () => {
+      expect(bangSpans(render('!true'))[0]).not.toMatch(/is-warning|is-error/);
+      expect(bangSpans(render('!false'))[0]).not.toMatch(/is-warning|is-error/);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('an unmatched (still-typing) paren after "!" is yellow, not blue', () => {
+      const spans = bangSpans(render('!(#self.Level > 0'));
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).toContain('is-warning');
+    });
+
+    it('an invalid property path after "!" is red', () => {
+      const spans = bangSpans(render('!#self.bogusPath'));
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).toContain('is-error');
+    });
+
+    it('chained "!!" reads through to the ultimate operand', () => {
+      const spans = bangSpans(render('!!#self.name'));
+      expect(spans).toHaveLength(2);
+      expect(spans.every(span => !span.includes('is-warning') && !span.includes('is-error'))).toBe(true);
+    });
+  });
+});
+
+// Sanity check that extractVariables/validateFormula still behave normally
+// alongside the new "!" highlighting (it doesn't touch variable parsing).
+describe('"!" highlighting does not affect variable extraction', () => {
+  it('extracts #self.name unaffected by a preceding "!"', () => {
+    const variables = extractVariables('!#self.name');
+    expect(variables).toHaveLength(1);
+    expect(variables[0].variable).toBe('#self.name');
+  });
+});

--- a/tests/unit/familiar/render-formula-html-parens.test.mts
+++ b/tests/unit/familiar/render-formula-html-parens.test.mts
@@ -55,4 +55,39 @@ describe('renderFormulaHTML — parenthesis pairing', () => {
     expect(parenSpans.filter(span => span.includes('is-warning'))).toHaveLength(1);
     expect(parenSpans.filter(span => !span.includes('is-warning'))).toHaveLength(2);
   });
+
+  /**
+   * Backslash-escaped parens (`\(`/`\)`) are literal text to the real
+   * `$conditional(...)` grammar (FormulaResolver.conditionalGrammar.mts's
+   * `findMatchingParen` skips them entirely) — the editor highlighter must
+   * not wrap them in a `.formula-paren` span, and they must not consume a
+   * slot on the paren-matching stack (so they can't falsely "absorb" or
+   * "orphan" a real, unescaped paren elsewhere in the formula).
+   */
+  it('does not highlight a backslash-escaped paren as a formula-paren span', () => {
+    const formula = '\\(literal\\)';
+    const html = renderFormulaHTML(formula, parseFormula(formula), []);
+    const parenSpans = html.match(/<span class="formula-paren[^"]*"/g) ?? [];
+    expect(parenSpans).toHaveLength(0);
+    expect(html).toContain('\\(literal\\)');
+  });
+
+  it('an escaped paren does not throw off matching of real parens elsewhere in the formula', () => {
+    const formula = '(#self.level) \\(literal\\)';
+    const html = renderFormulaHTML(formula, parseFormula(formula), []);
+    const parenSpans = html.match(/<span class="formula-paren[^"]*"/g) ?? [];
+    // Only the real, unescaped pair gets wrapped — and it's matched.
+    expect(parenSpans).toHaveLength(2);
+    expect(parenSpans.every(span => !span.includes('is-warning'))).toBe(true);
+  });
+
+  it('a real unmatched paren after an escaped paren is still flagged as unmatched', () => {
+    const formula = '\\(literal) #self.level';
+    const html = renderFormulaHTML(formula, parseFormula(formula), []);
+    const parenSpans = html.match(/<span class="formula-paren[^"]*"/g) ?? [];
+    // The escaped "\(" is inert; the real ")" has nothing on the stack to
+    // pair with, so it's unmatched.
+    expect(parenSpans).toHaveLength(1);
+    expect(parenSpans[0]).toContain('is-warning');
+  });
 });

--- a/tests/unit/familiar/render-formula-html-parens.test.mts
+++ b/tests/unit/familiar/render-formula-html-parens.test.mts
@@ -1,0 +1,55 @@
+import { parseFormula, renderFormulaHTML } from '@helpers/formulae/utils.mjs';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Paren-pairing highlight (added alongside §7.7b's operator-highlighting work).
+ * `renderFormulaHTML()` wraps each `(`/`)` in a `formula-paren` span, tagged
+ * `is-warning` when unmatched and untagged (blue) when part of a complete pair.
+ * Matching is computed over the whole formula string, so it must hold across
+ * nesting and across multiple text-token boundaries (variables split the
+ * formula into several text tokens).
+ */
+describe('renderFormulaHTML — parenthesis pairing', () => {
+  it('marks a single balanced pair as matched (no is-warning)', () => {
+    const formula = '(#self.level)';
+    const html = renderFormulaHTML(formula, parseFormula(formula), []);
+    const parenSpans = html.match(/<span class="formula-paren[^"]*"/g) ?? [];
+    expect(parenSpans).toHaveLength(2);
+    expect(parenSpans.every(span => !span.includes('is-warning'))).toBe(true);
+  });
+
+  it('marks nested balanced pairs as matched across multiple text-token boundaries', () => {
+    const formula = '(#self.level + (#self.AC / 2))';
+    const html = renderFormulaHTML(formula, parseFormula(formula), []);
+    const parenSpans = html.match(/<span class="formula-paren[^"]*"/g) ?? [];
+    expect(parenSpans).toHaveLength(4);
+    expect(parenSpans.every(span => !span.includes('is-warning'))).toBe(true);
+  });
+
+  it('marks an unmatched opening paren as is-warning (still typing)', () => {
+    const formula = '(#self.level + 1';
+    const html = renderFormulaHTML(formula, parseFormula(formula), []);
+    const parenSpans = html.match(/<span class="formula-paren[^"]*"/g) ?? [];
+    expect(parenSpans).toHaveLength(1);
+    expect(parenSpans[0]).toContain('is-warning');
+  });
+
+  it('marks an unmatched closing paren as is-warning', () => {
+    const formula = '#self.level)';
+    const html = renderFormulaHTML(formula, parseFormula(formula), []);
+    const parenSpans = html.match(/<span class="formula-paren[^"]*"/g) ?? [];
+    expect(parenSpans).toHaveLength(1);
+    expect(parenSpans[0]).toContain('is-warning');
+  });
+
+  it('mixed: innermost pair matched, extra outer opening paren unmatched', () => {
+    const formula = '((#self.level)';
+    const html = renderFormulaHTML(formula, parseFormula(formula), []);
+    const parenSpans = html.match(/<span class="formula-paren[^"]*"/g) ?? [];
+    // Stack-based matching: the second "(" pairs with the ")", leaving the
+    // first (outermost) "(" unmatched.
+    expect(parenSpans).toHaveLength(3);
+    expect(parenSpans.filter(span => span.includes('is-warning'))).toHaveLength(1);
+    expect(parenSpans.filter(span => !span.includes('is-warning'))).toHaveLength(2);
+  });
+});

--- a/tests/unit/familiar/render-formula-html-parens.test.mts
+++ b/tests/unit/familiar/render-formula-html-parens.test.mts
@@ -1,5 +1,8 @@
-import { parseFormula, renderFormulaHTML } from '@helpers/formulae/utils.mjs';
+import { FormulaResolver } from '@helpers/formulae/FormulaResolver.mjs';
+import { renderFormulaHTML } from '@helpers/formulae/utils.mjs';
 import { describe, expect, it } from 'vitest';
+
+const { parseFormula } = FormulaResolver;
 
 /**
  * Paren-pairing highlight (added alongside §7.7b's operator-highlighting work).

--- a/tests/unit/familiar/schema-walker.test.mts
+++ b/tests/unit/familiar/schema-walker.test.mts
@@ -10,7 +10,7 @@ import { describe, expect, it } from 'vitest';
 // - optional `field.label` (the localized label set after i18nInit)
 // ---------------------------------------------------------------------------
 
-const { NumberField, StringField, SchemaField } = foundry.data.fields;
+const { NumberField, StringField, BooleanField, SchemaField } = foundry.data.fields;
 
 type AnyField = foundry.data.fields.DataField;
 
@@ -21,6 +21,11 @@ const makeNumber = (opts: Record<string, unknown> = {}): AnyField => {
 
 const makeString = (opts: Record<string, unknown> = {}): AnyField => {
   const f = new (StringField as any)({ ...opts });
+  return f as AnyField;
+};
+
+const makeBoolean = (opts: Record<string, unknown> = {}): AnyField => {
+  const f = new (BooleanField as any)({ ...opts });
   return f as AnyField;
 };
 
@@ -72,6 +77,15 @@ describe('gatherAspectsFromSchema — FormulaFamiliar schema walker', () => {
       const aspect = group.flavor as FieldAspect;
       expect(aspect.type).toBe('string');
       expect(aspect.accessPath).toBe('system.flavor');
+    });
+
+    it('includes a plain BooleanField as a boolean leaf (Story A)', () => {
+      const group = gatherAspectsFromSchema(makeModelClass({
+        hasCondition: makeBoolean(),
+      }));
+      const aspect = group.hasCondition as FieldAspect;
+      expect(aspect.type).toBe('boolean');
+      expect(aspect.accessPath).toBe('system.hasCondition');
     });
 
     it('excludes a field marked `formulaVisible: false`', () => {

--- a/tests/unit/settings/deathThreshold.test.mts
+++ b/tests/unit/settings/deathThreshold.test.mts
@@ -1,0 +1,23 @@
+import { resolveDeathThresholdValue } from '@settings/combat/deathThreshold.mjs';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Regression tests for `resolveDeathThresholdValue()`'s `Roll.safeEval` call site
+ * (no `actor` passed → formula is evaluated as-is). Uses the DEFAULT (un-overridden)
+ * `tests/setup.mts` `Roll.safeEval` stub, which throws if called detached from `Roll`
+ * — the real Foundry implementation depends on `this.MATH_PROXY` and breaks silently
+ * in that case (the exact bug fixed this session across 4 call sites).
+ */
+describe('resolveDeathThresholdValue — Roll.safeEval this-binding regression', () => {
+  it('resolves a plain numeric setting without an actor', () => {
+    expect(resolveDeathThresholdValue('-10')).toBe(-10);
+  });
+
+  it('resolves a parenthesized formula setting without throwing', () => {
+    expect(() => resolveDeathThresholdValue('(0 - 10)')).not.toThrow();
+  });
+
+  it('falls back to 0 for an empty setting', () => {
+    expect(resolveDeathThresholdValue('')).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 7 (poc.7 — Roll Formulas & Custom Rolls), Story B (§7.7a/§7.7b): boolean formula type, AE Change conditional gate, and the AE sheet revamp — split out of the Phase 9 token branch into its own PR since it was unrelated work.

## Changes

- **Boolean condition grammar**: `#conditional(...)` syntax (later rescoped to `$conditional(when(cond, value) ... else(default))`), AE Change conditional gate wiring
- **Sigil rescope**: conditional keyword moved from `#conditional(...)` to `$conditional(...)` — `#` stays reserved for context/property data references, `$` for control-flow keywords. Added `$and`/`$or` as case-insensitive aliases for `&&`/`||`
- **Operator highlighting**: formula syntax highlighting now tags comparison/logical operators (`>`, `<`, `>=`, `<=`, `==`, `!=`, `&&`, `||`) and `$conditional`/`when(`/`else(` keywords, with focus-aware yellow→red severity escalation
- **FormulaResolver split**: `evaluateBooleanExpression.mts`/`conditionalFormula.mts` consolidated into `FormulaResolver.aspectResolution/.booleanGrammar/.conditionalGrammar/.types/.validation.mts`
- **General AE custom sheet**: `GeneralSheet.mts`/`.vue`, `GeneralStore.mts` — thin pass-through mirroring Material's pattern
- **EffectChangesList.vue revamp**: Target column first, removed branch-toggle button, new Condition column (`expectedType: boolean`), Value column's expected-type now derived from the picked aspect
- **Tests**: Condition column operator highlighting, Value column type-mismatch rejection (quoted-string formula vs. number-typed aspect), General/Material AE sheet Duration/Changes tab parity

## Verification

- `npx vitest run tests/unit/` — 621/621 passing
- `npm run build` — clean (lint + typecheck + vite build + pack validation)

## Docs

- `docs/migration-plan/poc/phase-07-roll-formulas.md` — §7.7b checklist fully checked off
